### PR TITLE
[codex] Fix RazorWire MVC example README repo-root commands

### DIFF
--- a/examples/razorwire-mvc/README.md
+++ b/examples/razorwire-mvc/README.md
@@ -36,11 +36,13 @@ Forms are enhanced to perform partial page updates without full reloads.
 
 ## Getting Started
 
-1.  **Run the application**:
+1.  **Run the application from the repository root**:
 
     ```bash
-    dotnet run
+    dotnet run --project examples/razorwire-mvc/RazorWireWebExample.csproj
     ```
+
+    If you `cd examples/razorwire-mvc` first, `dotnet run` also works from there.
 
 2.  **Open the demo**:
     Navigate to `http://localhost:5233` (or the port indicated in the console).


### PR DESCRIPTION
## Summary
Fix the RazorWire MVC example README so the getting-started command works when run from the repository root.

## Why
Issue #119 called out a first-five-minutes paper cut: the README told users to run `dotnet run`, which fails from the repo root because there is no project in that directory.

## Changes
- update the getting-started command to use `dotnet run --project examples/razorwire-mvc/RazorWireWebExample.csproj`
- clarify that plain `dotnet run` still works after `cd examples/razorwire-mvc`

## Validation
- reproduced the original repo-root failure with bare `dotnet run`
- smoke-tested `dotnet run --project examples/razorwire-mvc/RazorWireWebExample.csproj` from the repo root
- smoke-tested `dotnet run` from `examples/razorwire-mvc`
