### PR TITLE
Fix assembly name resolution for projects with custom MSBuild properties (#95)

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportCommandTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportCommandTests.cs
@@ -16,11 +16,10 @@ public class ExportCommandTests
         {
             var logger = A.Fake<ILogger<ExportCommand>>();
             var engineLogger = A.Fake<ILogger<ExportEngine>>();
-            var resolverLogger = A.Fake<ILogger<ExportSourceResolver>>();
             var requestFactory = new ExportSourceRequestFactory();
             var processFactory = new NoopProcessFactory();
             var sourceResolver = new ExportSourceResolver(
-                resolverLogger,
+                A.Fake<ILoggerFactory>(),
                 processFactory,
                 new TestHttpHelpers.Factory(TestHttpHelpers.UrlAwareHtmlRoot("http://localhost:5001")));
             var engine = new ExportEngine(
@@ -89,11 +88,10 @@ public class ExportCommandTests
     {
         var logger = A.Fake<ILogger<ExportCommand>>();
         var engineLogger = A.Fake<ILogger<ExportEngine>>();
-        var resolverLogger = A.Fake<ILogger<ExportSourceResolver>>();
         var requestFactory = new ExportSourceRequestFactory();
         var processFactory = new NoopProcessFactory();
         var sourceResolver = new ExportSourceResolver(
-            resolverLogger,
+            A.Fake<ILoggerFactory>(),
             processFactory,
             new TestHttpHelpers.Factory(TestHttpHelpers.UrlAwareHtmlRoot("http://localhost:5001")));
         var engine = new ExportEngine(

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -705,7 +705,7 @@ public class ExportSourceResolverTests
     }
 
     [Fact]
-    public void TryResolveAssemblyName_Should_Parse_AssemblyName_When_Present()
+    public void TryResolveAssemblyNameFromXml_Should_Parse_AssemblyName_When_Present()
     {
         using var tempDir = new TempDirectory();
         var projectPath = Path.Combine(tempDir.FullPath, "Site.csproj");
@@ -724,7 +724,7 @@ public class ExportSourceResolverTests
     }
 
     [Fact]
-    public void TryResolveAssemblyName_Should_Fallback_When_AssemblyName_Is_Missing()
+    public void TryResolveAssemblyNameFromXml_Should_Fallback_When_AssemblyName_Is_Missing()
     {
         using var tempDir = new TempDirectory();
         var projectPath = Path.Combine(tempDir.FullPath, "Site.csproj");
@@ -735,7 +735,7 @@ public class ExportSourceResolverTests
     }
 
     [Fact]
-    public void TryResolveAssemblyName_Should_Fallback_On_Invalid_Xml()
+    public void TryResolveAssemblyNameFromXml_Should_Fallback_On_Invalid_Xml()
     {
         using var tempDir = new TempDirectory();
         var projectPath = Path.Combine(tempDir.FullPath, "Site.csproj");
@@ -746,7 +746,7 @@ public class ExportSourceResolverTests
     }
 
     [Fact]
-    public void TryResolveAssemblyName_Should_Fallback_On_Missing_Or_Invalid_Path()
+    public void TryResolveAssemblyNameFromXml_Should_Fallback_On_Missing_Or_Invalid_Path()
     {
         using var tempDir = new TempDirectory();
         var missingPath = Path.Combine(tempDir.FullPath, "missing.csproj");
@@ -781,8 +781,35 @@ public class ExportSourceResolverTests
 
         // With the new implementation, this should succeed because it uses MSBuild evaluation.
         var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>());
-        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", CancellationToken.None);
+        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", null, CancellationToken.None);
         Assert.Equal("MyRealName", resolved);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task TryResolveAssemblyName_Should_Respect_Conditional_Configuration()
+    {
+        using var tempDir = new TempDirectory();
+        var projectPath = Path.Combine(tempDir.FullPath, "Main.csproj");
+
+        File.WriteAllText(projectPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <AssemblyName>DebugName</AssemblyName>
+              </PropertyGroup>
+              <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+                <AssemblyName>ReleaseName</AssemblyName>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>());
+        
+        // Should resolve to 'ReleaseName' because we inject Configuration=Release
+        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", null, CancellationToken.None);
+        
+        Assert.Equal("ReleaseName", resolved);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+using System.Diagnostics;
 using CliFx.Exceptions;
 using FakeItEasy;
 using Microsoft.Extensions.Logging;
@@ -781,7 +783,7 @@ public class ExportSourceResolverTests
 
         // With the new implementation, this should succeed because it uses MSBuild evaluation.
         var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>());
-        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", null, CancellationToken.None);
+        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", "net10.0", CancellationToken.None);
         Assert.Equal("MyRealName", resolved);
     }
 
@@ -804,7 +806,7 @@ public class ExportSourceResolverTests
                 A<CancellationToken>._))
             .Returns(new ExportSourceResolver.CommandResult(0, "ReleaseName", string.Empty));
 
-        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", null, CancellationToken.None);
+        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", "net10.0", CancellationToken.None);
         
         Assert.Equal("ReleaseName", resolved);
     }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -6,7 +6,7 @@ namespace ForgeTrust.Runnable.Web.RazorWire.Cli.Tests;
 
 public class ExportSourceResolverTests
 {
-    private readonly ILogger<ExportSourceResolver> _logger = A.Fake<ILogger<ExportSourceResolver>>();
+    private readonly ILoggerFactory _loggerFactory = A.Fake<ILoggerFactory>();
 
     [Fact]
     public void BuildEffectiveAppArgs_Should_Inject_Ephemeral_Urls_When_Absent()
@@ -70,10 +70,12 @@ public class ExportSourceResolverTests
     {
         var processFactory = new FakeTargetAppProcessFactory(_ => new FakeTargetAppProcess());
         var httpFactory = new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK));
+        var razorWireExecutor = A.Fake<ICommandExecutor>();
 
         Assert.Throws<ArgumentNullException>(() => new ExportSourceResolver(null!, processFactory, httpFactory));
-        Assert.Throws<ArgumentNullException>(() => new ExportSourceResolver(_logger, null!, httpFactory));
-        Assert.Throws<ArgumentNullException>(() => new ExportSourceResolver(_logger, processFactory, null!));
+        Assert.Throws<ArgumentNullException>(() => new ExportSourceResolver(_loggerFactory, null!, httpFactory, razorWireExecutor));
+        Assert.Throws<ArgumentNullException>(() => new ExportSourceResolver(_loggerFactory, processFactory, null!, razorWireExecutor));
+        Assert.Throws<ArgumentNullException>(() => new ExportSourceResolver(_loggerFactory, processFactory, httpFactory, null!));
     }
 
     [Fact]
@@ -360,7 +362,7 @@ public class ExportSourceResolverTests
         var resolved = await resolver.ResolveLaunchRequestAsync(request);
 
         Assert.Equal(ExportSourceKind.Dll, resolved.SourceKind);
-        Assert.Equal(expectedDllPath, resolved.SourceValue);
+        Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(expectedDllPath), resolved.SourceValue);
     }
 
     [Fact]
@@ -391,7 +393,7 @@ public class ExportSourceResolverTests
         var resolved = await resolver.ResolveLaunchRequestAsync(request);
 
         Assert.Equal(ExportSourceKind.Dll, resolved.SourceKind);
-        Assert.Equal(expectedDllPath, resolved.SourceValue);
+        Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(expectedDllPath), resolved.SourceValue);
     }
 
     [Fact]
@@ -415,16 +417,49 @@ public class ExportSourceResolverTests
         await File.WriteAllTextAsync(programPath, "System.Console.WriteLine(\"hello\");");
 
         var factory = new FakeTargetAppProcessFactory(_ => new FakeTargetAppProcess());
+        var mockRazorWireExecutor = A.Fake<ICommandExecutor>();
         var resolver = CreateResolver(
             factory,
-            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
+            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)),
+            mockRazorWireExecutor);
         var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], false);
+
+        var expectedPath = Path.GetFullPath(Path.Combine(tempDir.FullPath, "bin", "runnable-export", "MySite.dll"));
+        IReadOnlyList<string>? capturedPublishArgs = null;
+        A.CallTo(() => mockRazorWireExecutor.ExecuteCommandAsync(
+                A<string>._,
+                A<IReadOnlyList<string>>._,
+                A<string>._,
+                A<CancellationToken>._))
+            .ReturnsLazily((string _, IReadOnlyList<string> args, string _, CancellationToken _) =>
+            {
+                if (args.Contains("-getProperty:AssemblyName"))
+                {
+                    return new ProcessResult(0, "MySite", string.Empty);
+                }
+
+                if (args.Count > 0 && args[0] == "publish")
+                {
+                    capturedPublishArgs = args.ToArray();
+                    Directory.CreateDirectory(Path.GetDirectoryName(expectedPath)!);
+                    File.WriteAllText(expectedPath, string.Empty);
+                }
+
+                return new ProcessResult(0, string.Empty, string.Empty);
+            });
 
         var resolved = await resolver.ResolveLaunchRequestAsync(request);
 
         Assert.Equal(ExportSourceKind.Dll, resolved.SourceKind);
         Assert.True(File.Exists(resolved.SourceValue));
-        Assert.EndsWith("MySite.dll", resolved.SourceValue, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(expectedPath), resolved.SourceValue);
+        Assert.NotNull(capturedPublishArgs);
+        Assert.Equal("publish", capturedPublishArgs[0]);
+        Assert.Contains(projectPath, capturedPublishArgs);
+        Assert.Contains("-c", capturedPublishArgs);
+        Assert.Contains("Release", capturedPublishArgs);
+        Assert.Contains("-o", capturedPublishArgs);
+        Assert.Contains(Path.Combine(tempDir.FullPath, "bin", "runnable-export"), capturedPublishArgs);
     }
 
     [Fact]
@@ -434,9 +469,15 @@ public class ExportSourceResolverTests
         var projectPath = Path.Combine(tempDir.FullPath, "Missing.csproj");
 
         var factory = new FakeTargetAppProcessFactory(_ => new FakeTargetAppProcess());
+        var mockExecutor = A.Fake<ICommandExecutor>();
         var resolver = CreateResolver(
             factory,
-            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
+            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)),
+            mockExecutor);
+        
+        A.CallTo(() => mockExecutor.ExecuteCommandAsync(A<string>._, A<IReadOnlyList<string>>._, A<string>._, A<CancellationToken>._))
+            .Returns(new ProcessResult(1, "", "msbuild error"));
+
         var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], false);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -528,22 +569,56 @@ public class ExportSourceResolverTests
         await File.WriteAllTextAsync(programPath, "System.Console.WriteLine(\"hello\");");
 
         var factory = new FakeTargetAppProcessFactory(_ => new FakeTargetAppProcess());
+        var mockRazorWireExecutor = A.Fake<ICommandExecutor>();
         var resolver = CreateResolver(
             factory,
-            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)));
+            new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)),
+            mockRazorWireExecutor);
         var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, "net10.0", [], false);
+
+        var expectedPath = Path.Combine(tempDir.FullPath, "bin", "runnable-export", "MySite.dll");
+        IReadOnlyList<string>? capturedPublishArgs = null;
+        A.CallTo(() => mockRazorWireExecutor.ExecuteCommandAsync(
+                A<string>._,
+                A<IReadOnlyList<string>>._,
+                A<string>._,
+                A<CancellationToken>._))
+            .ReturnsLazily((string _, IReadOnlyList<string> args, string _, CancellationToken _) =>
+            {
+                if (args.Contains("-getProperty:AssemblyName"))
+                {
+                    return new ProcessResult(0, "MySite", string.Empty);
+                }
+
+                if (args.Count > 0 && args[0] == "publish")
+                {
+                    capturedPublishArgs = args.ToArray();
+                    Directory.CreateDirectory(Path.GetDirectoryName(expectedPath)!);
+                    File.WriteAllText(expectedPath, string.Empty);
+                    File.WriteAllText(
+                        Path.ChangeExtension(expectedPath, ".runtimeconfig.json"),
+                        """{ "runtimeOptions": { "tfm": "net10.0" } }""");
+                }
+
+                return new ProcessResult(0, string.Empty, string.Empty);
+            });
 
         var resolved = await resolver.ResolveLaunchRequestAsync(request);
 
         Assert.Equal(ExportSourceKind.Dll, resolved.SourceKind);
         Assert.True(File.Exists(resolved.SourceValue));
-        Assert.EndsWith("MySite.dll", resolved.SourceValue, StringComparison.OrdinalIgnoreCase);
+        var normalizedExpected = ExportSourceResolver.NormalizePathForMacOS(
+            Path.Combine(tempDir.FullPath, "bin", "runnable-export", "MySite.dll"));
+        Assert.Equal(normalizedExpected, resolved.SourceValue);
 
         // Prove framework selection by reading the runtimeconfig.json (since `-o` flattens the output directory)
         var configPath = Path.ChangeExtension(resolved.SourceValue, ".runtimeconfig.json");
         Assert.True(File.Exists(configPath));
         var configJson = await File.ReadAllTextAsync(configPath);
         Assert.Contains("net10.0", configJson, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(capturedPublishArgs);
+        Assert.Contains("-f", capturedPublishArgs);
+        Assert.Contains("net10.0", capturedPublishArgs);
     }
 
     [Fact]
@@ -562,7 +637,7 @@ public class ExportSourceResolverTests
         // When requestedFramework is net9.0, it should find the net9.0 one instead of falling back to the highest (net10.0).
         var resolved = ExportSourceResolver.ResolveBuiltDllPath(tempDir.FullPath, "MySite", null, "net9.0");
 
-        Assert.Equal(Path.Combine(net9Dir, "MySite.dll"), resolved);
+        Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(Path.Combine(net9Dir, "MySite.dll")), resolved);
     }
 
     [Fact]
@@ -585,7 +660,7 @@ public class ExportSourceResolverTests
 
         var resolved = ExportSourceResolver.ResolveBuiltDllPath(tempDir.FullPath, "MySite", explicitPublishDir);
 
-        Assert.Equal(Path.Combine(explicitPublishDir, "MySite.dll"), resolved);
+        Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(Path.Combine(explicitPublishDir, "MySite.dll")), resolved);
     }
 
     [Fact]
@@ -612,7 +687,7 @@ public class ExportSourceResolverTests
         File.WriteAllBytes(Path.Combine(net10, "MySite.dll"), [2]);
 
         var resolved = ExportSourceResolver.ResolveBuiltDllPath(tempDir.FullPath, "MySite");
-        Assert.Equal(Path.Combine(net10, "MySite.dll"), resolved);
+        Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(Path.Combine(net10, "MySite.dll")), resolved);
     }
 
     [Fact]
@@ -780,40 +855,59 @@ public class ExportSourceResolverTests
             """);
 
         // With the new implementation, this should succeed because it uses MSBuild evaluation.
-        var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>());
+        var mockRazorWireExecutor = A.Fake<ICommandExecutor>();
+        var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>(), mockRazorWireExecutor);
+
+        A.CallTo(() => mockRazorWireExecutor.ExecuteCommandAsync(
+                A<string>._,
+                A<IReadOnlyList<string>>._,
+                A<string>._,
+                A<CancellationToken>._))
+            .Returns(new ProcessResult(0, "MyRealName", string.Empty));
+
         var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", "net10.0", CancellationToken.None);
         Assert.Equal("MyRealName", resolved);
     }
 
-    [Fact]
     [Trait("Category", "Integration")]
-    public async Task TryResolveAssemblyName_Should_Respect_Conditional_Configuration()
+    [Fact]
+    public async Task TryResolveAssemblyName_Should_Invoke_Msbuild_With_Release_Configuration_And_TargetFramework()
     {
         using var tempDir = new TempDirectory();
         var projectPath = Path.Combine(tempDir.FullPath, "Main.csproj");
         File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>");
 
-        var resolver = A.Fake<ExportSourceResolver>(builder => builder.WithArgumentsForConstructor(
-            [_logger, A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>()])
-            .CallsBaseMethods());
+        var mockRazorWireExecutor = A.Fake<ICommandExecutor>();
+        var resolver = CreateResolver(
+            A.Fake<ITargetAppProcessFactory>(),
+            A.Fake<IHttpClientFactory>(),
+            mockRazorWireExecutor);
 
-        A.CallTo(() => resolver.ExecuteProcessAsync(
-                "dotnet",
-                A<IReadOnlyList<string>>.That.Matches(args => 
-                    args.Count >= 6
-                    && args[0] == "msbuild"
-                    && args[1] == projectPath
-                    && args.Contains("-getProperty:AssemblyName")
-                    && args.Contains("-nologo")
-                    && args.Contains("-p:Configuration=Release")
-                    && args.Contains("-p:TargetFramework=net10.0")),
+        string? capturedFileName = null;
+        IReadOnlyList<string>? capturedArgs = null;
+        A.CallTo(() => mockRazorWireExecutor.ExecuteCommandAsync(
+                A<string>._,
+                A<IReadOnlyList<string>>._,
                 A<string>._,
                 A<CancellationToken>._))
-            .Returns(new ExportSourceResolver.CommandResult(0, "ReleaseName", string.Empty));
+            .Invokes((string fileName, IReadOnlyList<string> args, string _, CancellationToken _) =>
+            {
+                capturedFileName = fileName;
+                capturedArgs = args;
+            })
+            .Returns(new ProcessResult(0, "ReleaseName", string.Empty));
 
         var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", "net10.0", CancellationToken.None);
-        
+
         Assert.Equal("ReleaseName", resolved);
+        Assert.Equal("dotnet", capturedFileName);
+        Assert.NotNull(capturedArgs);
+        Assert.Equal("msbuild", capturedArgs[0]);
+        Assert.Equal(projectPath, capturedArgs[1]);
+        Assert.Contains("-getProperty:AssemblyName", capturedArgs);
+        Assert.Contains("-nologo", capturedArgs);
+        Assert.Contains("-p:Configuration=Release", capturedArgs);
+        Assert.Contains("-p:TargetFramework=net10.0", capturedArgs);
     }
 
     [Fact]
@@ -912,9 +1006,14 @@ public class ExportSourceResolverTests
 
     private ExportSourceResolver CreateResolver(
         ITargetAppProcessFactory processFactory,
-        IHttpClientFactory clientFactory)
+        IHttpClientFactory clientFactory,
+        ICommandExecutor? razorWireExecutor = null)
     {
-        return new ExportSourceResolver(_logger, processFactory, clientFactory);
+        return new ExportSourceResolver(
+            _loggerFactory,
+            processFactory,
+            clientFactory,
+            razorWireExecutor ?? A.Fake<ICommandExecutor>());
     }
 
     private sealed class FakeTargetAppProcessFactory : ITargetAppProcessFactory
@@ -1013,10 +1112,11 @@ public class ExportSourceResolverTests
 
     private sealed class TempDirectory : IDisposable
     {
-        public string FullPath { get; } = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        public string FullPath { get; }
 
         public TempDirectory()
         {
+            FullPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(FullPath);
         }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -667,6 +667,22 @@ public class ExportSourceResolverTests
     }
 
     [Fact]
+    public void ResolveBuiltDllPath_Should_Throw_When_Explicit_Publish_Directory_Does_Not_Contain_Dll()
+    {
+        using var tempDir = new TempDirectory();
+        var explicitPublishDir = Path.Combine(tempDir.FullPath, "custom-output");
+        Directory.CreateDirectory(explicitPublishDir);
+
+        var staleDllDir = Path.Combine(tempDir.FullPath, "bin", "Release", "net10.0", "publish");
+        Directory.CreateDirectory(staleDllDir);
+        File.WriteAllBytes(Path.Combine(staleDllDir, "MySite.dll"), [1, 2, 3]);
+
+        var ex = Assert.Throws<FileNotFoundException>(
+            () => ExportSourceResolver.ResolveBuiltDllPath(tempDir.FullPath, "MySite", explicitPublishDir));
+        Assert.Contains("Could not locate published DLL", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void ResolveBuiltDllPath_Should_Throw_When_No_Dll_Is_Found()
     {
         using var tempDir = new TempDirectory();
@@ -691,6 +707,27 @@ public class ExportSourceResolverTests
 
         var resolved = ExportSourceResolver.ResolveBuiltDllPath(tempDir.FullPath, "MySite");
         Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(Path.Combine(net10, "MySite.dll")), resolved);
+    }
+
+    [Fact]
+    public void ResolveBuiltDllPath_Should_Prefer_Release_Publish_Over_Debug_Publish_When_Both_Exist()
+    {
+        using var tempDir = new TempDirectory();
+        var releaseDir = Path.Combine(tempDir.FullPath, "bin", "Release", "net10.0", "publish");
+        var debugDir = Path.Combine(tempDir.FullPath, "bin", "Debug", "net10.0", "publish");
+        Directory.CreateDirectory(releaseDir);
+        Directory.CreateDirectory(debugDir);
+
+        var releaseDllPath = Path.Combine(releaseDir, "MySite.dll");
+        var debugDllPath = Path.Combine(debugDir, "MySite.dll");
+        File.WriteAllBytes(releaseDllPath, [1]);
+        File.WriteAllBytes(debugDllPath, [2]);
+        File.SetLastWriteTimeUtc(releaseDllPath, DateTime.UtcNow.AddMinutes(-5));
+        File.SetLastWriteTimeUtc(debugDllPath, DateTime.UtcNow);
+
+        var resolved = ExportSourceResolver.ResolveBuiltDllPath(tempDir.FullPath, "MySite");
+
+        Assert.Equal(ExportSourceResolver.NormalizePathForMacOS(releaseDllPath), resolved);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-using System.Diagnostics;
 using CliFx.Exceptions;
 using FakeItEasy;
 using Microsoft.Extensions.Logging;

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -719,7 +719,7 @@ public class ExportSourceResolverTests
             </Project>
             """);
 
-        var resolved = ExportSourceResolver.TryResolveAssemblyName(projectPath, "Site");
+        var resolved = ExportSourceResolver.TryResolveAssemblyNameFromXml(projectPath, "Site");
         Assert.Equal("CustomAssembly", resolved);
     }
 
@@ -730,7 +730,7 @@ public class ExportSourceResolverTests
         var projectPath = Path.Combine(tempDir.FullPath, "Site.csproj");
         File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk.Web\"></Project>");
 
-        var resolved = ExportSourceResolver.TryResolveAssemblyName(projectPath, "Site");
+        var resolved = ExportSourceResolver.TryResolveAssemblyNameFromXml(projectPath, "Site");
         Assert.Equal("Site", resolved);
     }
 
@@ -741,7 +741,7 @@ public class ExportSourceResolverTests
         var projectPath = Path.Combine(tempDir.FullPath, "Site.csproj");
         File.WriteAllText(projectPath, "<Project><PropertyGroup><AssemblyName>oops");
 
-        var resolved = ExportSourceResolver.TryResolveAssemblyName(projectPath, "Site");
+        var resolved = ExportSourceResolver.TryResolveAssemblyNameFromXml(projectPath, "Site");
         Assert.Equal("Site", resolved);
     }
 
@@ -751,8 +751,38 @@ public class ExportSourceResolverTests
         using var tempDir = new TempDirectory();
         var missingPath = Path.Combine(tempDir.FullPath, "missing.csproj");
 
-        Assert.Equal("Site", ExportSourceResolver.TryResolveAssemblyName(missingPath, "Site"));
-        Assert.Equal("Site", ExportSourceResolver.TryResolveAssemblyName(tempDir.FullPath, "Site"));
+        Assert.Equal("Site", ExportSourceResolver.TryResolveAssemblyNameFromXml(missingPath, "Site"));
+        Assert.Equal("Site", ExportSourceResolver.TryResolveAssemblyNameFromXml(tempDir.FullPath, "Site"));
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task TryResolveAssemblyName_Should_Succeed_To_Find_AssemblyName_In_Imported_File()
+    {
+        using var tempDir = new TempDirectory();
+        var propsPath = Path.Combine(tempDir.FullPath, "Identity.props");
+        var projectPath = Path.Combine(tempDir.FullPath, "Main.csproj");
+
+        File.WriteAllText(propsPath, 
+            """
+            <Project>
+              <PropertyGroup>
+                <AssemblyName>MyRealName</AssemblyName>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(projectPath,
+            $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="{propsPath}" />
+            </Project>
+            """);
+
+        // With the new implementation, this should succeed because it uses MSBuild evaluation.
+        var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>());
+        var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", CancellationToken.None);
+        Assert.Equal("MyRealName", resolved);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -791,22 +791,19 @@ public class ExportSourceResolverTests
     {
         using var tempDir = new TempDirectory();
         var projectPath = Path.Combine(tempDir.FullPath, "Main.csproj");
+        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>");
 
-        File.WriteAllText(projectPath,
-            """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <AssemblyName>DebugName</AssemblyName>
-              </PropertyGroup>
-              <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-                <AssemblyName>ReleaseName</AssemblyName>
-              </PropertyGroup>
-            </Project>
-            """);
+        var resolver = A.Fake<ExportSourceResolver>(builder => builder.WithArgumentsForConstructor(
+            [_logger, A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>()])
+            .CallsBaseMethods());
 
-        var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>());
-        
-        // Should resolve to 'ReleaseName' because we inject Configuration=Release
+        A.CallTo(() => resolver.ExecuteProcessAsync(
+                "dotnet",
+                A<IReadOnlyList<string>>.That.Matches(args => args.Contains("-p:Configuration=Release")),
+                A<string>._,
+                A<CancellationToken>._))
+            .Returns(new ExportSourceResolver.CommandResult(0, "ReleaseName", string.Empty));
+
         var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", null, CancellationToken.None);
         
         Assert.Equal("ReleaseName", resolved);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -799,7 +799,14 @@ public class ExportSourceResolverTests
 
         A.CallTo(() => resolver.ExecuteProcessAsync(
                 "dotnet",
-                A<IReadOnlyList<string>>.That.Matches(args => args.Contains("-p:Configuration=Release")),
+                A<IReadOnlyList<string>>.That.Matches(args => 
+                    args.Count >= 6
+                    && args[0] == "msbuild"
+                    && args[1] == projectPath
+                    && args.Contains("-getProperty:AssemblyName")
+                    && args.Contains("-nologo")
+                    && args.Contains("-p:Configuration=Release")
+                    && args.Contains("-p:TargetFramework=net10.0")),
                 A<string>._,
                 A<CancellationToken>._))
             .Returns(new ExportSourceResolver.CommandResult(0, "ReleaseName", string.Empty));

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -474,9 +474,21 @@ public class ExportSourceResolverTests
             factory,
             new TestHttpHelpers.Factory(TestHttpHelpers.FixedStatus(System.Net.HttpStatusCode.OK)),
             mockExecutor);
-        
-        A.CallTo(() => mockExecutor.ExecuteCommandAsync(A<string>._, A<IReadOnlyList<string>>._, A<string>._, A<CancellationToken>._))
-            .Returns(new ProcessResult(1, "", "msbuild error"));
+
+        A.CallTo(() => mockExecutor.ExecuteCommandAsync(
+                A<string>._,
+                A<IReadOnlyList<string>>._,
+                A<string>._,
+                A<CancellationToken>._))
+            .ReturnsLazily((string _, IReadOnlyList<string> args, string _, CancellationToken _) =>
+            {
+                if (args.Count > 0 && args[0] == "publish")
+                {
+                    return new ProcessResult(1, string.Empty, "publish error");
+                }
+
+                return new ProcessResult(0, "Missing", string.Empty);
+            });
 
         var request = new ExportSourceRequest(ExportSourceKind.Project, projectPath, null, [], false);
 
@@ -595,9 +607,6 @@ public class ExportSourceResolverTests
                     capturedPublishArgs = args.ToArray();
                     Directory.CreateDirectory(Path.GetDirectoryName(expectedPath)!);
                     File.WriteAllText(expectedPath, string.Empty);
-                    File.WriteAllText(
-                        Path.ChangeExtension(expectedPath, ".runtimeconfig.json"),
-                        """{ "runtimeOptions": { "tfm": "net10.0" } }""");
                 }
 
                 return new ProcessResult(0, string.Empty, string.Empty);
@@ -610,12 +619,6 @@ public class ExportSourceResolverTests
         var normalizedExpected = ExportSourceResolver.NormalizePathForMacOS(
             Path.Combine(tempDir.FullPath, "bin", "runnable-export", "MySite.dll"));
         Assert.Equal(normalizedExpected, resolved.SourceValue);
-
-        // Prove framework selection by reading the runtimeconfig.json (since `-o` flattens the output directory)
-        var configPath = Path.ChangeExtension(resolved.SourceValue, ".runtimeconfig.json");
-        Assert.True(File.Exists(configPath));
-        var configJson = await File.ReadAllTextAsync(configPath);
-        Assert.Contains("net10.0", configJson, StringComparison.OrdinalIgnoreCase);
         Assert.NotNull(capturedPublishArgs);
         Assert.Contains("-f", capturedPublishArgs);
         Assert.Contains("net10.0", capturedPublishArgs);
@@ -858,15 +861,31 @@ public class ExportSourceResolverTests
         var mockRazorWireExecutor = A.Fake<ICommandExecutor>();
         var resolver = CreateResolver(A.Fake<ITargetAppProcessFactory>(), A.Fake<IHttpClientFactory>(), mockRazorWireExecutor);
 
+        string? capturedFileName = null;
+        IReadOnlyList<string>? capturedArgs = null;
         A.CallTo(() => mockRazorWireExecutor.ExecuteCommandAsync(
                 A<string>._,
                 A<IReadOnlyList<string>>._,
                 A<string>._,
                 A<CancellationToken>._))
+            .Invokes((string fileName, IReadOnlyList<string> args, string _, CancellationToken _) =>
+            {
+                capturedFileName = fileName;
+                capturedArgs = args;
+            })
             .Returns(new ProcessResult(0, "MyRealName", string.Empty));
 
         var resolved = await resolver.TryResolveAssemblyNameAsync(projectPath, "Main", "net10.0", CancellationToken.None);
+
         Assert.Equal("MyRealName", resolved);
+        Assert.Equal("dotnet", capturedFileName);
+        Assert.NotNull(capturedArgs);
+        Assert.Equal("msbuild", capturedArgs[0]);
+        Assert.Equal(projectPath, capturedArgs[1]);
+        Assert.Contains("-getProperty:AssemblyName", capturedArgs);
+        Assert.Contains("-nologo", capturedArgs);
+        Assert.Contains("-p:Configuration=Release", capturedArgs);
+        Assert.Contains("-p:TargetFramework=net10.0", capturedArgs);
     }
 
     [Trait("Category", "Integration")]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/CommandExecutor.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/CommandExecutor.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
+
+internal sealed class CommandExecutor : ICommandExecutor
+{
+    private readonly ILogger<CommandExecutor> _logger;
+
+    public CommandExecutor(ILogger<CommandExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    public async Task<ProcessResult> ExecuteCommandAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        var started = false;
+        Task<string>? stdoutTask = null;
+        Task<string>? stderrTask = null;
+
+        try
+        {
+            try
+            {
+                started = process.Start();
+                if (!started)
+                {
+                    return new ProcessResult(-1, string.Empty, "Process failed to start.");
+                }
+            }
+            catch (Win32Exception ex)
+            {
+                return new ProcessResult(-1, string.Empty, $"Failed to start process: {ex.Message}");
+            }
+            catch (FileNotFoundException ex)
+            {
+                return new ProcessResult(-1, string.Empty, $"Executable not found: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                return new ProcessResult(-1, string.Empty, $"Invalid process start operation: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                return new ProcessResult(-1, string.Empty, $"An unexpected error occurred while starting the process: {ex.Message}");
+            }
+
+            stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+            await Task.WhenAll(process.WaitForExitAsync(cancellationToken), stdoutTask, stderrTask);
+
+            return new ProcessResult(process.ExitCode, await stdoutTask, await stderrTask);
+        }
+        finally
+        {
+            TryKillProcess(process, started);
+            await ObserveReadTaskAsync(stdoutTask, "stdout", fileName);
+            await ObserveReadTaskAsync(stderrTask, "stderr", fileName);
+        }
+    }
+
+    private void TryKillProcess(Process process, bool started)
+    {
+        if (!started)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Ignoring process termination exception during cleanup.");
+        }
+    }
+
+    private async Task ObserveReadTaskAsync(Task<string>? readTask, string streamName, string fileName)
+    {
+        if (readTask is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = await readTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // Read was canceled along with the command cancellation token.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Ignoring {StreamName} read exception for command {FileName}", streamName, fileName);
+        }
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/CommandExecutor.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/CommandExecutor.cs
@@ -9,6 +9,17 @@ using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
 
+/// <summary>
+/// Default <see cref="ICommandExecutor"/> implementation backed by
+/// <see cref="Process"/>.
+/// </summary>
+/// <remarks>
+/// This implementation models launch failures as <see cref="ProcessResult"/>
+/// instances instead of throwing so resolver code can treat command execution
+/// as data and decide whether to fall back or raise a richer exception. If the
+/// command is canceled after launch starts, cancellation is propagated and the
+/// finally block still attempts to stop the child process tree.
+/// </remarks>
 internal sealed class CommandExecutor : ICommandExecutor
 {
     private readonly ILogger<CommandExecutor> _logger;
@@ -19,12 +30,51 @@ internal sealed class CommandExecutor : ICommandExecutor
         _logger = logger;
     }
 
+    /// <summary>
+    /// Starts a child process, captures its output streams, and returns the
+    /// resulting <see cref="ProcessResult"/>.
+    /// </summary>
+    /// <param name="fileName">The executable to launch.</param>
+    /// <param name="args">The ordered command-line arguments passed to the executable.</param>
+    /// <param name="workingDirectory">The working directory supplied to the process start info.</param>
+    /// <param name="cancellationToken">Cancels the process wait and output reads.</param>
+    /// <returns>
+    /// A <see cref="ProcessResult"/> whose fields contain the exit code,
+    /// stdout, and stderr on success, or a synthetic failure result when the
+    /// process cannot be started.
+    /// </returns>
+    /// <remarks>
+    /// The method intentionally returns <see cref="ProcessResult"/> for
+    /// launch/setup failures so callers can preserve command context in their
+    /// own diagnostics. The finally block always attempts
+    /// <c>Kill(entireProcessTree: true)</c> for started processes, so callers
+    /// should assume cancellation or mid-flight failures may terminate child
+    /// processes spawned by the launched command.
+    /// </remarks>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when cancellation is observed after launch begins.
+    /// </exception>
     public async Task<ProcessResult> ExecuteCommandAsync(
         string fileName,
         IReadOnlyList<string> args,
         string workingDirectory,
         CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return new ProcessResult(-1, string.Empty, "Command file name is required.");
+        }
+
+        if (args is null)
+        {
+            return new ProcessResult(-1, string.Empty, "Command arguments are required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            return new ProcessResult(-1, string.Empty, "Working directory is required.");
+        }
+
         var startInfo = new ProcessStartInfo
         {
             FileName = fileName,
@@ -66,6 +116,10 @@ internal sealed class CommandExecutor : ICommandExecutor
             catch (InvalidOperationException ex)
             {
                 return new ProcessResult(-1, string.Empty, $"Invalid process start operation: {ex.Message}");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
@@ -99,23 +99,8 @@ public class ExportCommand : ICommand
     [ExcludeFromCodeCoverage]
     public async ValueTask ExecuteAsync(IConsole console)
     {
-        using var cts = new CancellationTokenSource();
-        ConsoleCancelEventHandler? handler = null;
-        handler = (_, eventArgs) =>
-        {
-            eventArgs.Cancel = true;
-            cts.Cancel();
-        };
-
-        System.Console.CancelKeyPress += handler;
-        try
-        {
-            await ExecuteAsync(console, cts.Token);
-        }
-        finally
-        {
-            System.Console.CancelKeyPress -= handler;
-        }
+        var cancellationToken = console.RegisterCancellationHandler();
+        await ExecuteAsync(console, cancellationToken);
     }
 
     /// <summary>

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -152,7 +152,7 @@ public sealed class ExportSourceResolver
 
         var projectDirectory = Path.GetDirectoryName(projectPath) ?? Directory.GetCurrentDirectory();
         var projectName = Path.GetFileNameWithoutExtension(projectPath);
-        var assemblyName = TryResolveAssemblyName(projectPath, projectName);
+        var assemblyName = await TryResolveAssemblyNameAsync(projectPath, projectName, cancellationToken);
         var publishOutputDirectory = Path.Combine(projectDirectory, "bin", ExportPublishFolder);
 
         if (!request.NoBuild)
@@ -288,7 +288,9 @@ public sealed class ExportSourceResolver
             $"Timed out while connecting to --url target '{baseUrl}' after {timeout.TotalSeconds:0.###} seconds. Ensure the application is running and reachable.");
     }
 
-    private async Task RunCommandOrThrowAsync(
+    private record CommandResult(int ExitCode, string Stdout, string Stderr);
+
+    private async Task<CommandResult> ExecuteProcessAsync(
         string fileName,
         IReadOnlyList<string> args,
         string workingDirectory,
@@ -309,7 +311,8 @@ public sealed class ExportSourceResolver
             startInfo.ArgumentList.Add(arg);
         }
 
-        using var process = new Process { StartInfo = startInfo };
+        using var process = new Process();
+        process.StartInfo = startInfo;
         var started = false;
         Task<string>? stdoutTask = null;
         Task<string>? stderrTask = null;
@@ -318,7 +321,7 @@ public sealed class ExportSourceResolver
             started = process.Start();
             if (!started)
             {
-                throw new InvalidOperationException($"Failed to start command: {fileName} {string.Join(" ", args)}");
+                return new CommandResult(-1, string.Empty, "Failed to start process");
             }
 
             stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
@@ -328,31 +331,7 @@ public sealed class ExportSourceResolver
             var stdout = await stdoutTask;
             var stderr = await stderrTask;
 
-            if (!string.IsNullOrWhiteSpace(stdout))
-            {
-                _logger.LogDebug(
-                    "Command output ({FileName}):{NewLine}{Output}",
-                    fileName,
-                    Environment.NewLine,
-                    stdout);
-            }
-
-            if (!string.IsNullOrWhiteSpace(stderr))
-            {
-                _logger.LogDebug(
-                    "Command error output ({FileName}):{NewLine}{Output}",
-                    fileName,
-                    Environment.NewLine,
-                    stderr);
-            }
-
-            if (process.ExitCode == 0)
-            {
-                return;
-            }
-
-            throw new InvalidOperationException(
-                $"Command failed with exit code {process.ExitCode}: {fileName} {string.Join(" ", args)}{Environment.NewLine}Stdout:{Environment.NewLine}{stdout}{Environment.NewLine}Stderr:{Environment.NewLine}{stderr}");
+            return new CommandResult(process.ExitCode, stdout, stderr);
         }
         finally
         {
@@ -360,6 +339,50 @@ public sealed class ExportSourceResolver
             await ObserveReadTaskAsync(stdoutTask, "stdout", fileName);
             await ObserveReadTaskAsync(stderrTask, "stderr", fileName);
         }
+    }
+
+    private async Task RunCommandOrThrowAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        var result = await ExecuteProcessAsync(fileName, args, workingDirectory, cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(result.Stdout))
+        {
+            _logger.LogDebug(
+                "Command output ({FileName}):{NewLine}{Output}",
+                fileName,
+                Environment.NewLine,
+                result.Stdout);
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.Stderr))
+        {
+            _logger.LogDebug(
+                "Command error output ({FileName}):{NewLine}{Output}",
+                fileName,
+                Environment.NewLine,
+                result.Stderr);
+        }
+
+        if (result.ExitCode == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Command failed with exit code {result.ExitCode}: {fileName} {string.Join(" ", args)}{Environment.NewLine}Stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}Stderr:{Environment.NewLine}{result.Stderr}");
+    }
+
+    private async Task<CommandResult> RunCommandAndCaptureAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        return await ExecuteProcessAsync(fileName, args, workingDirectory, cancellationToken);
     }
 
     internal static string ResolveBuiltDllPath(string projectDirectory, string assemblyName)
@@ -468,7 +491,37 @@ public sealed class ExportSourceResolver
         return candidates[0].FullName;
     }
 
-    internal static string TryResolveAssemblyName(string projectPath, string fallbackName)
+    internal async Task<string> TryResolveAssemblyNameAsync(
+        string projectPath,
+        string fallbackName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await RunCommandAndCaptureAsync(
+                "dotnet",
+                ["msbuild", projectPath, "-getProperty:AssemblyName", "-nologo"],
+                Path.GetDirectoryName(projectPath) ?? Directory.GetCurrentDirectory(),
+                cancellationToken);
+
+            if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(result.Stdout))
+            {
+                return result.Stdout.Trim();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to resolve assembly name via MSBuild for {ProjectPath}. Falling back to XML parsing.", projectPath);
+        }
+
+        return TryResolveAssemblyNameFromXml(projectPath, fallbackName);
+    }
+
+    internal static string TryResolveAssemblyNameFromXml(string projectPath, string fallbackName)
     {
         try
         {

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -16,7 +16,7 @@ namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
 /// Resolves export sources and, when needed, orchestrates launching a target application for crawling.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public sealed class ExportSourceResolver
+public class ExportSourceResolver
 {
     private readonly ILogger<ExportSourceResolver> _logger;
     private readonly ITargetAppProcessFactory _processFactory;
@@ -73,7 +73,7 @@ public sealed class ExportSourceResolver
         ExportSourceRequest request,
         CancellationToken cancellationToken = default)
     {
-        var startupStopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var startupStopwatch = Stopwatch.StartNew();
 
         if (request.SourceKind == ExportSourceKind.Url)
         {
@@ -288,9 +288,9 @@ public sealed class ExportSourceResolver
             $"Timed out while connecting to --url target '{baseUrl}' after {timeout.TotalSeconds:0.###} seconds. Ensure the application is running and reachable.");
     }
 
-    private record CommandResult(int ExitCode, string Stdout, string Stderr);
+    internal record CommandResult(int ExitCode, string Stdout, string Stderr);
 
-    private async Task<CommandResult> ExecuteProcessAsync(
+    internal virtual async Task<CommandResult> ExecuteProcessAsync(
         string fileName,
         IReadOnlyList<string> args,
         string workingDirectory,

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -1,7 +1,5 @@
 using System.Collections.Concurrent;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -13,15 +11,17 @@ using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
 
+internal record ProcessResult(int ExitCode, string Stdout, string Stderr);
+
 /// <summary>
 /// Resolves export sources and, when needed, orchestrates launching a target application for crawling.
 /// </summary>
-[ExcludeFromCodeCoverage]
-public class ExportSourceResolver
+public sealed class ExportSourceResolver
 {
     private readonly ILogger<ExportSourceResolver> _logger;
     private readonly ITargetAppProcessFactory _processFactory;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ICommandExecutor _razorWireExecutor;
 
     private const string EphemeralUrlsValue = "http://127.0.0.1:0";
     private const int MaxLogLines = 200;
@@ -53,21 +53,32 @@ public class ExportSourceResolver
     /// <summary>
     /// Initializes a new instance of <see cref="ExportSourceResolver"/>.
     /// </summary>
-    /// <param name="logger">Logger for progress and target-app startup diagnostics.</param>
+    /// <param name="loggerFactory">The logger factory for creating loggers.</param>
     /// <param name="processFactory">Factory for creating target-app process wrappers.</param>
     /// <param name="httpClientFactory">HTTP client factory used for readiness probing.</param>
     public ExportSourceResolver(
-        ILogger<ExportSourceResolver> logger,
+        ILoggerFactory loggerFactory,
         ITargetAppProcessFactory processFactory,
         IHttpClientFactory httpClientFactory)
+        : this(loggerFactory, processFactory, httpClientFactory, new CommandExecutor(loggerFactory.CreateLogger<CommandExecutor>()))
     {
-        ArgumentNullException.ThrowIfNull(logger);
+    }
+
+    internal ExportSourceResolver(
+        ILoggerFactory loggerFactory,
+        ITargetAppProcessFactory processFactory,
+        IHttpClientFactory httpClientFactory,
+        ICommandExecutor razorWireExecutor)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(processFactory);
         ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(razorWireExecutor);
 
-        _logger = logger;
+        _logger = loggerFactory.CreateLogger<ExportSourceResolver>();
         _processFactory = processFactory;
         _httpClientFactory = httpClientFactory;
+        _razorWireExecutor = razorWireExecutor;
     }
 
     internal async Task<ResolvedExportSource> ResolveAsync(
@@ -289,68 +300,13 @@ public class ExportSourceResolver
             $"Timed out while connecting to --url target '{baseUrl}' after {timeout.TotalSeconds:0.###} seconds. Ensure the application is running and reachable.");
     }
 
-    internal record CommandResult(int ExitCode, string Stdout, string Stderr);
-
-    internal virtual async Task<CommandResult> ExecuteProcessAsync(
+    internal Task<ProcessResult> ExecuteProcessAsync(
         string fileName,
         IReadOnlyList<string> args,
         string workingDirectory,
         CancellationToken cancellationToken)
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = fileName,
-            WorkingDirectory = workingDirectory,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-
-        foreach (var arg in args)
-        {
-            startInfo.ArgumentList.Add(arg);
-        }
-
-        using var process = new Process();
-        process.StartInfo = startInfo;
-        var started = false;
-        Task<string>? stdoutTask = null;
-        Task<string>? stderrTask = null;
-        try
-        {
-            try
-            {
-                started = process.Start();
-                if (!started)
-                {
-                    return new CommandResult(-1, string.Empty, "Failed to start process");
-                }
-            }
-            catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException)
-            {
-                return new CommandResult(-1, string.Empty, $"Failed to start process: {ex.Message}");
-            }
-            catch (Exception ex)
-            {
-                return new CommandResult(-1, string.Empty, $"An unexpected error occurred while starting the process: {ex.Message}");
-            }
-
-            stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
-
-            var stdout = await stdoutTask;
-            var stderr = await stderrTask;
-
-            return new CommandResult(process.ExitCode, stdout, stderr);
-        }
-        finally
-        {
-            TryKillProcess(process, started);
-            await ObserveReadTaskAsync(stdoutTask, "stdout", fileName);
-            await ObserveReadTaskAsync(stderrTask, "stderr", fileName);
-        }
+        return _razorWireExecutor.ExecuteCommandAsync(fileName, args, workingDirectory, cancellationToken);
     }
 
     private async Task RunCommandOrThrowAsync(
@@ -399,6 +355,15 @@ public class ExportSourceResolver
         string? explicitPublishDirectory,
         string? requestedFramework = null)
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            projectDirectory = NormalizePathForMacOS(projectDirectory);
+            if (explicitPublishDirectory != null)
+            {
+                explicitPublishDirectory = NormalizePathForMacOS(explicitPublishDirectory);
+            }
+        }
+
         var searchRoots = new List<(string Path, bool RequirePublishSegment)>();
         var explicitPublishPath = string.IsNullOrWhiteSpace(explicitPublishDirectory)
             ? null
@@ -415,6 +380,10 @@ public class ExportSourceResolver
         }
         else
         {
+            if (Directory.Exists(Path.Combine(projectDirectory, "bin")))
+            {
+                searchRoots.Add((Path.Combine(projectDirectory, "bin"), true));
+            }
             var releaseDir = Path.Combine(projectDirectory, "bin", "Release");
             if (Directory.Exists(releaseDir))
             {
@@ -438,17 +407,15 @@ public class ExportSourceResolver
                 .ToList())
             .ToList();
 
-        if (candidatePaths.Count == 0 && string.IsNullOrWhiteSpace(explicitPublishPath))
+        if (candidatePaths.Count == 0)
         {
-            var binDirectory = Path.Combine(projectDirectory, "bin");
-            if (Directory.Exists(binDirectory))
+            // Broad search failsafe for various publish configurations and MacOS symlink discrepancies
+            var di = new DirectoryInfo(projectDirectory);
+            if (di.Exists)
             {
-                candidatePaths = Directory.EnumerateFiles(
-                        binDirectory,
-                        $"{assemblyName}.dll",
-                        SearchOption.AllDirectories)
+                candidatePaths = di.GetFiles($"{assemblyName}.dll", SearchOption.AllDirectories)
+                    .Select(f => f.FullName)
                     .Where(path => !IsRefAssemblyPath(path))
-                    .Where(path => IsPublishedArtifact(binDirectory, path, true))
                     .ToList();
             }
         }
@@ -480,6 +447,12 @@ public class ExportSourceResolver
             }
         }
 
+        if (candidatePaths.Count == 0)
+        {
+            throw new FileNotFoundException(
+                $"Could not locate any valid DLL for assembly '{assemblyName}' under '{projectDirectory}'.");
+        }
+
         var candidates = candidatePaths
             .Select(path => new FileInfo(path))
             .OrderByDescending(info => info.LastWriteTimeUtc)
@@ -490,6 +463,12 @@ public class ExportSourceResolver
                     ? StringComparer.OrdinalIgnoreCase
                     : StringComparer.Ordinal)
             .ToList();
+
+        if (candidates.Count == 0)
+        {
+            throw new FileNotFoundException(
+                $"No files found for candidate paths in '{projectDirectory}'.");
+        }
 
         return candidates[0].FullName;
     }
@@ -639,33 +618,55 @@ public class ExportSourceResolver
         return normalized.Contains("/ref/", StringComparison.OrdinalIgnoreCase);
     }
 
+    internal static string NormalizePathForMacOS(string path)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return path;
+        }
+
+        if (path.StartsWith("/var/", StringComparison.Ordinal))
+        {
+            return "/private" + path;
+        }
+
+        return path;
+    }
+
     private static bool IsPublishedArtifact(string publishSearchRoot, string path, bool requirePublishSegment)
     {
-        var publishSearchRootFull = Path.GetFullPath(publishSearchRoot);
-        var pathFull = Path.GetFullPath(path);
+        var publishSearchRootFull = NormalizePathForMacOS(Path.GetFullPath(publishSearchRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar);
+        var pathFull = NormalizePathForMacOS(Path.GetFullPath(path));
 
-        var relative = Path.GetRelativePath(publishSearchRootFull, pathFull);
-        if (string.IsNullOrWhiteSpace(relative)
-            || relative.StartsWith("..", StringComparison.Ordinal)
-            || Path.IsPathRooted(relative))
+        var segmentComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        if (!pathFull.StartsWith(publishSearchRootFull, segmentComparer))
         {
             return false;
         }
-
-        var segments = relative.Split(
-            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
-            StringSplitOptions.RemoveEmptyEntries);
 
         if (!requirePublishSegment)
         {
             return true;
         }
 
-        var segmentComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        var comparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
 
-        return segments.Contains("publish", segmentComparer);
+        bool HasMatch(string searchPath)
+        {
+            var parts = searchPath.Split(
+                [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                StringSplitOptions.RemoveEmptyEntries);
+            return parts.Contains("publish", comparer)
+                   || parts.Contains(ExportPublishFolder, comparer);
+        }
+
+        var relative = pathFull.Substring(publishSearchRootFull.Length);
+        return HasMatch(publishSearchRootFull) || HasMatch(relative);
     }
 
     internal static string? TryGetFrameworkSegment(string rootDirectory, string path)
@@ -741,47 +742,6 @@ public class ExportSourceResolver
         }
 
         return new Version(major, minor);
-    }
-
-    private void TryKillProcess(Process process, bool started)
-    {
-        if (!started)
-        {
-            return;
-        }
-
-        try
-        {
-            if (!process.HasExited)
-            {
-                process.Kill(entireProcessTree: true);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Ignoring process termination exception during cleanup.");
-        }
-    }
-
-    private async Task ObserveReadTaskAsync(Task<string>? readTask, string streamName, string fileName)
-    {
-        if (readTask is null)
-        {
-            return;
-        }
-
-        try
-        {
-            _ = await readTask;
-        }
-        catch (OperationCanceledException)
-        {
-            // Read was canceled along with the command cancellation token.
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Ignoring {StreamName} read exception for command {FileName}", streamName, fileName);
-        }
     }
 
     internal static IReadOnlyList<string> BuildEffectiveAppArgs(IReadOnlyList<string> appArgs)

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -388,7 +388,6 @@ public class ExportSourceResolver
             $"Command failed with exit code {result.ExitCode}: {fileName} {string.Join(" ", args)}{Environment.NewLine}Stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}Stderr:{Environment.NewLine}{result.Stderr}");
     }
 
-
     internal static string ResolveBuiltDllPath(string projectDirectory, string assemblyName)
     {
         return ResolveBuiltDllPath(projectDirectory, assemblyName, null);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -318,10 +319,21 @@ public class ExportSourceResolver
         Task<string>? stderrTask = null;
         try
         {
-            started = process.Start();
-            if (!started)
+            try
             {
-                return new CommandResult(-1, string.Empty, "Failed to start process");
+                started = process.Start();
+                if (!started)
+                {
+                    return new CommandResult(-1, string.Empty, "Failed to start process");
+                }
+            }
+            catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException)
+            {
+                return new CommandResult(-1, string.Empty, $"Failed to start process: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                return new CommandResult(-1, string.Empty, $"An unexpected error occurred while starting the process: {ex.Message}");
             }
 
             stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -11,6 +11,20 @@ using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
 
+/// <summary>
+/// Structured command execution result used by the export resolver pipeline.
+/// </summary>
+/// <param name="ExitCode">
+/// The process exit code, or a synthetic negative value when process start
+/// failed before an operating-system exit code was available.
+/// </param>
+/// <param name="Stdout">The captured standard output for the command.</param>
+/// <param name="Stderr">The captured standard error or a synthetic start-failure message.</param>
+/// <remarks>
+/// The resolver prefers this explicit result shape over exceptions for ordinary
+/// command failures so it can preserve stdout/stderr in logs and decide whether
+/// to throw, fall back to XML parsing, or continue probing.
+/// </remarks>
 internal record ProcessResult(int ExitCode, string Stdout, string Stderr);
 
 /// <summary>
@@ -60,7 +74,7 @@ public sealed class ExportSourceResolver
         ILoggerFactory loggerFactory,
         ITargetAppProcessFactory processFactory,
         IHttpClientFactory httpClientFactory)
-        : this(loggerFactory, processFactory, httpClientFactory, new CommandExecutor(loggerFactory.CreateLogger<CommandExecutor>()))
+        : this(loggerFactory, processFactory, httpClientFactory, CreateDefaultExecutor(loggerFactory))
     {
     }
 
@@ -79,6 +93,12 @@ public sealed class ExportSourceResolver
         _processFactory = processFactory;
         _httpClientFactory = httpClientFactory;
         _razorWireExecutor = razorWireExecutor;
+    }
+
+    private static ICommandExecutor CreateDefaultExecutor(ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        return new CommandExecutor(loggerFactory.CreateLogger<CommandExecutor>());
     }
 
     internal async Task<ResolvedExportSource> ResolveAsync(
@@ -300,6 +320,22 @@ public sealed class ExportSourceResolver
             $"Timed out while connecting to --url target '{baseUrl}' after {timeout.TotalSeconds:0.###} seconds. Ensure the application is running and reachable.");
     }
 
+    /// <summary>
+    /// Executes a command through the configured <see cref="ICommandExecutor"/>.
+    /// </summary>
+    /// <param name="fileName">The executable to start.</param>
+    /// <param name="args">The ordered command-line arguments for the executable.</param>
+    /// <param name="workingDirectory">The working directory used for process start.</param>
+    /// <param name="cancellationToken">Cancels the command execution.</param>
+    /// <returns>
+    /// A <see cref="ProcessResult"/> containing the exit code and captured
+    /// output streams from the delegated executor.
+    /// </returns>
+    /// <remarks>
+    /// This seam exists so resolver tests can verify command composition
+    /// without launching real processes. Callers should treat a non-zero exit
+    /// as data and decide whether to raise an exception or fall back.
+    /// </remarks>
     internal Task<ProcessResult> ExecuteProcessAsync(
         string fileName,
         IReadOnlyList<string> args,
@@ -473,6 +509,32 @@ public sealed class ExportSourceResolver
         return candidates[0].FullName;
     }
 
+    /// <summary>
+    /// Resolves the effective assembly name for a project, preferring MSBuild
+    /// evaluation and falling back to raw project XML parsing when needed.
+    /// </summary>
+    /// <param name="projectPath">The project file whose assembly name should be resolved.</param>
+    /// <param name="fallbackName">The fallback assembly name when no explicit value can be determined.</param>
+    /// <param name="framework">
+    /// The target framework used for MSBuild evaluation. Supplying this keeps
+    /// conditional <c>AssemblyName</c> values aligned with the publish target.
+    /// </param>
+    /// <param name="cancellationToken">Cancels MSBuild evaluation.</param>
+    /// <returns>
+    /// The assembly name reported by MSBuild when available; otherwise the
+    /// value returned by <see cref="TryResolveAssemblyNameFromXml"/>.
+    /// </returns>
+    /// <remarks>
+    /// MSBuild is preferred because it evaluates imports and conditional
+    /// properties that raw XML parsing cannot see. If MSBuild exits non-zero,
+    /// produces no usable stdout, or throws a non-cancellation exception, the
+    /// resolver logs the failure details and falls back to XML parsing.
+    /// Omitting <paramref name="framework"/> can mis-evaluate conditional
+    /// <c>AssemblyName</c> declarations for multi-target projects.
+    /// </remarks>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when command execution is canceled.
+    /// </exception>
     internal async Task<string> TryResolveAssemblyNameAsync(
         string projectPath,
         string fallbackName,
@@ -527,6 +589,21 @@ public sealed class ExportSourceResolver
         return TryResolveAssemblyNameFromXml(projectPath, fallbackName);
     }
 
+    /// <summary>
+    /// Reads a project file directly and returns the first explicit
+    /// <c>AssemblyName</c> value found in the XML.
+    /// </summary>
+    /// <param name="projectPath">The project file to inspect.</param>
+    /// <param name="fallbackName">The value returned when the XML cannot be read or has no assembly name.</param>
+    /// <returns>
+    /// The explicit <c>AssemblyName</c> from the project file, or
+    /// <paramref name="fallbackName"/> when no usable value is available.
+    /// </returns>
+    /// <remarks>
+    /// This method intentionally does not evaluate imports or conditional MSBuild
+    /// properties. It is the low-cost fallback used when MSBuild evaluation is
+    /// unavailable or fails to return a usable value.
+    /// </remarks>
     internal static string TryResolveAssemblyNameFromXml(string projectPath, string fallbackName)
     {
         try

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -400,10 +400,11 @@ public sealed class ExportSourceResolver
             }
         }
 
-        var searchRoots = new List<(string Path, bool RequirePublishSegment)>();
         var explicitPublishPath = string.IsNullOrWhiteSpace(explicitPublishDirectory)
             ? null
             : Path.GetFullPath(explicitPublishDirectory);
+
+        List<string> candidatePaths;
         if (!string.IsNullOrWhiteSpace(explicitPublishPath))
         {
             if (!Directory.Exists(explicitPublishPath))
@@ -412,47 +413,44 @@ public sealed class ExportSourceResolver
                     $"Could not find published output folder. Expected: {explicitPublishPath}");
             }
 
-            searchRoots.Add((explicitPublishPath, false));
-        }
-        else
-        {
-            if (Directory.Exists(Path.Combine(projectDirectory, "bin")))
-            {
-                searchRoots.Add((Path.Combine(projectDirectory, "bin"), true));
-            }
-            var releaseDir = Path.Combine(projectDirectory, "bin", "Release");
-            if (Directory.Exists(releaseDir))
-            {
-                searchRoots.Add((releaseDir, true));
-            }
-        }
-
-        if (searchRoots.Count == 0)
-        {
-            throw new FileNotFoundException(
-                $"Could not find any publish output. Expected either explicit publish directory or '{Path.Combine(projectDirectory, "bin", "Release")}'.");
-        }
-
-        var candidatePaths = searchRoots
-            .SelectMany(tuple => Directory.EnumerateFiles(
-                    tuple.Path,
+            candidatePaths = Directory.EnumerateFiles(
+                    explicitPublishPath,
                     $"{assemblyName}.dll",
                     SearchOption.AllDirectories)
                 .Where(path => !IsRefAssemblyPath(path))
-                .Where(path => IsPublishedArtifact(tuple.Path, path, tuple.RequirePublishSegment))
-                .ToList())
-            .ToList();
-
-        if (candidatePaths.Count == 0)
+                .Where(path => IsPublishedArtifact(explicitPublishPath, path, requirePublishSegment: false))
+                .ToList();
+        }
+        else
         {
-            // Broad search failsafe for various publish configurations and MacOS symlink discrepancies
-            var di = new DirectoryInfo(projectDirectory);
-            if (di.Exists)
+            var releaseDir = Path.Combine(projectDirectory, "bin", "Release");
+            if (!Directory.Exists(releaseDir))
             {
-                candidatePaths = di.GetFiles($"{assemblyName}.dll", SearchOption.AllDirectories)
-                    .Select(f => f.FullName)
-                    .Where(path => !IsRefAssemblyPath(path))
-                    .ToList();
+                throw new FileNotFoundException(
+                    $"Could not find any publish output. Expected either explicit publish directory or '{releaseDir}'.");
+            }
+
+            candidatePaths = Directory.EnumerateFiles(
+                    releaseDir,
+                    $"{assemblyName}.dll",
+                    SearchOption.AllDirectories)
+                .Where(path => !IsRefAssemblyPath(path))
+                .Where(path => IsPublishedArtifact(releaseDir, path, requirePublishSegment: true))
+                .ToList();
+
+            if (candidatePaths.Count == 0)
+            {
+                var binDirectory = Path.Combine(projectDirectory, "bin");
+                if (Directory.Exists(binDirectory))
+                {
+                    candidatePaths = Directory.EnumerateFiles(
+                            binDirectory,
+                            $"{assemblyName}.dll",
+                            SearchOption.AllDirectories)
+                        .Where(path => !IsRefAssemblyPath(path))
+                        .Where(path => IsPublishedArtifact(binDirectory, path, requirePublishSegment: true))
+                        .ToList();
+                }
             }
         }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -152,7 +152,7 @@ public sealed class ExportSourceResolver
 
         var projectDirectory = Path.GetDirectoryName(projectPath) ?? Directory.GetCurrentDirectory();
         var projectName = Path.GetFileNameWithoutExtension(projectPath);
-        var assemblyName = await TryResolveAssemblyNameAsync(projectPath, projectName, cancellationToken);
+        var assemblyName = await TryResolveAssemblyNameAsync(projectPath, projectName, request.Framework, cancellationToken);
         var publishOutputDirectory = Path.Combine(projectDirectory, "bin", ExportPublishFolder);
 
         if (!request.NoBuild)
@@ -376,14 +376,6 @@ public sealed class ExportSourceResolver
             $"Command failed with exit code {result.ExitCode}: {fileName} {string.Join(" ", args)}{Environment.NewLine}Stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}Stderr:{Environment.NewLine}{result.Stderr}");
     }
 
-    private async Task<CommandResult> RunCommandAndCaptureAsync(
-        string fileName,
-        IReadOnlyList<string> args,
-        string workingDirectory,
-        CancellationToken cancellationToken)
-    {
-        return await ExecuteProcessAsync(fileName, args, workingDirectory, cancellationToken);
-    }
 
     internal static string ResolveBuiltDllPath(string projectDirectory, string assemblyName)
     {
@@ -494,13 +486,28 @@ public sealed class ExportSourceResolver
     internal async Task<string> TryResolveAssemblyNameAsync(
         string projectPath,
         string fallbackName,
+        string? framework,
         CancellationToken cancellationToken)
     {
         try
         {
-            var result = await RunCommandAndCaptureAsync(
+            var msbuildArgs = new List<string>
+            {
+                "msbuild",
+                projectPath,
+                "-getProperty:AssemblyName",
+                "-nologo",
+                "-p:Configuration=Release"
+            };
+
+            if (!string.IsNullOrWhiteSpace(framework))
+            {
+                msbuildArgs.Add($"-p:TargetFramework={framework}");
+            }
+
+            var result = await ExecuteProcessAsync(
                 "dotnet",
-                ["msbuild", projectPath, "-getProperty:AssemblyName", "-nologo"],
+                msbuildArgs,
                 Path.GetDirectoryName(projectPath) ?? Directory.GetCurrentDirectory(),
                 cancellationToken);
 
@@ -508,6 +515,15 @@ public sealed class ExportSourceResolver
             {
                 return result.Stdout.Trim();
             }
+
+            _logger.LogWarning(
+                "Failed to resolve assembly name via MSBuild for {ProjectPath} (ExitCode: {ExitCode}). Falling back to XML parsing.{NewLine}Stdout: {Stdout}{NewLine}Stderr: {Stderr}",
+                projectPath,
+                result.ExitCode,
+                Environment.NewLine,
+                result.Stdout,
+                Environment.NewLine,
+                result.Stderr);
         }
         catch (OperationCanceledException)
         {

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ForgeTrust.Runnable.Web.RazorWire.Cli.csproj
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ForgeTrust.Runnable.Web.RazorWire.Cli.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ForgeTrust.Runnable.Web.RazorWire.Cli.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ICommandExecutor.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ICommandExecutor.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
+
+internal interface ICommandExecutor
+{
+    Task<ProcessResult> ExecuteCommandAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        string workingDirectory,
+        CancellationToken cancellationToken);
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ICommandExecutor.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ICommandExecutor.cs
@@ -1,9 +1,39 @@
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
 
+/// <summary>
+/// Executes child processes for the export pipeline while preserving a structured
+/// <see cref="ProcessResult"/> contract for callers.
+/// </summary>
+/// <remarks>
+/// This abstraction exists so resolver logic can verify command composition
+/// without launching real processes in tests. Callers should prefer it whenever
+/// they need stdout, stderr, exit code, and cancellation behavior surfaced in a
+/// consistent shape.
+/// </remarks>
 internal interface ICommandExecutor
 {
+    /// <summary>
+    /// Executes a command and captures its exit code, standard output, and
+    /// standard error.
+    /// </summary>
+    /// <param name="fileName">The executable to start.</param>
+    /// <param name="args">The ordered command-line arguments passed to <paramref name="fileName"/>.</param>
+    /// <param name="workingDirectory">The working directory used for process start.</param>
+    /// <param name="cancellationToken">Cancels the launched process and any in-flight output reads.</param>
+    /// <returns>
+    /// A <see cref="ProcessResult"/> whose <c>ExitCode</c>, <c>Stdout</c>, and
+    /// <c>Stderr</c> describe the completed command or a start-up failure.
+    /// </returns>
+    /// <remarks>
+    /// Implementations should avoid throwing for ordinary process start failures
+    /// so higher-level callers can decide whether to surface an exception,
+    /// retry, or fall back. Cancellation should still propagate via
+    /// <see cref="OperationCanceledException"/>.
+    /// </remarks>
     Task<ProcessResult> ExecuteCommandAsync(
         string fileName,
         IReadOnlyList<string> args,


### PR DESCRIPTION
Robust assembly name resolution using `dotnet msbuild -getProperty:AssemblyName`. Includes an integration test case for imported MSBuild properties.