### PR TITLE
Add configurable CORS support via WebOptions

### DIFF
--- a/ForgeTrust.Runnable.slnx
+++ b/ForgeTrust.Runnable.slnx
@@ -1,20 +1,21 @@
 <Solution>
   <Folder Name="/Console/">
-    <Project Path="Console\ForgeTrust.Runnable.Console.Tests\ForgeTrust.Runnable.Console.Tests.csproj" Type="Classic C#" />
-    <Project Path="Console\ForgeTrust.Runnable.Console\ForgeTrust.Runnable.Console.csproj" Type="Classic C#" />
+    <Project Path="Console\\ForgeTrust.Runnable.Console.Tests\\ForgeTrust.Runnable.Console.Tests.csproj" Type="Classic C#" />
+    <Project Path="Console\\ForgeTrust.Runnable.Console\\ForgeTrust.Runnable.Console.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/Dependency/">
-    <Project Path="Dependency\ForgeTrust.Runnable.Autofac\ForgeTrust.Runnable.Autofac.csproj" Type="Classic C#" />
+    <Project Path="Dependency\\ForgeTrust.Runnable.Autofac\\ForgeTrust.Runnable.Autofac.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/Examples/">
-    <Project Path="examples\console-app\ConsoleAppExample.csproj" Type="Classic C#" />
-    <Project Path="examples\web-app\WebAppExample.csproj" Type="Classic C#" />
+    <Project Path="examples\\console-app\\ConsoleAppExample.csproj" Type="Classic C#" />
+    <Project Path="examples\\web-app\\WebAppExample.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/Web/">
-    <Project Path="Web\ForgeTrust.Runnable.Web.OpenApi\ForgeTrust.Runnable.Web.OpenApi.csproj" Type="Classic C#" />
-    <Project Path="Web\ForgeTrust.Runnable.Web.Scalar\ForgeTrust.Runnable.Web.Scalar.csproj" Type="Classic C#" />
-    <Project Path="Web\ForgeTrust.Runnable.Web\ForgeTrust.Runnable.Web.csproj" Type="Classic C#" />
+    <Project Path="Web\\ForgeTrust.Runnable.Web.Tests\\ForgeTrust.Runnable.Web.Tests.csproj" Type="Classic C#" />
+    <Project Path="Web\\ForgeTrust.Runnable.Web.OpenApi\\ForgeTrust.Runnable.Web.OpenApi.csproj" Type="Classic C#" />
+    <Project Path="Web\\ForgeTrust.Runnable.Web.Scalar\\ForgeTrust.Runnable.Web.Scalar.csproj" Type="Classic C#" />
+    <Project Path="Web\\ForgeTrust.Runnable.Web\\ForgeTrust.Runnable.Web.csproj" Type="Classic C#" />
   </Folder>
-  <Project Path="ForgeTrust.Runnable.Core.Tests\ForgeTrust.Runnable.Core.Tests.csproj" Type="Classic C#" />
-  <Project Path="ForgeTrust.Runnable.Core\ForgeTrust.Runnable.Core.csproj" Type="Classic C#" />
+  <Project Path="ForgeTrust.Runnable.Core.Tests\\ForgeTrust.Runnable.Core.Tests.csproj" Type="Classic C#" />
+  <Project Path="ForgeTrust.Runnable.Core\\ForgeTrust.Runnable.Core.csproj" Type="Classic C#" />
 </Solution>

--- a/Web/ForgeTrust.Runnable.Web.Tests/CorsOptionsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.Tests/CorsOptionsTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Threading.Tasks;
+using ForgeTrust.Runnable.Core;
+using ForgeTrust.Runnable.Web;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+public class CorsOptionsTests
+{
+    private class TestWebModule : IRunnableWebModule
+    {
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder) { }
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder) { }
+        public void ConfigureServices(StartupContext context, IServiceCollection services) { }
+        public void RegisterDependentModules(ModuleDependencyBuilder builder) { }
+        public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app) { }
+    }
+
+    private class TestStartup : WebStartup<TestWebModule>
+    {
+        public void ConfigureServicesPublic(StartupContext context, IServiceCollection services)
+            => base.ConfigureServicesForAppType(context, services);
+    }
+
+    [Fact]
+    public async Task EnableAllOriginsInDevelopment_AllowsAnyOrigin()
+    {
+        var previous = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Development);
+
+            var startup = new TestStartup();
+            startup.WithOptions(o =>
+            {
+                o.Cors.EnableCors = true;
+                o.Cors.AllowedOrigins = ["https://example.com"];
+                o.Cors.EnableAllOriginsInDevelopment = true;
+            });
+
+            var context = new StartupContext([], new TestWebModule());
+            var services = new ServiceCollection();
+            startup.ConfigureServicesPublic(context, services);
+
+            var provider = services.BuildServiceProvider();
+            var policyProvider = provider.GetRequiredService<ICorsPolicyProvider>();
+            var policy = await policyProvider.GetPolicyAsync(new DefaultHttpContext(), "DefaultCorsPolicy");
+
+            Assert.True(policy!.AllowAnyOrigin);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previous);
+        }
+    }
+
+    [Fact]
+    public async Task DisableAllOriginsOutsideDevelopment_UsesConfiguredOrigins()
+    {
+        var previous = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Production);
+
+            var startup = new TestStartup();
+            startup.WithOptions(o =>
+            {
+                o.Cors.EnableCors = true;
+                o.Cors.AllowedOrigins = ["https://example.com"];
+                o.Cors.EnableAllOriginsInDevelopment = true;
+            });
+
+            var context = new StartupContext([], new TestWebModule());
+            var services = new ServiceCollection();
+            startup.ConfigureServicesPublic(context, services);
+
+            var provider = services.BuildServiceProvider();
+            var policyProvider = provider.GetRequiredService<ICorsPolicyProvider>();
+            var policy = await policyProvider.GetPolicyAsync(new DefaultHttpContext(), "DefaultCorsPolicy");
+
+            Assert.False(policy!.AllowAnyOrigin);
+            Assert.Contains("https://example.com", policy!.Origins);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previous);
+        }
+    }
+
+    [Fact]
+    public async Task NoConfiguredOrigins_AllowsAnyOriginOutsideDevelopment()
+    {
+        var previous = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Production);
+
+            var startup = new TestStartup();
+            startup.WithOptions(o =>
+            {
+                o.Cors.EnableCors = true;
+            });
+
+            var context = new StartupContext([], new TestWebModule());
+            var services = new ServiceCollection();
+            startup.ConfigureServicesPublic(context, services);
+
+            var provider = services.BuildServiceProvider();
+            var policyProvider = provider.GetRequiredService<ICorsPolicyProvider>();
+            var policy = await policyProvider.GetPolicyAsync(new DefaultHttpContext(), "DefaultCorsPolicy");
+
+            Assert.True(policy!.AllowAnyOrigin);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previous);
+        }
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.Tests/ForgeTrust.Runnable.Web.Tests.csproj
+++ b/Web/ForgeTrust.Runnable.Web.Tests/ForgeTrust.Runnable.Web.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.9.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ForgeTrust.Runnable.Web\ForgeTrust.Runnable.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Web/ForgeTrust.Runnable.Web/CorsOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web/CorsOptions.cs
@@ -1,0 +1,13 @@
+namespace ForgeTrust.Runnable.Web;
+
+public record CorsOptions
+{
+    public bool EnableAllOriginsInDevelopment { get; set; } = true;
+    public bool EnableCors { get; set; } = false;
+
+    public string[] AllowedOrigins { get; set; } = [];
+
+    public string PolicyName { get; set; } = "DefaultCorsPolicy";
+
+    public static CorsOptions Default => new();
+}

--- a/Web/ForgeTrust.Runnable.Web/IRunnableWebModule.cs
+++ b/Web/ForgeTrust.Runnable.Web/IRunnableWebModule.cs
@@ -6,6 +6,11 @@ namespace ForgeTrust.Runnable.Web;
 
 public interface IRunnableWebModule : IRunnableHostModule
 {
+    void ConfigureWebOptions(StartupContext context, WebOptions options)
+    {
+        // Default implementation does nothing, so we don't force an implementation.
+    }
+
     void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
     {
         // Default implementation does nothing, so we don't force an implementation.

--- a/Web/ForgeTrust.Runnable.Web/WebApp.cs
+++ b/Web/ForgeTrust.Runnable.Web/WebApp.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Routing;
-
 namespace ForgeTrust.Runnable.Web;
 
 public static class WebApp<TStartup, TModule>
@@ -8,9 +6,9 @@ public static class WebApp<TStartup, TModule>
 {
     public static Task RunAsync(
         string[] args,
-        Action<IEndpointRouteBuilder>? mapEndpoints = null) =>
+        Action<WebOptions>? configureOptions = null) =>
         new TStartup()
-            .WithDirectConfiguration(mapEndpoints)
+            .WithOptions(configureOptions)
             .RunAsync(args);
 }
 
@@ -19,8 +17,8 @@ public static class WebApp<TModule>
 {
     public static Task RunAsync(
         string[] args,
-        Action<IEndpointRouteBuilder>? mapEndpoints = null) =>
-        WebApp<GenericWebStartup<TModule>, TModule>.RunAsync(args, mapEndpoints);
+        Action<WebOptions>? configureOptions = null) =>
+        WebApp<GenericWebStartup<TModule>, TModule>.RunAsync(args, configureOptions);
 
     private class GenericWebStartup<TNew> : WebStartup<TNew>
         where TNew : IRunnableWebModule, new()

--- a/Web/ForgeTrust.Runnable.Web/WebOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web/WebOptions.cs
@@ -1,29 +1,15 @@
-namespace ForgeTrust.Runnable.Web;
+﻿namespace ForgeTrust.Runnable.Web;
 
-using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 
 public record WebOptions
 {
     public static WebOptions Default => new();
 
-    public OpenApiOptions OpenApi { get; set; } = OpenApiOptions.Default;
-
     public CorsOptions Cors { get; set; } = CorsOptions.Default;
 
-    public Action<IEndpointRouteBuilder>? MapEndpoints { get; set; }
-    public Action<IEndpointRouteBuilder>? MapEndpoints { get; set; } = null;
-}
-
-public record OpenApiOptions(bool EnableOpenApi = true, bool EnableSwaggerUi = true)
-{
-    public static OpenApiOptions Default => new();
-}
-
-public record CorsOptions(
-    bool EnableCors = false,
-    string PolicyName = "CorsPolicy",
-    Action<CorsPolicyBuilder>? ConfigurePolicy = null)
-{
-    public static CorsOptions Default => new();
+    public Action<IEndpointRouteBuilder> MapEndpoints { get; set; } = _ =>
+    {
+        // Default endpoint mapping can be empty or provide a basic route
+    };
 }

--- a/Web/ForgeTrust.Runnable.Web/WebOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web/WebOptions.cs
@@ -1,11 +1,29 @@
-﻿namespace ForgeTrust.Runnable.Web;
+namespace ForgeTrust.Runnable.Web;
 
-public record WebOptions(OpenApiOptions OpenApi)
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+
+public record WebOptions
 {
-    public static readonly WebOptions Default = new(OpenApiOptions.Default);
+    public static WebOptions Default => new();
+
+    public OpenApiOptions OpenApi { get; set; } = OpenApiOptions.Default;
+
+    public CorsOptions Cors { get; set; } = CorsOptions.Default;
+
+    public Action<IEndpointRouteBuilder>? MapEndpoints { get; set; }
+        = null;
 }
 
-public record OpenApiOptions(bool EnableOpenApi, bool EnableSwaggerUi)
+public record OpenApiOptions(bool EnableOpenApi = true, bool EnableSwaggerUi = true)
 {
-    public static readonly OpenApiOptions Default = new(true, true);
+    public static OpenApiOptions Default => new();
+}
+
+public record CorsOptions(
+    bool EnableCors = false,
+    string PolicyName = "CorsPolicy",
+    Action<CorsPolicyBuilder>? ConfigurePolicy = null)
+{
+    public static CorsOptions Default => new();
 }

--- a/Web/ForgeTrust.Runnable.Web/WebOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web/WebOptions.cs
@@ -12,7 +12,7 @@ public record WebOptions
     public CorsOptions Cors { get; set; } = CorsOptions.Default;
 
     public Action<IEndpointRouteBuilder>? MapEndpoints { get; set; }
-        = null;
+    public Action<IEndpointRouteBuilder>? MapEndpoints { get; set; } = null;
 }
 
 public record OpenApiOptions(bool EnableOpenApi = true, bool EnableSwaggerUi = true)

--- a/Web/ForgeTrust.Runnable.Web/WebStartup.cs
+++ b/Web/ForgeTrust.Runnable.Web/WebStartup.cs
@@ -1,3 +1,4 @@
+using System;
 using ForgeTrust.Runnable.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -76,19 +77,25 @@ public abstract class WebStartup<TModule> : RunnableStartup<TModule>
 
         if (_options.Cors.EnableCors)
         {
+            var isDevelopment = string.Equals(
+                Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+                Environments.Development,
+                StringComparison.OrdinalIgnoreCase);
+
             services.AddCors(o =>
                 o.AddPolicy(
                     _options.Cors.PolicyName,
                     builder =>
                     {
-                        if (_options.Cors.AllowedOrigins.Length > 0)
+                        if (_options.Cors.AllowedOrigins.Length == 0 ||
+                            (_options.Cors.EnableAllOriginsInDevelopment && isDevelopment))
                         {
-                            builder.SetIsOriginAllowedToAllowWildcardSubdomains();
-                            builder.WithOrigins(_options.Cors.AllowedOrigins);
+                            builder.AllowAnyOrigin();
                         }
                         else
                         {
-                            builder.AllowAnyOrigin();
+                            builder.SetIsOriginAllowedToAllowWildcardSubdomains();
+                            builder.WithOrigins(_options.Cors.AllowedOrigins);
                         }
                     }));
         }

--- a/examples/web-app/ExampleModule.cs
+++ b/examples/web-app/ExampleModule.cs
@@ -2,6 +2,8 @@ using ForgeTrust.Runnable.Core;
 using ForgeTrust.Runnable.Web;
 using ForgeTrust.Runnable.Web.Scalar;
 
+namespace WebAppExample;
+
 public class ExampleModule : IRunnableWebModule
 {
     public void ConfigureServices(StartupContext context, IServiceCollection services)

--- a/examples/web-app/Program.cs
+++ b/examples/web-app/Program.cs
@@ -1,10 +1,13 @@
 using ForgeTrust.Runnable.Web;
+using Microsoft.AspNetCore.Routing;
 
 await WebApp<ExampleModule>.RunAsync(
     args,
-    MapEndpoints);
-
-static void MapEndpoints(IEndpointRouteBuilder endpoints)
-{
-    endpoints.MapGet("/", () => "Hello World from the root!");
-}
+    options =>
+    {
+        options.Cors.EnableCors = true;
+        options.MapEndpoints = endpoints =>
+        {
+            endpoints.MapGet("/", () => "Hello World from the root!");
+        };
+    });

--- a/examples/web-app/Program.cs
+++ b/examples/web-app/Program.cs
@@ -1,11 +1,12 @@
 using ForgeTrust.Runnable.Web;
-using Microsoft.AspNetCore.Routing;
+using WebAppExample;
 
 await WebApp<ExampleModule>.RunAsync(
     args,
     options =>
     {
         options.Cors.EnableCors = true;
+        options.Cors.AllowedOrigins = ["myothersite.com"];
         options.MapEndpoints = endpoints =>
         {
             endpoints.MapGet("/", () => "Hello World from the root!");


### PR DESCRIPTION
## Summary
- add `CorsOptions` and endpoint mapping to `WebOptions`
- allow `WebApp.RunAsync` to accept an options configurator
- let `IRunnableWebModule` configure `WebOptions`
- enable CORS middleware and direct endpoint mapping in `WebStartup`
- update example web app
- centralize module collection in `WebStartup`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d6c618de08324b4047f8fffd760c6