### PR TITLE
Add console app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Runnable
 Monorepo for the ForgeTrust.Runnable projects
+
+## Examples
+
+The [examples](examples) directory contains sample applications that demonstrate how to use this project.
+Start with the [console app example](examples/console-app) to see how to build a simple command line application using [CliFx](https://github.com/Tyrrrz/CliFx) for command definitions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+This directory contains sample applications that use **ForgeTrust.Runnable**.
+
+- [Console app example](console-app) – shows how to build a simple console application using [CliFx](https://github.com/Tyrrrz/CliFx) for command definitions.

--- a/examples/console-app/ConsoleAppExample.csproj
+++ b/examples/console-app/ConsoleAppExample.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../ForgeTrust.Runnable.Console/ForgeTrust.Runnable.Console.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/console-app/ExampleModule.cs
+++ b/examples/console-app/ExampleModule.cs
@@ -1,0 +1,26 @@
+namespace ConsoleAppExample;
+
+using ForgeTrust.Runnable.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+public class ExampleModule : IRunnableHostModule
+{
+    public void ConfigureServices(StartupContext context, IServiceCollection services)
+    {
+        // Register services for the application here if needed
+    }
+
+    public void RegisterDependentModules(ModuleDependencyBuilder builder)
+    {
+        // Add module dependencies here if needed
+    }
+
+    public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+    {
+    }
+
+    public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+    {
+    }
+}

--- a/examples/console-app/Program.cs
+++ b/examples/console-app/Program.cs
@@ -1,0 +1,21 @@
+namespace ConsoleAppExample;
+
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+using ForgeTrust.Runnable.Console;
+
+await ConsoleApp<ExampleModule>.RunAsync(args);
+
+[Command("greet", Description = "Prints a greeting message.")]
+public class GreetCommand : ICommand
+{
+    [CommandParameter(0, Description = "The name to greet.")]
+    public string Name { get; set; } = string.Empty;
+
+    public ValueTask ExecuteAsync(IConsole console)
+    {
+        console.Output.WriteLine($"Hello, {Name}!");
+        return default;
+    }
+}

--- a/examples/console-app/README.md
+++ b/examples/console-app/README.md
@@ -1,0 +1,15 @@
+# Console app example
+
+This sample demonstrates how to build a console application with **ForgeTrust.Runnable**.
+
+It defines a module and a `greet` command. The command uses attributes from the [CliFx](https://github.com/Tyrrrz/CliFx) library—see the [CliFx documentation on attributes](https://github.com/Tyrrrz/CliFx/blob/master/docs/attributes.md) for more details. Run the sample with:
+
+```bash
+dotnet run --project examples/console-app/ConsoleAppExample.csproj -- greet World
+```
+
+This will output:
+
+```
+Hello, World!
+```


### PR DESCRIPTION
## Summary
- simplify console app example with top-level entry and inline greet command
- document CliFx usage and link to attribute docs

## Testing
- `dotnet build examples/console-app/ConsoleAppExample.csproj -v minimal` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_689827896cb883249d021f93dce4aca2