### PR TITLE
Use StartupContext name for host configuration

### DIFF
--- a/ForgeTrust.Runnable.Core.Tests/RunnableStartupTests.cs
+++ b/ForgeTrust.Runnable.Core.Tests/RunnableStartupTests.cs
@@ -68,6 +68,19 @@ public class RunnableStartupTests
     }
 
     [Fact]
+    public void CreateHostBuilder_SetsHostApplicationName()
+    {
+        var context = new StartupContext([], new RootModule(), ApplicationName: "CustomApp");
+        var startup = new TestStartup();
+
+        var hostBuilder = ((IRunnableStartup)startup).CreateHostBuilder(context);
+        using var host = hostBuilder.Build();
+
+        var env = host.Services.GetRequiredService<IHostEnvironment>();
+        Assert.Equal("CustomApp", env.ApplicationName);
+    }
+
+    [Fact]
     public async Task RunAsync_WithArgs_InvokesCreateRootModuleAndRunsHost()
     {
         var root = new RootModule();

--- a/ForgeTrust.Runnable.Core/RunnableStartup.cs
+++ b/ForgeTrust.Runnable.Core/RunnableStartup.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -59,6 +61,11 @@ public abstract class RunnableStartup<TRootModule> : IRunnableStartup
     private IHostBuilder CreateHostBuilderCore(StartupContext context)
     {
         var builder = Host.CreateDefaultBuilder();
+        builder.ConfigureHostConfiguration(config =>
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [HostDefaults.ApplicationKey] = context.ApplicationName
+            }));
         
         context.RootModule.RegisterDependentModules(context.Dependencies);
 


### PR DESCRIPTION
## Summary
- ensure host builder sets `ApplicationName` from StartupContext so internal module name isn't exposed
- test that the host environment uses the supplied application name

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689913a97d1c832495134c7a26fea903