### PR TITLE
Add web support and example

### DIFF
--- a/ForgeTrust.Runnable.Web/ForgeTrust.Runnable.Web.csproj
+++ b/ForgeTrust.Runnable.Web/ForgeTrust.Runnable.Web.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ForgeTrust.Runnable.Core\ForgeTrust.Runnable.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+</Project>

--- a/ForgeTrust.Runnable.Web/IRunnableWebModule.cs
+++ b/ForgeTrust.Runnable.Web/IRunnableWebModule.cs
@@ -1,0 +1,9 @@
+using ForgeTrust.Runnable.Core;
+using Microsoft.AspNetCore.Builder;
+
+namespace ForgeTrust.Runnable.Web;
+
+public interface IRunnableWebModule : IRunnableHostModule
+{
+    void ConfigureWebApplication(StartupContext context, IApplicationBuilder app);
+}

--- a/ForgeTrust.Runnable.Web/WebApp.cs
+++ b/ForgeTrust.Runnable.Web/WebApp.cs
@@ -1,0 +1,20 @@
+using ForgeTrust.Runnable.Core;
+
+namespace ForgeTrust.Runnable.Web;
+
+public static class WebApp<TStartup, TModule>
+    where TStartup : WebStartup<TModule>, new()
+    where TModule : IRunnableHostModule, new()
+{
+    public static Task RunAsync(string[] args) => new TStartup().RunAsync(args);
+}
+
+public class WebApp<TModule>
+    where TModule : IRunnableHostModule, new()
+{
+    public static Task RunAsync(string[] args) => new GenericWebStartup().RunAsync(args);
+
+    private class GenericWebStartup : WebStartup<TModule>
+    {
+    }
+}

--- a/ForgeTrust.Runnable.Web/WebStartup.cs
+++ b/ForgeTrust.Runnable.Web/WebStartup.cs
@@ -1,0 +1,42 @@
+using ForgeTrust.Runnable.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace ForgeTrust.Runnable.Web;
+
+public abstract class WebStartup<TModule> : RunnableStartup<TModule>
+    where TModule : IRunnableHostModule, new()
+{
+    protected sealed override void ConfigureServicesForAppType(StartupContext context, IServiceCollection services)
+    {
+        // No additional services required for web apps.
+    }
+
+    protected override IHostBuilder ConfigureBuilderForAppType(StartupContext context, IHostBuilder builder)
+    {
+        return builder.ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.Configure(app =>
+            {
+                var modules = new List<IRunnableWebModule>();
+                foreach (var dep in context.GetDependencies())
+                {
+                    if (dep is IRunnableWebModule webModule)
+                    {
+                        modules.Add(webModule);
+                    }
+                }
+                if (context.RootModule is IRunnableWebModule root)
+                {
+                    modules.Add(root);
+                }
+                foreach (var module in modules)
+                {
+                    module.ConfigureWebApplication(context, app);
+                }
+            });
+        });
+    }
+}

--- a/ForgeTrust.Runnable.slnx
+++ b/ForgeTrust.Runnable.slnx
@@ -4,4 +4,5 @@
   <Project Path="ForgeTrust.Runnable.Console\ForgeTrust.Runnable.Console.csproj" Type="Classic C#" />
   <Project Path="ForgeTrust.Runnable.Core.Tests\ForgeTrust.Runnable.Core.Tests.csproj" Type="Classic C#" />
   <Project Path="ForgeTrust.Runnable.Core\ForgeTrust.Runnable.Core.csproj" Type="Classic C#" />
+  <Project Path="ForgeTrust.Runnable.Web\ForgeTrust.Runnable.Web.csproj" Type="Classic C#" />
 </Solution>

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,3 +3,4 @@
 This directory contains sample applications that use **ForgeTrust.Runnable**.
 
 - [Console app example](console-app) – shows how to build a simple console application using [CliFx](https://github.com/Tyrrrz/CliFx) for command definitions.
+- [Web app example](web-app) – demonstrates starting a minimal ASP.NET Core web application.

--- a/examples/web-app/ExampleModule.cs
+++ b/examples/web-app/ExampleModule.cs
@@ -1,0 +1,35 @@
+using ForgeTrust.Runnable.Core;
+using ForgeTrust.Runnable.Web;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Routing;
+
+public class ExampleModule : IRunnableWebModule
+{
+    public void ConfigureServices(StartupContext context, IServiceCollection services)
+    {
+        // Register services for the application here if needed
+    }
+
+    public void RegisterDependentModules(ModuleDependencyBuilder builder)
+    {
+        // Add module dependencies here if needed
+    }
+
+    public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+    {
+    }
+
+    public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+    {
+    }
+
+    public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app)
+    {
+        if (app is IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapGet("/", () => "Hello from web app example!");
+        }
+    }
+}

--- a/examples/web-app/Program.cs
+++ b/examples/web-app/Program.cs
@@ -1,0 +1,3 @@
+using ForgeTrust.Runnable.Web;
+
+await WebApp<ExampleModule>.RunAsync(args);

--- a/examples/web-app/README.md
+++ b/examples/web-app/README.md
@@ -1,0 +1,11 @@
+# Web app example
+
+This example shows how to build a minimal ASP.NET Core application using **ForgeTrust.Runnable.Web**.
+
+Run the application:
+
+```bash
+dotnet run
+```
+
+Then open <http://localhost:5000> to see the greeting.

--- a/examples/web-app/WebAppExample.csproj
+++ b/examples/web-app/WebAppExample.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../ForgeTrust.Runnable.Web/ForgeTrust.Runnable.Web.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add `Runnable.Web` project for ASP.NET Core startup
- provide minimal web app example

## Testing
- `dotnet test`
- `dotnet build examples/web-app/WebAppExample.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6898396604c08324b264214dda28941d