### PR TITLE
feat(cli): handle multi-target projects in export command

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceRequestFactoryTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceRequestFactoryTests.cs
@@ -9,45 +9,45 @@ public class ExportSourceRequestFactoryTests
     [Fact]
     public void Create_Should_Throw_When_No_Source_Is_Provided()
     {
-        Assert.Throws<CommandException>(() => _sut.Create(null, null, null, [], false));
+        Assert.Throws<CommandException>(() => _sut.Create(null, null, null, null, [], false));
     }
 
     [Fact]
     public void Create_Should_Throw_When_Multiple_Sources_Are_Provided()
     {
-        Assert.Throws<CommandException>(() => _sut.Create("http://localhost:5000", "app.csproj", null, [], false));
+        Assert.Throws<CommandException>(() => _sut.Create("http://localhost:5000", "app.csproj", null, null, [], false));
     }
 
     [Fact]
     public void Create_Should_Throw_When_Url_Is_Invalid()
     {
-        var ex = Assert.Throws<CommandException>(() => _sut.Create("not-a-url", null, null, [], false));
+        var ex = Assert.Throws<CommandException>(() => _sut.Create("not-a-url", null, null, null, [], false));
         Assert.Contains("--url", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void Create_Should_Throw_When_Project_File_Is_Missing()
     {
-        Assert.Throws<CommandException>(() => _sut.Create(null, "missing.csproj", null, [], false));
+        Assert.Throws<CommandException>(() => _sut.Create(null, "missing.csproj", null, null, [], false));
     }
 
     [Fact]
     public void Create_Should_Throw_When_Dll_File_Is_Missing()
     {
-        Assert.Throws<CommandException>(() => _sut.Create(null, null, "missing.dll", [], false));
+        Assert.Throws<CommandException>(() => _sut.Create(null, null, "missing.dll", null, [], false));
     }
 
     [Fact]
     public void Create_Should_Throw_When_Project_File_Extension_Is_Invalid()
     {
-        var ex = Assert.Throws<CommandException>(() => _sut.Create(null, "app.txt", null, [], false));
+        var ex = Assert.Throws<CommandException>(() => _sut.Create(null, "app.txt", null, null, [], false));
         Assert.Contains("--project must point to a .csproj file.", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void Create_Should_Throw_When_Dll_File_Extension_Is_Invalid()
     {
-        var ex = Assert.Throws<CommandException>(() => _sut.Create(null, null, "app.txt", [], false));
+        var ex = Assert.Throws<CommandException>(() => _sut.Create(null, null, "app.txt", null, [], false));
         Assert.Contains("--dll must point to a .dll file.", ex.Message, StringComparison.Ordinal);
     }
 
@@ -59,10 +59,11 @@ public class ExportSourceRequestFactoryTests
         File.Move(tempPath, projectPath);
         try
         {
-            var request = _sut.Create(null, projectPath, null, ["--foo", "bar"], true);
+            var request = _sut.Create(null, projectPath, null, "net9.0", ["--foo", "bar"], true);
 
             Assert.Equal(ExportSourceKind.Project, request.SourceKind);
             Assert.Equal(Path.GetFullPath(projectPath), request.SourceValue);
+            Assert.Equal("net9.0", request.Framework);
             Assert.Equal(["--foo", "bar"], request.AppArgs);
             Assert.True(request.NoBuild);
         }
@@ -83,10 +84,11 @@ public class ExportSourceRequestFactoryTests
         File.Move(tempPath, dllPath);
         try
         {
-            var request = _sut.Create(null, null, dllPath, ["--foo", "bar"], false);
+            var request = _sut.Create(null, null, dllPath, "net9.0", ["--foo", "bar"], false);
 
             Assert.Equal(ExportSourceKind.Dll, request.SourceKind);
             Assert.Equal(Path.GetFullPath(dllPath), request.SourceValue);
+            Assert.Equal("net9.0", request.Framework);
             Assert.Equal(["--foo", "bar"], request.AppArgs);
             Assert.False(request.NoBuild);
         }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -91,6 +91,7 @@ public class ExportSourceResolverTests
         var request = new ExportSourceRequest(
             ExportSourceKind.Dll,
             "/tmp/app.dll",
+            null,
             ["--foo", "bar"],
             false);
 
@@ -122,6 +123,7 @@ public class ExportSourceResolverTests
         var request = new ExportSourceRequest(
             ExportSourceKind.Url,
             "http://localhost:5233",
+            null,
             [],
             false);
 
@@ -147,6 +149,7 @@ public class ExportSourceResolverTests
         var request = new ExportSourceRequest(
             ExportSourceKind.Url,
             "http://localhost:5233",
+            null,
             [],
             false);
 
@@ -173,6 +176,7 @@ public class ExportSourceResolverTests
         var request = new ExportSourceRequest(
             ExportSourceKind.Url,
             "http://localhost:5233",
+            null,
             [],
             false);
 
@@ -198,6 +202,7 @@ public class ExportSourceResolverTests
         var request = new ExportSourceRequest(
             ExportSourceKind.Url,
             "http://localhost:5233",
+            null,
             [],
             false);
 
@@ -219,7 +224,7 @@ public class ExportSourceResolverTests
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
         resolver.ListeningUrlTimeout = TimeSpan.FromMilliseconds(100);
 
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", null, [], false);
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await resolver.ResolveAsync(request));
 
@@ -237,7 +242,7 @@ public class ExportSourceResolverTests
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
         resolver.ListeningUrlTimeout = TimeSpan.FromSeconds(1);
 
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", null, [], false);
         fakeProcess.OnStart = () =>
         {
             fakeProcess.EmitError("failed to bind");
@@ -260,7 +265,7 @@ public class ExportSourceResolverTests
         resolver.AppReadyTimeout = TimeSpan.FromMilliseconds(120);
         resolver.AppReadyPollInterval = TimeSpan.FromMilliseconds(20);
 
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", null, [], false);
         fakeProcess.OnStart = () => fakeProcess.EmitOutput("Now listening on: http://127.0.0.1:5050");
 
         await Assert.ThrowsAsync<TimeoutException>(async () => await resolver.ResolveAsync(request));
@@ -279,7 +284,7 @@ public class ExportSourceResolverTests
         var resolver = CreateResolver(
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", null, [], false);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await resolver.ResolveAsync(request));
 
@@ -298,7 +303,7 @@ public class ExportSourceResolverTests
         resolver.AppReadyPollInterval = TimeSpan.FromMilliseconds(20);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(80));
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", null, [], false);
         fakeProcess.OnStart = () => fakeProcess.EmitOutput("Now listening on: http://127.0.0.1:5050");
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -315,7 +320,7 @@ public class ExportSourceResolverTests
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.NotFound)));
 
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/site.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/site.dll", null, [], false);
         fakeProcess.OnStart = () => fakeProcess.EmitOutput("Now listening on: http://127.0.0.1:5050");
 
         await using var result = await resolver.ResolveAsync(request);
@@ -329,7 +334,7 @@ public class ExportSourceResolverTests
         var resolver = CreateResolver(
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
-        var request = new ExportSourceRequest(ExportSourceKind.Project, "/tmp/site.csproj", ["--flag"], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Project, "/tmp/site.csproj", null, ["--flag"], false);
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.BuildProcessLaunchSpec(request));
         Assert.Contains("resolved to a DLL", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -350,7 +355,7 @@ public class ExportSourceResolverTests
         var resolver = CreateResolver(
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
-        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, [], true);
+        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], true);
 
         var resolved = await resolver.ResolveLaunchRequestAsync(request);
 
@@ -381,7 +386,7 @@ public class ExportSourceResolverTests
         var resolver = CreateResolver(
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
-        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, [], true);
+        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], true);
 
         var resolved = await resolver.ResolveLaunchRequestAsync(request);
 
@@ -413,7 +418,7 @@ public class ExportSourceResolverTests
         var resolver = CreateResolver(
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
-        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], false);
 
         var resolved = await resolver.ResolveLaunchRequestAsync(request);
 
@@ -432,11 +437,106 @@ public class ExportSourceResolverTests
         var resolver = CreateResolver(
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
-        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], false);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => resolver.ResolveLaunchRequestAsync(request));
         Assert.Contains("dotnet publish", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsMultiTargetProject_Should_Return_True_When_TargetFrameworks_Exists()
+    {
+        using var tempDir = new TempDirectory();
+        var projectPath = Path.Combine(tempDir.FullPath, "MySite.csproj");
+        File.WriteAllText(
+            projectPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        Assert.True(ExportSourceResolver.IsMultiTargetProject(projectPath));
+    }
+
+    [Fact]
+    public void IsMultiTargetProject_Should_Return_False_When_TargetFrameworks_Is_Missing()
+    {
+        using var tempDir = new TempDirectory();
+        var projectPath = Path.Combine(tempDir.FullPath, "MySite.csproj");
+        File.WriteAllText(
+            projectPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        Assert.False(ExportSourceResolver.IsMultiTargetProject(projectPath));
+    }
+
+    [Fact]
+    public async Task ResolveLaunchRequestAsync_Should_Throw_When_MultiTarget_Project_And_Framework_Missing()
+    {
+        using var tempDir = new TempDirectory();
+        var projectPath = Path.Combine(tempDir.FullPath, "MySite.csproj");
+        await File.WriteAllTextAsync(
+            projectPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var factory = new FakeTargetAppProcessFactory(_ => new FakeTargetAppProcess());
+        var resolver = CreateResolver(
+            factory,
+            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
+        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], false);
+
+        var ex = await Assert.ThrowsAsync<CommandException>(
+            () => resolver.ResolveLaunchRequestAsync(request));
+        Assert.Contains("multi-target project", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--framework", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ResolveLaunchRequestAsync_Should_Inject_Framework_Arg_When_Framework_Specified()
+    {
+        using var tempDir = new TempDirectory();
+        var projectPath = Path.Combine(tempDir.FullPath, "MySite.csproj");
+        var programPath = Path.Combine(tempDir.FullPath, "Program.cs");
+
+        await File.WriteAllTextAsync(
+            projectPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """);
+        await File.WriteAllTextAsync(programPath, "System.Console.WriteLine(\"hello\");");
+
+        var factory = new FakeTargetAppProcessFactory(_ => new FakeTargetAppProcess());
+        var resolver = CreateResolver(
+            factory,
+            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
+        var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, "net10.0", [], false);
+
+        var resolved = await resolver.ResolveLaunchRequestAsync(request);
+
+        Assert.Equal(ExportSourceKind.Dll, resolved.SourceKind);
+        Assert.True(File.Exists(resolved.SourceValue));
+        Assert.EndsWith("MySite.dll", resolved.SourceValue, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -647,6 +747,7 @@ public class ExportSourceResolverTests
         var request = new ExportSourceRequest(
             ExportSourceKind.Dll,
             "/tmp/site.dll",
+            null,
             ["--urls", "http://127.0.0.1:6001"],
             false);
 
@@ -667,7 +768,7 @@ public class ExportSourceResolverTests
         resolver.AppReadyTimeout = TimeSpan.FromMilliseconds(120);
         resolver.AppReadyPollInterval = TimeSpan.FromMilliseconds(20);
 
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", null, [], false);
         fakeProcess.OnStart = () => fakeProcess.EmitOutput("Now listening on: http://127.0.0.1:5050");
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await resolver.ResolveAsync(request));
@@ -686,7 +787,7 @@ public class ExportSourceResolverTests
         resolver.AppReadyTimeout = TimeSpan.FromSeconds(1);
         resolver.AppReadyPollInterval = TimeSpan.FromMilliseconds(20);
 
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", [], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/app.dll", null, [], false);
         fakeProcess.OnStart = () =>
         {
             fakeProcess.EmitOutput("Now listening on: http://127.0.0.1:5050");
@@ -708,7 +809,7 @@ public class ExportSourceResolverTests
         var resolver = CreateResolver(
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
-        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/site.dll", ["--flag"], false);
+        var request = new ExportSourceRequest(ExportSourceKind.Dll, "/tmp/site.dll", null, ["--flag"], false);
 
         var spec = resolver.BuildProcessLaunchSpec(request);
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -538,6 +538,31 @@ public class ExportSourceResolverTests
         Assert.Equal(ExportSourceKind.Dll, resolved.SourceKind);
         Assert.True(File.Exists(resolved.SourceValue));
         Assert.EndsWith("MySite.dll", resolved.SourceValue, StringComparison.OrdinalIgnoreCase);
+
+        // Prove framework selection by reading the runtimeconfig.json (since `-o` flattens the output directory)
+        var configPath = Path.ChangeExtension(resolved.SourceValue, ".runtimeconfig.json");
+        Assert.True(File.Exists(configPath));
+        var configJson = await File.ReadAllTextAsync(configPath);
+        Assert.Contains("net10.0", configJson, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveBuiltDllPath_Should_Honor_Requested_Framework_When_Provided()
+    {
+        using var tempDir = new TempDirectory();
+        
+        var net9Dir = Path.Combine(tempDir.FullPath, "bin", "Release", "net9.0", "publish");
+        Directory.CreateDirectory(net9Dir);
+        File.WriteAllBytes(Path.Combine(net9Dir, "MySite.dll"), [1, 2, 3]);
+
+        var net10Dir = Path.Combine(tempDir.FullPath, "bin", "Release", "net10.0", "publish");
+        Directory.CreateDirectory(net10Dir);
+        File.WriteAllBytes(Path.Combine(net10Dir, "MySite.dll"), [4, 5, 6]);
+
+        // When requestedFramework is net9.0, it should find the net9.0 one instead of falling back to the highest (net10.0).
+        var resolved = ExportSourceResolver.ResolveBuiltDllPath(tempDir.FullPath, "MySite", null, "net9.0");
+
+        Assert.Equal(Path.Combine(net9Dir, "MySite.dll"), resolved);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -508,6 +508,7 @@ public class ExportSourceResolverTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task ResolveLaunchRequestAsync_Should_Inject_Framework_Arg_When_Framework_Specified()
     {
         using var tempDir = new TempDirectory();

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
@@ -44,6 +44,12 @@ public class ExportCommand : ICommand
     public string? DllPath { get; init; }
 
     /// <summary>
+    /// Gets or sets an optional target framework for project exports, required for multi-target projects.
+    /// </summary>
+    [CommandOption("framework", 'f', Description = "Target framework (required for multi-target projects).")]
+    public string? Framework { get; init; }
+
+    /// <summary>
     /// Gets or sets app arguments forwarded to the launched target app.
     /// Repeat this option for each token.
     /// </summary>
@@ -120,7 +126,7 @@ public class ExportCommand : ICommand
     /// <returns>A <see cref="ValueTask"/> that completes when the export operation finishes.</returns>
     public async ValueTask ExecuteAsync(IConsole console, CancellationToken cancellationToken)
     {
-        var request = _requestFactory.Create(BaseUrl, ProjectPath, DllPath, AppArgs, NoBuild);
+        var request = _requestFactory.Create(BaseUrl, ProjectPath, DllPath, Framework, AppArgs, NoBuild);
         await using var resolvedSource = await _sourceResolver.ResolveAsync(request, cancellationToken);
 
         _logger.LogInformation("Exporting to {OutputPath}...", OutputPath);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceRequest.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceRequest.cs
@@ -10,5 +10,6 @@ internal enum ExportSourceKind
 internal sealed record ExportSourceRequest(
     ExportSourceKind SourceKind,
     string SourceValue,
+    string? Framework,
     IReadOnlyList<string> AppArgs,
     bool NoBuild);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceRequestFactory.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceRequestFactory.cs
@@ -11,6 +11,7 @@ public class ExportSourceRequestFactory
         string? baseUrl,
         string? projectPath,
         string? dllPath,
+        string? framework,
         IReadOnlyList<string> appArgs,
         bool noBuild)
     {
@@ -43,6 +44,7 @@ public class ExportSourceRequestFactory
             return new ExportSourceRequest(
                 ExportSourceKind.Url,
                 uri.ToString().TrimEnd('/'),
+                framework,
                 appArgs,
                 noBuild);
         }
@@ -50,11 +52,11 @@ public class ExportSourceRequestFactory
         if (!string.IsNullOrWhiteSpace(projectPath))
         {
             var fullPath = ValidateFile(projectPath, ".csproj", "--project");
-            return new ExportSourceRequest(ExportSourceKind.Project, fullPath, appArgs, noBuild);
+            return new ExportSourceRequest(ExportSourceKind.Project, fullPath, framework, appArgs, noBuild);
         }
 
         var dllFullPath = ValidateFile(dllPath!, ".dll", "--dll");
-        return new ExportSourceRequest(ExportSourceKind.Dll, dllFullPath, appArgs, noBuild);
+        return new ExportSourceRequest(ExportSourceKind.Dll, dllFullPath, framework, appArgs, noBuild);
     }
 
     private static string ValidateFile(string filePath, string extension, string optionName)

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -197,7 +197,8 @@ public sealed class ExportSourceResolver
         var dllPath = ResolveBuiltDllPath(
             projectDirectory,
             assemblyName,
-            request.NoBuild ? null : publishOutputDirectory);
+            request.NoBuild ? null : publishOutputDirectory,
+            request.Framework);
         _logger.LogInformation("Launching published DLL for export: {DllPath}", dllPath);
 
         return request with
@@ -369,7 +370,8 @@ public sealed class ExportSourceResolver
     internal static string ResolveBuiltDllPath(
         string projectDirectory,
         string assemblyName,
-        string? explicitPublishDirectory)
+        string? explicitPublishDirectory,
+        string? requestedFramework = null)
     {
         var searchRoots = new List<(string Path, bool RequirePublishSegment)>();
         var explicitPublishPath = string.IsNullOrWhiteSpace(explicitPublishDirectory)
@@ -431,7 +433,11 @@ public sealed class ExportSourceResolver
                 $"Could not locate published DLL for assembly '{assemblyName}' under '{projectDirectory}'.");
         }
 
-        var preferredFramework = ResolvePreferredFramework(candidatePaths, projectDirectory);
+        var preferredFramework =
+            string.IsNullOrWhiteSpace(explicitPublishPath) &&
+            !string.IsNullOrWhiteSpace(requestedFramework)
+                ? requestedFramework
+                : ResolvePreferredFramework(candidatePaths, projectDirectory);
         if (!string.IsNullOrWhiteSpace(preferredFramework))
         {
             candidatePaths = candidatePaths
@@ -508,10 +514,16 @@ public sealed class ExportSourceResolver
 
             return document
                 .Descendants()
-                .Any(node => string.Equals(
+                .Where(node => string.Equals(
                     node.Name.LocalName,
                     "TargetFrameworks",
-                    StringComparison.OrdinalIgnoreCase));
+                    StringComparison.OrdinalIgnoreCase))
+                .SelectMany(node => node.Value.Split(
+                    ';',
+                    StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Skip(1)
+                .Any();
         }
         catch (IOException)
         {

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -29,6 +29,7 @@ public sealed class ExportSourceResolver
     private static readonly Regex ListeningUrlRegex = new(
         @"Now listening on:\s*(https?://\S+)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     private static readonly Regex FrameworkSegmentRegex = new(
         @"^(net(?<major>\d+)(\.(?<minor>\d+))?|netcoreapp(?<major>\d+)(\.(?<minor>\d+))?|netstandard(?<major>\d+)(\.(?<minor>\d+))?)(?:-[A-Za-z0-9][A-Za-z0-9\.-]*)?$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -78,6 +79,7 @@ public sealed class ExportSourceResolver
         {
             _logger.LogInformation("Using URL source directly: {BaseUrl}", request.SourceValue);
             await ValidateUrlSourceAsync(request.SourceValue, cancellationToken);
+
             return new ResolvedExportSource(request.SourceValue, null);
         }
 
@@ -94,8 +96,9 @@ public sealed class ExportSourceResolver
         process.Exited += () =>
         {
             Interlocked.Exchange(ref processExited, 1);
-            boundBaseUrlSource.TrySetException(new InvalidOperationException(
-                $"Target application exited before publishing a listening URL.{Environment.NewLine}{GetRecentLogs(logs)}"));
+            boundBaseUrlSource.TrySetException(
+                new InvalidOperationException(
+                    $"Target application exited before publishing a listening URL.{Environment.NewLine}{GetRecentLogs(logs)}"));
         };
 
         try
@@ -107,18 +110,25 @@ public sealed class ExportSourceResolver
                 AppReadyTimeout.TotalSeconds);
 
             var baseUrl = await WaitForBoundBaseUrlAsync(boundBaseUrlSource, logs, cancellationToken);
-            await WaitForAppReadyAsync(baseUrl, process, () => Volatile.Read(ref processExited) == 1, logs, cancellationToken);
+            await WaitForAppReadyAsync(
+                baseUrl,
+                process,
+                () => Volatile.Read(ref processExited) == 1,
+                logs,
+                cancellationToken);
 
             startupStopwatch.Stop();
             _logger.LogInformation(
                 "Resolved export source URL: {BaseUrl} (startup took {ElapsedMs}ms)",
                 baseUrl,
                 startupStopwatch.ElapsedMilliseconds);
+
             return new ResolvedExportSource(baseUrl, process);
         }
         catch
         {
             await process.DisposeAsync();
+
             throw;
         }
     }
@@ -133,6 +143,13 @@ public sealed class ExportSourceResolver
         }
 
         var projectPath = request.SourceValue;
+
+        if (string.IsNullOrWhiteSpace(request.Framework) && IsMultiTargetProject(projectPath))
+        {
+            throw new CommandException(
+                "The publish target is not supported without specifying a target framework in a multi-target project. Use the --framework option to specify.");
+        }
+
         var projectDirectory = Path.GetDirectoryName(projectPath) ?? Directory.GetCurrentDirectory();
         var projectName = Path.GetFileNameWithoutExtension(projectPath);
         var assemblyName = TryResolveAssemblyName(projectPath, projectName);
@@ -144,14 +161,31 @@ public sealed class ExportSourceResolver
             {
                 Directory.Delete(publishOutputDirectory, true);
             }
+
             Directory.CreateDirectory(publishOutputDirectory);
             _logger.LogInformation(
                 "Publishing project for export: {ProjectPath} -> {OutputPath}",
                 projectPath,
                 publishOutputDirectory);
+
+            var publishArgs = new List<string>
+            {
+                "publish",
+                projectPath,
+                "-c",
+                "Release",
+                "-o",
+                publishOutputDirectory
+            };
+            if (!string.IsNullOrWhiteSpace(request.Framework))
+            {
+                publishArgs.Add("-f");
+                publishArgs.Add(request.Framework);
+            }
+
             await RunCommandOrThrowAsync(
                 "dotnet",
-                ["publish", projectPath, "-c", "Release", "-o", publishOutputDirectory],
+                publishArgs,
                 projectDirectory,
                 cancellationToken);
         }
@@ -179,11 +213,12 @@ public sealed class ExportSourceResolver
 
         if (request.SourceKind == ExportSourceKind.Project)
         {
-            throw new InvalidOperationException("Project sources must be resolved to a DLL launch request before building process launch spec.");
+            throw new InvalidOperationException(
+                "Project sources must be resolved to a DLL launch request before building process launch spec.");
         }
 
         var dllDirectory = Path.GetDirectoryName(request.SourceValue)
-            ?? Directory.GetCurrentDirectory();
+                           ?? Directory.GetCurrentDirectory();
         var dllArgs = new List<string> { request.SourceValue };
         dllArgs.AddRange(effectiveAppArgs);
         // Deliberately force production hosting for launched export targets so middleware/static-asset
@@ -234,11 +269,13 @@ public sealed class ExportSourceResolver
         {
             throw new CommandException(BuildUrlSourceTimeoutMessage(baseUrl, AppReadyTimeout));
         }
-        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested && !timeoutCts.IsCancellationRequested)
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested
+                                            && !timeoutCts.IsCancellationRequested)
         {
             var effectiveTimeout = client.Timeout != Timeout.InfiniteTimeSpan
                 ? client.Timeout
                 : AppReadyTimeout;
+
             throw new CommandException(BuildUrlSourceTimeoutMessage(baseUrl, effectiveTimeout));
         }
     }
@@ -292,12 +329,20 @@ public sealed class ExportSourceResolver
 
             if (!string.IsNullOrWhiteSpace(stdout))
             {
-                _logger.LogDebug("Command output ({FileName}):{NewLine}{Output}", fileName, Environment.NewLine, stdout);
+                _logger.LogDebug(
+                    "Command output ({FileName}):{NewLine}{Output}",
+                    fileName,
+                    Environment.NewLine,
+                    stdout);
             }
 
             if (!string.IsNullOrWhiteSpace(stderr))
             {
-                _logger.LogDebug("Command error output ({FileName}):{NewLine}{Output}", fileName, Environment.NewLine, stderr);
+                _logger.LogDebug(
+                    "Command error output ({FileName}):{NewLine}{Output}",
+                    fileName,
+                    Environment.NewLine,
+                    stderr);
             }
 
             if (process.ExitCode == 0)
@@ -321,7 +366,10 @@ public sealed class ExportSourceResolver
         return ResolveBuiltDllPath(projectDirectory, assemblyName, null);
     }
 
-    internal static string ResolveBuiltDllPath(string projectDirectory, string assemblyName, string? explicitPublishDirectory)
+    internal static string ResolveBuiltDllPath(
+        string projectDirectory,
+        string assemblyName,
+        string? explicitPublishDirectory)
     {
         var searchRoots = new List<(string Path, bool RequirePublishSegment)>();
         var explicitPublishPath = string.IsNullOrWhiteSpace(explicitPublishDirectory)
@@ -354,9 +402,9 @@ public sealed class ExportSourceResolver
 
         var candidatePaths = searchRoots
             .SelectMany(tuple => Directory.EnumerateFiles(
-                tuple.Path,
-                $"{assemblyName}.dll",
-                SearchOption.AllDirectories)
+                    tuple.Path,
+                    $"{assemblyName}.dll",
+                    SearchOption.AllDirectories)
                 .Where(path => !IsRefAssemblyPath(path))
                 .Where(path => IsPublishedArtifact(tuple.Path, path, tuple.RequirePublishSegment))
                 .ToList())
@@ -421,9 +469,13 @@ public sealed class ExportSourceResolver
             var document = XDocument.Load(projectPath);
             var assemblyName = document
                 .Descendants()
-                .FirstOrDefault(node => string.Equals(node.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault(node => string.Equals(
+                    node.Name.LocalName,
+                    "AssemblyName",
+                    StringComparison.OrdinalIgnoreCase))
                 ?.Value
                 ?.Trim();
+
             return string.IsNullOrWhiteSpace(assemblyName) ? fallbackName : assemblyName;
         }
         catch (IOException)
@@ -448,6 +500,41 @@ public sealed class ExportSourceResolver
         }
     }
 
+    internal static bool IsMultiTargetProject(string projectPath)
+    {
+        try
+        {
+            var document = XDocument.Load(projectPath);
+
+            return document
+                .Descendants()
+                .Any(node => string.Equals(
+                    node.Name.LocalName,
+                    "TargetFrameworks",
+                    StringComparison.OrdinalIgnoreCase));
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (XmlException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
     internal static bool IsRefAssemblyPath(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -456,6 +543,7 @@ public sealed class ExportSourceResolver
         }
 
         var normalized = path.Replace('\\', '/');
+
         return normalized.Contains("/ref/", StringComparison.OrdinalIgnoreCase);
     }
 
@@ -643,6 +731,7 @@ public sealed class ExportSourceResolver
         }
 
         baseUrl = uri.GetLeftPart(UriPartial.Authority);
+
         return true;
     }
 
@@ -721,7 +810,11 @@ public sealed class ExportSourceResolver
             {
                 using var response = await client.GetAsync(baseUrl, timeoutCts.Token);
                 // Any HTTP response proves the app is reachable; we don't require a specific status code.
-                _logger.LogDebug("Readiness probe returned {StatusCode} for {BaseUrl}", (int)response.StatusCode, baseUrl);
+                _logger.LogDebug(
+                    "Readiness probe returned {StatusCode} for {BaseUrl}",
+                    (int)response.StatusCode,
+                    baseUrl);
+
                 return;
             }
             catch (HttpRequestException)


### PR DESCRIPTION
Resolves #96

## Description
This PR adds support for exporting multi-target projects by introducing a `--framework` (or `-f`) option to the `export` command.

When exporting a project using `export --project <path>`, the command now:
1. Detects if the `.csproj` file defines `<TargetFrameworks>` (plural), indicating it is a multi-target project.
2. Validates that a target framework has been specified using the `--framework` option if it is a multi-target project, throwing a helpful validation error otherwise.
3. Automatically passes the `-f <framework>` argument forward to the underlying `dotnet publish` command.

## Changes
- **`ExportCommand.cs`**: Added `--framework` (`-f`) option.
- **`ExportSourceResolver.cs`**: Implemented `IsMultiTargetProject` method to parse `.csproj` XML efficiently and added logic to append the `-f` flag to the process publish arguments pipeline.
- **`ExportSourceResolverTests.cs`**: Added test coverage for multi-target validation exceptions and argument injection. Fixed testing paths related to the flat output architecture of `dotnet publish`.

## Verification
- Unit tests updated to accommodate the new constructor permutations and passing.
- Manually verified against a test multi-target (`net9.0;net10.0`) project.
