### PR TITLE
Add configuration provider tests

### DIFF
--- a/Config/ForgeTrust.Runnable.Config/AssemblyInfo.cs
+++ b/Config/ForgeTrust.Runnable.Config/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ForgeTrust.Runnable.config.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Config/ForgeTrust.Runnable.config.Tests/ConfigTests.cs
+++ b/Config/ForgeTrust.Runnable.config.Tests/ConfigTests.cs
@@ -1,0 +1,93 @@
+using FakeItEasy;
+using ForgeTrust.Runnable.Config;
+using ForgeTrust.Runnable.Core;
+
+namespace ForgeTrust.Runnable.config.Tests;
+
+public class ConfigTests
+{
+    private sealed class TestConfig : Config<string>
+    {
+        public override string? DefaultValue => "fallback";
+    }
+
+    private sealed class TestStructConfig : ConfigStruct<int>
+    {
+        public override int? DefaultValue => 42;
+    }
+
+    private sealed class IntConfigManagerStub : IConfigManager
+    {
+        public int Priority => 0;
+
+        public string Name => nameof(IntConfigManagerStub);
+
+        public int? ValueToReturn { get; set; }
+
+        public T? GetValue<T>(string environment, string key)
+        {
+            if (typeof(T) == typeof(int))
+            {
+                return ValueToReturn is null
+                    ? default
+                    : (T?)(object?)ValueToReturn;
+            }
+
+            return default;
+        }
+    }
+
+    [Fact]
+    public void Init_UsesDefaultValueWhenManagerReturnsNull()
+    {
+        var configManager = A.Fake<IConfigManager>();
+        var environmentProvider = A.Fake<IEnvironmentProvider>();
+        var config = new TestConfig();
+
+        A.CallTo(() => environmentProvider.Environment).Returns("Production");
+        A.CallTo(() => configManager.GetValue<string>("Production", "Test.Key"))
+            .Returns(null);
+
+        ((IConfig)config).Init(configManager, environmentProvider, "Test.Key");
+
+        Assert.True(config.HasValue);
+        Assert.True(config.IsDefaultValue);
+        Assert.Equal("fallback", config.Value);
+    }
+
+    [Fact]
+    public void Init_PopulatesValueFromConfigManagerWhenPresent()
+    {
+        var configManager = A.Fake<IConfigManager>();
+        var environmentProvider = A.Fake<IEnvironmentProvider>();
+        var config = new TestConfig();
+
+        A.CallTo(() => environmentProvider.Environment).Returns("Production");
+        A.CallTo(() => configManager.GetValue<string>("Production", "Test.Key"))
+            .Returns("value");
+
+        ((IConfig)config).Init(configManager, environmentProvider, "Test.Key");
+
+        Assert.True(config.HasValue);
+        Assert.False(config.IsDefaultValue);
+        Assert.Equal("value", config.Value);
+    }
+
+    [Fact]
+    public void Init_ForStructConfigUsesManagerValueWhenPresent()
+    {
+        var configManager = new IntConfigManagerStub
+        {
+            ValueToReturn = 7
+        };
+        var environmentProvider = A.Fake<IEnvironmentProvider>();
+        var config = new TestStructConfig();
+
+        A.CallTo(() => environmentProvider.Environment).Returns("Production");
+
+        config.Init(configManager, environmentProvider, "Struct.Key");
+
+        Assert.True(config.HasValue);
+        Assert.Equal<int?>(7, config.Value);
+    }
+}

--- a/Config/ForgeTrust.Runnable.config.Tests/DefaultConfigManagerTests.cs
+++ b/Config/ForgeTrust.Runnable.config.Tests/DefaultConfigManagerTests.cs
@@ -1,0 +1,90 @@
+using FakeItEasy;
+using ForgeTrust.Runnable.Config;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.Runnable.config.Tests;
+
+public class DefaultConfigManagerTests
+{
+    [Fact]
+    public void GetValue_ReturnsEnvironmentValueWhenPresent()
+    {
+        var environmentProvider = A.Fake<IEnvironmentConfigProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+        var otherProvider = A.Fake<IConfigProvider>();
+
+        A.CallTo(() => environmentProvider.GetValue<string>("Production", "App.Key"))
+            .Returns("from-environment");
+
+        var manager = new DefaultConfigManager(environmentProvider, [otherProvider], logger);
+
+        var value = manager.GetValue<string>("Production", "App.Key");
+
+        Assert.Equal("from-environment", value);
+        A.CallTo(() => otherProvider.GetValue<string>(A<string>._, A<string>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public void GetValue_QueriesProvidersByDescendingPriority()
+    {
+        var environmentProvider = A.Fake<IEnvironmentConfigProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+        var highPriorityProvider = A.Fake<IConfigProvider>();
+        var lowPriorityProvider = A.Fake<IConfigProvider>();
+        var anotherConfigManager = A.Fake<IConfigManager>();
+
+        A.CallTo(() => environmentProvider.GetValue<string>(A<string>._, A<string>._))
+            .Returns(null);
+        A.CallTo(() => highPriorityProvider.Priority).Returns(10);
+        A.CallTo(() => highPriorityProvider.GetValue<string>("Production", "Feature.Flag"))
+            .Returns(null);
+        A.CallTo(() => lowPriorityProvider.Priority).Returns(1);
+        A.CallTo(() => lowPriorityProvider.GetValue<string>("Production", "Feature.Flag"))
+            .Returns("from-low");
+
+        var manager = new DefaultConfigManager(
+            environmentProvider,
+            new IConfigProvider[]
+            {
+                highPriorityProvider,
+                lowPriorityProvider,
+                environmentProvider, // should be filtered out
+                anotherConfigManager  // should be filtered out
+            },
+            logger);
+
+        var value = manager.GetValue<string>("Production", "Feature.Flag");
+
+        Assert.Equal("from-low", value);
+
+        A.CallTo(() => highPriorityProvider.GetValue<string>("Production", "Feature.Flag"))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => lowPriorityProvider.GetValue<string>("Production", "Feature.Flag"))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => environmentProvider.GetValue<string>("Production", "Feature.Flag"))
+            .MustHaveHappenedOnceExactly();
+
+    }
+
+    [Fact]
+    public void GetValue_ReturnsDefaultWhenNoProvidersHaveValue()
+    {
+        var environmentProvider = A.Fake<IEnvironmentConfigProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+        var otherProvider = A.Fake<IConfigProvider>();
+
+        A.CallTo(() => environmentProvider.GetValue<string>(A<string>._, A<string>._)).Returns(null);
+        A.CallTo(() => otherProvider.GetValue<string>(A<string>._, A<string>._)).Returns(null);
+
+        var manager = new DefaultConfigManager(environmentProvider, [otherProvider], logger);
+
+        var value = manager.GetValue<string>("Any", "Missing.Key");
+
+        Assert.Null(value);
+        A.CallTo(() => environmentProvider.GetValue<string>("Any", "Missing.Key"))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => otherProvider.GetValue<string>("Any", "Missing.Key"))
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/Config/ForgeTrust.Runnable.config.Tests/DefaultConfigManagerTests.cs
+++ b/Config/ForgeTrust.Runnable.config.Tests/DefaultConfigManagerTests.cs
@@ -64,7 +64,6 @@ public class DefaultConfigManagerTests
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => environmentProvider.GetValue<string>("Production", "Feature.Flag"))
             .MustHaveHappenedOnceExactly();
-
     }
 
     [Fact]

--- a/Config/ForgeTrust.Runnable.config.Tests/EnvironmentConfigProviderTests.cs
+++ b/Config/ForgeTrust.Runnable.config.Tests/EnvironmentConfigProviderTests.cs
@@ -1,0 +1,62 @@
+using FakeItEasy;
+using ForgeTrust.Runnable.Config;
+using ForgeTrust.Runnable.Core;
+
+namespace ForgeTrust.Runnable.config.Tests;
+
+public class EnvironmentConfigProviderTests
+{
+    [Fact]
+    public void GetValue_UsesEnvironmentSpecificVariableFirst()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("PRODUCTION_FEATURE_ENABLED", A<string?>._))
+            .Returns("true");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        var value = provider.GetValue<bool>("Production", "Feature.Enabled");
+
+        Assert.True(value);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("PRODUCTION_FEATURE_ENABLED", A<string?>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("FEATURE_ENABLED", A<string?>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public void GetValue_FallsBackToKeyWhenEnvironmentSpecificVariableMissing()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("DEV_US_SECTION_VALUE", A<string?>._))
+            .Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("SECTION_VALUE", A<string?>._))
+            .Returns("42");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        var value = provider.GetValue<int>("Dev-Us", "Section.Value");
+
+        Assert.Equal(42, value);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("DEV_US_SECTION_VALUE", A<string?>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("SECTION_VALUE", A<string?>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public void Properties_AreProxiedToInnerProvider()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.Environment).Returns("Test");
+        A.CallTo(() => innerProvider.IsDevelopment).Returns(true);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("ANY", A<string?>._))
+            .Returns("value");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        Assert.Equal("Test", provider.Environment);
+        Assert.True(provider.IsDevelopment);
+        Assert.Equal("value", provider.GetEnvironmentVariable("ANY"));
+    }
+}

--- a/Config/ForgeTrust.Runnable.config.Tests/FileBasedConfigProviderTests.cs
+++ b/Config/ForgeTrust.Runnable.config.Tests/FileBasedConfigProviderTests.cs
@@ -1,0 +1,99 @@
+using FakeItEasy;
+using ForgeTrust.Runnable.Config;
+using ForgeTrust.Runnable.Core;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.Runnable.config.Tests;
+
+public class FileBasedConfigProviderTests
+{
+    [Fact]
+    public void GetValue_MergesFilesByEnvironmentAndPriority()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "appsettings.json"),
+                """{"Feature":{"Enabled":false,"Name":"Prod"}}""");
+            File.WriteAllText(Path.Combine(tempDir, "config_extra.json"),
+                """{"Feature":{"Extra":"ProdExtra"}}""");
+            File.WriteAllText(Path.Combine(tempDir, "appsettings.Development.json"),
+                """{"Feature":{"Name":"Dev"}}""");
+            File.WriteAllText(Path.Combine(tempDir, "config_extra.Development.json"),
+                """{"Feature":{"Enabled":true,"Extra":"Value"}}""");
+            File.WriteAllText(Path.Combine(tempDir, "config_bad.json"), "{not json}");
+
+            var environmentProvider = A.Fake<IEnvironmentProvider>();
+            var locationProvider = A.Fake<IConfigFileLocationProvider>();
+            var logger = A.Fake<ILogger<FileBasedConfigProvider>>();
+
+            A.CallTo(() => locationProvider.Directory).Returns(tempDir);
+
+            var provider = new FileBasedConfigProvider(environmentProvider, locationProvider, logger);
+
+            Assert.Equal("Dev", provider.GetValue<string>("Development", "Feature.Name"));
+            Assert.True(provider.GetValue<bool>("Development", "Feature.Enabled"));
+            Assert.Equal("Value", provider.GetValue<string>("Development", "Feature.Extra"));
+            Assert.False(provider.GetValue<bool>("Production", "Feature.Enabled"));
+            Assert.Equal("ProdExtra", provider.GetValue<string>("Production", "Feature.Extra"));
+            Assert.Null(provider.GetValue<string>("Production", "Feature.Unknown"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetValue_ReturnsDefaultWhenDirectoryMissing()
+    {
+        var environmentProvider = A.Fake<IEnvironmentProvider>();
+        var locationProvider = A.Fake<IConfigFileLocationProvider>();
+        var logger = A.Fake<ILogger<FileBasedConfigProvider>>();
+
+        A.CallTo(() => locationProvider.Directory).Returns(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+
+        var provider = new FileBasedConfigProvider(environmentProvider, locationProvider, logger);
+
+        Assert.Null(provider.GetValue<string>("Production", "Any.Key"));
+    }
+
+    [Fact]
+    public void GetValue_ReusesCachedConfigurationAfterInitialization()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var configPath = Path.Combine(tempDir, "appsettings.json");
+            File.WriteAllText(configPath, """{"Feature":{"Enabled":true}}""");
+
+            var environmentProvider = A.Fake<IEnvironmentProvider>();
+            var locationProvider = A.Fake<IConfigFileLocationProvider>();
+            var logger = A.Fake<ILogger<FileBasedConfigProvider>>();
+
+            A.CallTo(() => locationProvider.Directory).Returns(tempDir);
+
+            var provider = new FileBasedConfigProvider(environmentProvider, locationProvider, logger);
+
+            Assert.True(provider.GetValue<bool>("Production", "Feature.Enabled"));
+
+            File.WriteAllText(configPath, """{"Feature":{"Enabled":false}}""");
+
+            Assert.True(provider.GetValue<bool>("Production", "Feature.Enabled"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}

--- a/Config/ForgeTrust.Runnable.config.Tests/ForgeTrust.Runnable.config.Tests.csproj
+++ b/Config/ForgeTrust.Runnable.config.Tests/ForgeTrust.Runnable.config.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="8.0.2" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -20,6 +21,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ForgeTrust.Runnable.Config/ForgeTrust.Runnable.Config.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Config/ForgeTrust.Runnable.config.Tests/UnitTest1.cs
+++ b/Config/ForgeTrust.Runnable.config.Tests/UnitTest1.cs
@@ -1,9 +1,0 @@
-﻿namespace ForgeTrust.Runnable.config.Tests;
-
-public class UnitTest1
-{
-    [Fact]
-    public void Test1()
-    {
-    }
-}


### PR DESCRIPTION
## Summary
- add FakeItEasy and a project reference update for the configuration test project
- add tests covering DefaultConfigManager, EnvironmentConfigProvider, FileBasedConfigProvider, and Config types
- expose ForgeTrust.Runnable.Config internals for the new tests

## Testing
- dotnet test ForgeTrust.Runnable.slnx

------
https://chatgpt.com/codex/tasks/task_e_68e0ab1e723883248e73f70b68967924