### PR TITLE
chore: isolate benchmark dependencies into benchmarks/Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,6 @@
     <PackageVersion Include="Aspire.Hosting" Version="9.4.2" />
     <PackageVersion Include="Autofac" Version="8.0.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageVersion Include="Carter" Version="9.0.0" />
     <PackageVersion Include="CliFx" Version="2.3.6" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
@@ -29,10 +27,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.6.8" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.47.0" />
-    <PackageVersion Include="Volo.Abp.AspNetCore" Version="9.3.1" />
-    <PackageVersion Include="Volo.Abp.AspNetCore.Mvc" Version="9.3.1" />
-    <PackageVersion Include="Volo.Abp.Core" Version="9.3.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.36" />

--- a/benchmarks/Directory.Packages.props
+++ b/benchmarks/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageVersion Include="Carter" Version="9.0.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.47.0" />
+    <PackageVersion Include="Volo.Abp.AspNetCore" Version="9.3.1" />
+    <PackageVersion Include="Volo.Abp.AspNetCore.Mvc" Version="9.3.1" />
+    <PackageVersion Include="Volo.Abp.Core" Version="9.3.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes #63

## Summary
Isolated benchmark dependencies (`BenchmarkDotNet`, `Volo.Abp.*`, `Carter`, `Spectre.Console.Cli`) from the root `Directory.Packages.props` into a new `benchmarks/Directory.Packages.props`. This keeps the core library's dependency tree clean and lightweight.

## Changes
- Created `benchmarks/Directory.Packages.props` which imports the root props and adds benchmark-specific package versions.
- Removed benchmark-specific package versions from the root `Directory.Packages.props`.

## Verification
- Verified `dotnet build` works for `RunnableBenchmarks`.
- Verified `dotnet build` works for `ForgeTrust.Runnable.Web` and `Core`.
- Ran all unit tests. One unrelated failure was observed (pre-existing in `main`).
