### PR TITLE
[codex] add curated RazorDocs landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+---
+title: Runnable
+summary: Runnable gives .NET teams a modular startup pipeline for web, console, and distributed apps. Start with the pillar you need, then drill into concrete examples and API reference.
+featured_pages:
+  - question: How do I ship a web app with Runnable?
+    path: Web/README.md
+    supporting_copy: See the web surface that composes middleware, endpoints, and host startup without a monolithic Program.cs.
+    order: 10
+  - question: Show me a working app, not just abstractions
+    path: examples/web-app/README.md
+    supporting_copy: Walk through a minimal ASP.NET Core app that uses Runnable modules end to end.
+    order: 20
+  - question: How does this fit distributed systems?
+    path: Aspire/README.md
+    supporting_copy: See how the same modular approach extends into .NET Aspire and service-default composition.
+    order: 30
+  - question: What about CLI and worker flows?
+    path: Console/README.md
+    supporting_copy: Follow the console tooling for commands, critical services, and shared startup patterns.
+    order: 40
+---
+
 # Runnable
 
 > ⚠️ **Under Construction:** This library is actively being developed and is not intended for production use yet.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -909,6 +909,18 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDocByPathAsync_ShouldMatchNormalizedSourcePath_WhenLookupStartsWithBackslashes()
+    {
+        var harvestedDocs = new List<DocNode> { new("Guide", "docs/guide.md", "<p>Guide</p>") };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        var result = await _aggregator.GetDocByPathAsync("\\DOCS\\guide.md\\");
+
+        Assert.NotNull(result);
+        Assert.Equal("Guide", result!.Title);
+    }
+
+    [Fact]
     public async Task BuildCanonicalPath_ShouldNotAppendHtml_WhenSourceAlreadyHtml()
     {
         // Arrange

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocModelsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocModelsTests.cs
@@ -14,6 +14,14 @@ public class DocModelsTests
             Summary = "Summary",
             SummaryIsDerived = true,
             PageType = "guide",
+            FeaturedPages =
+            [
+                new DocFeaturedPageDefinition
+                {
+                    Question = "What is this for?",
+                    Path = "guides/intro.md"
+                }
+            ],
             Aliases = ["alias-one"],
             RedirectAliases = ["legacy/alias"]
         };
@@ -32,6 +40,7 @@ public class DocModelsTests
         Assert.Equal("Summary", node.Metadata?.Summary);
         Assert.True(node.Metadata?.SummaryIsDerived);
         Assert.Equal("guide", node.Metadata?.PageType);
+        Assert.Single(node.Metadata?.FeaturedPages!);
         Assert.Equal(["alias-one"], node.Metadata?.Aliases);
         Assert.Equal(["legacy/alias"], node.Metadata?.RedirectAliases);
     }
@@ -52,6 +61,14 @@ public class DocModelsTests
             Title = "Fallback Title",
             Summary = "Fallback Summary",
             SummaryIsDerived = true,
+            FeaturedPages =
+            [
+                new DocFeaturedPageDefinition
+                {
+                    Question = "Fallback question",
+                    Path = "guides/fallback.md"
+                }
+            ],
             Aliases = ["beta"],
             Keywords = ["keyword"],
             HideFromPublicNav = true
@@ -63,6 +80,9 @@ public class DocModelsTests
         Assert.Equal("Fallback Title", merged!.Title);
         Assert.Equal("Primary", merged.Summary);
         Assert.False(merged.SummaryIsDerived);
+        var featuredPages = Assert.IsAssignableFrom<IReadOnlyList<DocFeaturedPageDefinition>>(merged.FeaturedPages);
+        Assert.Single(featuredPages);
+        Assert.Equal("Fallback question", featuredPages[0].Question);
         Assert.Equal(["alpha"], merged.Aliases);
         Assert.Equal(["legacy/primary"], merged.RedirectAliases);
         Assert.Equal(["keyword"], merged.Keywords);
@@ -118,18 +138,28 @@ public class DocModelsTests
             new DocMetadata
             {
                 Aliases = Array.Empty<string>(),
-                Breadcrumbs = Array.Empty<string>()
+                Breadcrumbs = Array.Empty<string>(),
+                FeaturedPages = Array.Empty<DocFeaturedPageDefinition>()
             },
             new DocMetadata
             {
                 Aliases = ["fallback-alias"],
                 Breadcrumbs = ["Namespaces", "Web"],
-                BreadcrumbsMatchPathTargets = true
+                BreadcrumbsMatchPathTargets = true,
+                FeaturedPages =
+                [
+                    new DocFeaturedPageDefinition
+                    {
+                        Question = "Fallback question",
+                        Path = "guides/fallback.md"
+                    }
+                ]
             });
 
         Assert.NotNull(merged);
         Assert.Empty(merged!.Aliases!);
         Assert.Empty(merged.Breadcrumbs!);
+        Assert.Empty(merged.FeaturedPages!);
         Assert.Null(merged.BreadcrumbsMatchPathTargets);
     }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -24,13 +24,14 @@ public class DocsControllerTests : IDisposable
     private readonly IDocHarvester _harvesterFake;
     private readonly IMemoryCache _cache;
     private readonly IMemo _memo;
+    private readonly ILogger<DocsController> _controllerLoggerFake;
 
     public DocsControllerTests()
     {
         // Mock Aggregator dependencies
         _harvesterFake = A.Fake<IDocHarvester>();
         var loggerFake = A.Fake<ILogger<DocAggregator>>();
-        var controllerLoggerFake = A.Fake<ILogger<DocsController>>();
+        _controllerLoggerFake = A.Fake<ILogger<DocsController>>();
         var options = new RazorDocsOptions();
         _cache = new MemoryCache(new MemoryCacheOptions());
         var envFake = A.Fake<IWebHostEnvironment>();
@@ -51,26 +52,363 @@ public class DocsControllerTests : IDisposable
             loggerFake
         );
 
-        _controller = new DocsController(_aggregator, controllerLoggerFake)
+        _controller = new DocsController(_aggregator, _controllerLoggerFake)
         {
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
         };
     }
 
     [Fact]
-    public async Task Index_ShouldReturnViewWithDocs()
+    public async Task Index_ShouldReturnLandingViewModelWithFeaturedPages()
     {
-        // Arrange
-        var docs = new List<DocNode> { new DocNode("Title", "path", "content") };
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    Title = "Runnable",
+                    Summary = "Start with the proof paths that matter most.",
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "How does composition work?",
+                            Path = "guides/composition.md",
+                            Order = 10
+                        }
+                    ]
+                }),
+            new(
+                "Composition",
+                "guides/composition.md",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "See the composition model.",
+                    PageType = "guide"
+                })
+        };
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
 
-        // Act
         var result = await _controller.Index();
 
-        // Assert
         var viewResult = Assert.IsType<ViewResult>(result);
-        var model = Assert.IsAssignableFrom<IEnumerable<DocNode>>(viewResult.Model);
-        Assert.Single(model);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.True(model.HasFeaturedPages);
+        Assert.Equal("Runnable", model.Heading);
+        Assert.Equal("Start with the proof paths that matter most.", model.Description);
+        var featuredPage = Assert.Single(model.FeaturedPages);
+        Assert.Equal("How does composition work?", featuredPage.Question);
+        Assert.Equal("Composition", featuredPage.Title);
+        Assert.Equal("/docs/guides/composition.md.html", featuredPage.Href);
+        Assert.Equal("guide", featuredPage.PageType);
+        Assert.Equal("See the composition model.", featuredPage.SupportingText);
+    }
+
+    [Fact]
+    public async Task Index_ShouldUseDocTitleForCuratedHeading_WhenMetadataTitleIsMissing()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Runnable",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Path = "guides/composition.md"
+                        }
+                    ]
+                }),
+            new("Composition", "guides/composition.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.Equal("Runnable", model.Heading);
+    }
+
+    [Fact]
+    public async Task Index_ShouldReturnNeutralLanding_WhenRootReadmeIsMissing()
+    {
+        var docs = new List<DocNode>
+        {
+            new("Guide", "guides/intro.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.False(model.HasFeaturedPages);
+        Assert.Equal("Documentation", model.Heading);
+        Assert.Equal("Welcome to the technical documentation. Select a topic from the sidebar to verify implementation details and usage guides.", model.Description);
+        Assert.Single(model.VisibleDocs);
+    }
+
+    [Fact]
+    public async Task Index_ShouldReturnNeutralLanding_WhenRootReadmeHasNoFeaturedPages()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "Intro"
+                }),
+            new("Guide", "guides/intro.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.False(model.HasFeaturedPages);
+        Assert.Equal(2, model.VisibleDocs.Count);
+    }
+
+    [Fact]
+    public async Task Index_ShouldSkipHiddenFeaturedPages_AndFallbackWhenNoVisibleEntriesRemain()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "How does composition work?",
+                            Path = "guides/composition.md"
+                        }
+                    ]
+                }),
+            new(
+                "Composition",
+                "guides/composition.md",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    HideFromPublicNav = true,
+                    Summary = "Hidden"
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.False(model.HasFeaturedPages);
+        A.CallTo(_controllerLoggerFake)
+            .Where(call => call.Method.Name == "Log")
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Index_ShouldSkipFeaturedPagesWithoutDestinationPath_AndLogWarning()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Where do I start?"
+                        }
+                    ]
+                }),
+            new("Guide", "guides/intro.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.False(model.HasFeaturedPages);
+        A.CallTo(_controllerLoggerFake)
+            .Where(call => call.Method.Name == "Log")
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Index_ShouldSkipMissingFeaturedPages_AndLogWarning()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Show me an example",
+                            Path = "examples/missing.md"
+                        }
+                    ]
+                }),
+            new("Guide", "guides/intro.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.False(model.HasFeaturedPages);
+        A.CallTo(_controllerLoggerFake)
+            .Where(call => call.Method.Name == "Log")
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Index_ShouldSkipDuplicateFeaturedPages_AndKeepFirstResolvedEntry()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    Title = "Runnable",
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Start here",
+                            Path = "guides/composition.md"
+                        },
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Duplicate",
+                            Path = "guides/composition.md.html"
+                        }
+                    ]
+                }),
+            new(
+                "Composition",
+                "guides/composition.md",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "Composition summary."
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        var featuredPage = Assert.Single(model.FeaturedPages);
+        Assert.Equal("Start here", featuredPage.Question);
+        A.CallTo(_controllerLoggerFake)
+            .Where(call => call.Method.Name == "Log")
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Index_ShouldPreferAuthoredSupportingCopy_AndResolveCanonicalFeaturedPaths()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Path = "guides/composition.md.html",
+                            SupportingCopy = "Authored copy wins."
+                        }
+                    ]
+                }),
+            new(
+                "Composition",
+                "guides/composition.md",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "Destination summary should lose.",
+                    PageType = "guide"
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        var featuredPage = Assert.Single(model.FeaturedPages);
+        Assert.Equal("Composition", featuredPage.Question);
+        Assert.Equal("Authored copy wins.", featuredPage.SupportingText);
+    }
+
+    [Fact]
+    public async Task Index_ShouldResolveFeaturedPathsWithWindowsSeparators()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Path = "guides\\composition.md"
+                        }
+                    ]
+                }),
+            new("Composition", "guides/composition.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        var featuredPage = Assert.Single(model.FeaturedPages);
+        Assert.Equal("/docs/guides/composition.md.html", featuredPage.Href);
     }
 
     [Fact]
@@ -163,6 +501,19 @@ public class DocsControllerTests : IDisposable
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<DocNode>(viewResult.Model);
         Assert.Equal("Legacy", model.Title);
+    }
+
+    [Fact]
+    public async Task Details_ShouldReturnView_WhenDocRequestedByBackslashSeparatedPath()
+    {
+        var docs = new List<DocNode> { new("Guide", "guides/intro.md", "content") };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Details("guides\\intro.md");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocNode>(viewResult.Model);
+        Assert.Equal("Guide", model.Title);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -158,6 +158,25 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task Index_ShouldReturnNeutralLanding_WhenRootReadmeHasNoMetadata()
+    {
+        var docs = new List<DocNode>
+        {
+            new("Home", "README.md", "<p>Home</p>"),
+            new("Guide", "guides/intro.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.False(model.HasFeaturedPages);
+        Assert.Equal("Documentation", model.Heading);
+        Assert.Equal(2, model.VisibleDocs.Count);
+    }
+
+    [Fact]
     public async Task Index_ShouldReturnNeutralLanding_WhenRootReadmeHasNoFeaturedPages()
     {
         var docs = new List<DocNode>
@@ -381,6 +400,85 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task Index_ShouldUseCuratedFallbacks_WhenLandingMetadataUsesHomeDefaults()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    Title = " Home ",
+                    Summary = "   ",
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Path = "guides/composition.md"
+                        }
+                    ]
+                }),
+            new(
+                "Composition",
+                "guides/composition.md",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    Title = "Composition Guide",
+                    Summary = "Destination summary should still appear on the card.",
+                    PageType = "guide"
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        var featuredPage = Assert.Single(model.FeaturedPages);
+        Assert.Equal("Documentation", model.Heading);
+        Assert.Equal(
+            "Start with the proof paths that answer the first evaluator questions, then drill into guides, examples, and API details.",
+            model.Description);
+        Assert.Equal("Composition Guide", featuredPage.Question);
+        Assert.Equal("Composition Guide", featuredPage.Title);
+    }
+
+    [Fact]
+    public async Task Index_ShouldUseNeutralHeading_WhenLandingDocTitleIsWhitespace()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "   ",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    Title = "   ",
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Path = "guides/composition.md"
+                        }
+                    ]
+                }),
+            new("Composition", "guides/composition.md", "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        Assert.True(model.HasFeaturedPages);
+        Assert.Equal("Documentation", model.Heading);
+    }
+
+    [Fact]
     public async Task Index_ShouldResolveFeaturedPathsWithWindowsSeparators()
     {
         var docs = new List<DocNode>
@@ -409,6 +507,75 @@ public class DocsControllerTests : IDisposable
         var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
         var featuredPage = Assert.Single(model.FeaturedPages);
         Assert.Equal("/docs/guides/composition.md.html", featuredPage.Href);
+    }
+
+    [Fact]
+    public async Task Index_ShouldPreferBestFallbackCandidate_WhenFeaturedPathHasNoExactCanonicalMatch()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Path = "guides/intro.md#missing-fragment"
+                        }
+                    ]
+                }),
+            new("Guide Root", "guides/intro.md", "<p>Root body</p>"),
+            new("Guide Empty Anchor", "guides/intro.md#details", "   "),
+            new("Guide Filled Anchor", "guides/intro.md#setup", "<p>Setup body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        var featuredPage = Assert.Single(model.FeaturedPages);
+        Assert.Equal("Guide Root", featuredPage.Question);
+        Assert.Equal("Guide Root", featuredPage.Title);
+        Assert.Equal("/docs/guides/intro.md.html", featuredPage.Href);
+    }
+
+    [Fact]
+    public async Task Index_ShouldPreferNonEmptyFallbackCandidate_WhenAllFallbackEntriesUseFragments()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Path = "guides/advanced.md#missing-fragment"
+                        }
+                    ]
+                }),
+            new("Guide Empty Fragment", "guides/advanced.md#details", "   "),
+            new("Guide Rich Fragment", "guides/advanced.md#setup", "<p>Setup body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
+        var featuredPage = Assert.Single(model.FeaturedPages);
+        Assert.Equal("Guide Rich Fragment", featuredPage.Question);
+        Assert.Equal("Guide Rich Fragment", featuredPage.Title);
+        Assert.Equal("/docs/guides/advanced.md.html#setup", featuredPage.Href);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -238,9 +238,7 @@ public class DocsControllerTests : IDisposable
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
         Assert.False(model.HasFeaturedPages);
-        A.CallTo(_controllerLoggerFake)
-            .Where(call => call.Method.Name == "Log")
-            .MustHaveHappened();
+        AssertWarningLogged("destination page is hidden from public navigation");
     }
 
     [Fact]
@@ -271,9 +269,7 @@ public class DocsControllerTests : IDisposable
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
         Assert.False(model.HasFeaturedPages);
-        A.CallTo(_controllerLoggerFake)
-            .Where(call => call.Method.Name == "Log")
-            .MustHaveHappened();
+        AssertWarningLogged("has no destination path");
     }
 
     [Fact]
@@ -305,9 +301,7 @@ public class DocsControllerTests : IDisposable
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
         Assert.False(model.HasFeaturedPages);
-        A.CallTo(_controllerLoggerFake)
-            .Where(call => call.Method.Name == "Log")
-            .MustHaveHappened();
+        AssertWarningLogged("destination page could not be resolved");
     }
 
     [Fact]
@@ -353,9 +347,7 @@ public class DocsControllerTests : IDisposable
         var model = Assert.IsType<DocLandingViewModel>(viewResult.Model);
         var featuredPage = Assert.Single(model.FeaturedPages);
         Assert.Equal("Start here", featuredPage.Question);
-        A.CallTo(_controllerLoggerFake)
-            .Where(call => call.Method.Name == "Log")
-            .MustHaveHappened();
+        AssertWarningLogged("destination is already featured");
     }
 
     [Fact]
@@ -479,7 +471,7 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task Index_ShouldResolveFeaturedPathsWithWindowsSeparators()
+    public async Task Index_ShouldResolveFeaturedPathsWithLeadingWindowsSeparators()
     {
         var docs = new List<DocNode>
         {
@@ -493,7 +485,7 @@ public class DocsControllerTests : IDisposable
                     [
                         new DocFeaturedPageDefinition
                         {
-                            Path = "guides\\composition.md"
+                            Path = "\\guides\\composition.md"
                         }
                     ]
                 }),
@@ -1099,5 +1091,21 @@ public class DocsControllerTests : IDisposable
     {
         (_memo as IDisposable)?.Dispose();
         _cache.Dispose();
+    }
+
+    private void AssertWarningLogged(string expectedMessageFragment)
+    {
+        A.CallTo(_controllerLoggerFake)
+            .Where(
+                call => call.Method.Name == nameof(ILogger.Log)
+                        && call.GetArgument<LogLevel>(0) == LogLevel.Warning
+                        && LoggedMessageContains(call, expectedMessageFragment))
+            .MustHaveHappened();
+    }
+
+    private static bool LoggedMessageContains(FakeItEasy.Core.IFakeObjectCall call, string expectedMessageFragment)
+    {
+        var message = call.GetArgument<object>(2)?.ToString();
+        return message?.Contains(expectedMessageFragment, StringComparison.OrdinalIgnoreCase) == true;
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
@@ -80,6 +80,28 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void Extract_ShouldIgnoreNullFeaturedPageEntries()
+    {
+        var markdown = """
+            ---
+            featured_pages:
+              - null
+              - question: Where do I start?
+                path: guides/intro.md
+            ---
+            # Hello
+            """;
+
+        var (body, metadata) = MarkdownFrontMatterParser.Extract(markdown);
+
+        Assert.Equal("# Hello", body);
+        var featuredPages = Assert.IsAssignableFrom<IReadOnlyList<ForgeTrust.Runnable.Web.RazorDocs.Models.DocFeaturedPageDefinition>>(metadata!.FeaturedPages);
+        var featuredPage = Assert.Single(featuredPages);
+        Assert.Equal("Where do I start?", featuredPage.Question);
+        Assert.Equal("guides/intro.md", featuredPage.Path);
+    }
+
+    [Fact]
     public void Extract_ShouldReturnOriginalMarkdown_WhenFrontMatterIsInvalid()
     {
         var markdown = """

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
@@ -112,6 +112,22 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void Extract_ShouldReturnNullMetadata_WhenFrontMatterDocumentIsYamlNull()
+    {
+        var markdown = """
+            ---
+            null
+            ---
+            # Hello
+            """;
+
+        var (body, metadata) = MarkdownFrontMatterParser.Extract(markdown);
+
+        Assert.Equal("# Hello", body);
+        Assert.Null(metadata);
+    }
+
+    [Fact]
     public void Extract_ShouldReturnOriginalMarkdown_WhenOpeningMarkerIsNotFollowedByNewline()
     {
         var markdown = "---\rtitle: Quickstart\n---\n# Hello";

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
@@ -40,6 +40,46 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void Extract_ShouldParseFeaturedPages()
+    {
+        var markdown = """
+            ---
+            featured_pages:
+              - question: How does composition work?
+                path: guides/composition.md
+                supporting_copy: Follow the service graph.
+                order: 20
+              - path: examples/hello-world.md
+                order: 30
+            ---
+            # Hello
+            """;
+
+        var (body, metadata) = MarkdownFrontMatterParser.Extract(markdown);
+
+        Assert.Equal("# Hello", body);
+        Assert.NotNull(metadata);
+
+        var featuredPages = Assert.IsAssignableFrom<IReadOnlyList<ForgeTrust.Runnable.Web.RazorDocs.Models.DocFeaturedPageDefinition>>(metadata!.FeaturedPages);
+        Assert.Collection(
+            featuredPages,
+            first =>
+            {
+                Assert.Equal("How does composition work?", first.Question);
+                Assert.Equal("guides/composition.md", first.Path);
+                Assert.Equal("Follow the service graph.", first.SupportingCopy);
+                Assert.Equal(20, first.Order);
+            },
+            second =>
+            {
+                Assert.Null(second.Question);
+                Assert.Equal("examples/hello-world.md", second.Path);
+                Assert.Null(second.SupportingCopy);
+                Assert.Equal(30, second.Order);
+            });
+    }
+
+    [Fact]
     public void Extract_ShouldReturnOriginalMarkdown_WhenFrontMatterIsInvalid()
     {
         var markdown = """
@@ -104,6 +144,7 @@ public sealed class MarkdownFrontMatterParserTests
             ---
             aliases: []
             breadcrumbs: []
+            featured_pages: []
             related_pages: []
             ---
             # Hello
@@ -114,6 +155,7 @@ public sealed class MarkdownFrontMatterParserTests
         Assert.NotNull(metadata);
         Assert.Empty(metadata!.Aliases!);
         Assert.Empty(metadata.Breadcrumbs!);
+        Assert.Empty(metadata.FeaturedPages!);
         Assert.Empty(metadata.RelatedPages!);
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using AngleSharp.Dom;
 using ForgeTrust.Runnable.Caching;
 using ForgeTrust.Runnable.Web.RazorDocs.Controllers;
 using ForgeTrust.Runnable.Web.RazorDocs.Models;
@@ -169,6 +170,67 @@ public class RazorDocsViewsTests
         Assert.Contains("Show me an example", html);
         Assert.Contains("This is the summary fallback.", html);
         Assert.Contains("Example", html);
+    }
+
+    [Fact]
+    public async Task IndexView_ShouldFormatKnownPageTypes_AndHideCardBadgeWhenPageTypeIsMissing()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "API card",
+                            Path = "guides/api.md"
+                        },
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "How-to card",
+                            Path = "guides/how-to.md"
+                        },
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Start card",
+                            Path = "guides/start.md"
+                        },
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Untyped card",
+                            Path = "guides/plain.md"
+                        }
+                    ]
+                }),
+            new("API Page", "guides/api.md", "<p>API body</p>", Metadata: new DocMetadata { PageType = "api-reference" }),
+            new("How-To Page", "guides/how-to.md", "<p>How-to body</p>", Metadata: new DocMetadata { PageType = "how-to" }),
+            new("Start Page", "guides/start.md", "<p>Start body</p>", Metadata: new DocMetadata { PageType = "start-here" }),
+            new("Plain Page", "guides/plain.md", "<p>Plain body</p>")
+        };
+        using var services = CreateServiceProvider(docs);
+
+        var html = await RenderDocsViewAsync(services, "Index", c => c.Index());
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        Assert.Equal(
+            "API Reference",
+            document.QuerySelector("a.group[href='/docs/guides/api.md.html'] span.rounded-full")?.TextContent.Trim());
+        Assert.Equal(
+            "How-To",
+            document.QuerySelector("a.group[href='/docs/guides/how-to.md.html'] span.rounded-full")?.TextContent.Trim());
+        Assert.Equal(
+            "Start Here",
+            document.QuerySelector("a.group[href='/docs/guides/start.md.html'] span.rounded-full")?.TextContent.Trim());
+
+        var untypedCard = document.QuerySelector("a.group[href='/docs/guides/plain.md.html']");
+        Assert.NotNull(untypedCard);
+        Assert.Null(untypedCard!.QuerySelector("span.rounded-full"));
+        Assert.Null(untypedCard.QuerySelector("p.mt-3"));
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -86,6 +86,131 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task IndexView_ShouldRenderCuratedFeaturedCards()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    Title = "Runnable",
+                    Summary = "Proof before promises.",
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "How does composition work?",
+                            Path = "guides/composition.md",
+                            SupportingCopy = "Follow the composition model.",
+                            Order = 10
+                        }
+                    ]
+                }),
+            new(
+                "Composition",
+                "guides/composition.md",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    PageType = "guide",
+                    Summary = "Destination summary."
+                })
+        };
+        using var services = CreateServiceProvider(docs);
+
+        var html = await RenderDocsViewAsync(services, "Index", c => c.Index());
+
+        Assert.Contains(">Runnable</h1>", html);
+        Assert.Contains("Proof before promises.", html);
+        Assert.Contains("How does composition work?", html);
+        Assert.Contains(">Composition</h2>", html);
+        Assert.Contains("Follow the composition model.", html);
+        Assert.Contains("Guide", html);
+        Assert.Contains("href=\"/docs/guides/composition.md.html\"", html);
+    }
+
+    [Fact]
+    public async Task IndexView_ShouldFallbackToDestinationSummary_WhenSupportingCopyIsMissing()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Show me an example",
+                            Path = "examples/hello.md"
+                        }
+                    ]
+                }),
+            new(
+                "Hello Example",
+                "examples/hello.md",
+                "<p>Example body</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "This is the summary fallback.",
+                    PageType = "example"
+                })
+        };
+        using var services = CreateServiceProvider(docs);
+
+        var html = await RenderDocsViewAsync(services, "Index", c => c.Index());
+
+        Assert.Contains("Show me an example", html);
+        Assert.Contains("This is the summary fallback.", html);
+        Assert.Contains("Example", html);
+    }
+
+    [Fact]
+    public async Task IndexView_ShouldRenderNeutralFallback_WhenFeaturedEntriesResolveToHiddenPages()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Show me internals",
+                            Path = "guides/hidden.md"
+                        }
+                    ]
+                }),
+            new(
+                "Hidden Guide",
+                "guides/hidden.md",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    HideFromPublicNav = true
+                }),
+            new("Guide", "guides/intro.md", "<p>Guide body</p>")
+        };
+        using var services = CreateServiceProvider(docs);
+
+        var html = await RenderDocsViewAsync(services, "Index", c => c.Index());
+
+        Assert.Contains("Documentation", html);
+        Assert.DoesNotContain("Show me internals", html);
+        Assert.Contains("articles", html);
+    }
+
+    [Fact]
     public async Task DetailsView_ShouldRenderNamespaceBreadcrumbLinks()
     {
         using var services = CreateServiceProvider(CreateDocs());

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -165,11 +165,12 @@ public class DocsController : Controller
         var landingDoc = docs.FirstOrDefault(
             d => string.Equals(d.Path, RootLandingSourcePath, StringComparison.OrdinalIgnoreCase));
         var featuredPages = ResolveFeaturedPages(landingDoc, docs);
+        var hasFeaturedPages = featuredPages.Count > 0;
 
         return new DocLandingViewModel
         {
-            Heading = featuredPages.Count > 0 ? GetCuratedHeading(landingDoc) : NeutralLandingHeading,
-            Description = featuredPages.Count > 0 ? GetCuratedDescription(landingDoc) : NeutralLandingDescription,
+            Heading = hasFeaturedPages ? GetCuratedHeading(landingDoc!) : NeutralLandingHeading,
+            Description = hasFeaturedPages ? GetCuratedDescription(landingDoc!) : NeutralLandingDescription,
             LandingDoc = landingDoc,
             VisibleDocs = visibleDocs,
             FeaturedPages = featuredPages
@@ -219,7 +220,7 @@ public class DocsController : Controller
                 continue;
             }
 
-            var destinationLinkPath = destination.CanonicalPath ?? destination.Path;
+            var destinationLinkPath = GetSnapshotCanonicalPath(destination);
             if (!seenPaths.Add(destinationLinkPath))
             {
                 _logger.LogWarning(
@@ -257,7 +258,7 @@ public class DocsController : Controller
         foreach (var doc in docs)
         {
             AddLookupEntry(lookup, NormalizeLookupPath(doc.Path), doc);
-            AddLookupEntry(lookup, NormalizeLookupPath(doc.CanonicalPath ?? doc.Path), doc);
+            AddLookupEntry(lookup, NormalizeLookupPath(GetSnapshotCanonicalPath(doc)), doc);
         }
 
         return lookup;
@@ -291,7 +292,7 @@ public class DocsController : Controller
 
         var exactCanonicalMatch = candidates.FirstOrDefault(
             doc => string.Equals(
-                       NormalizeCanonicalPath(doc.CanonicalPath ?? doc.Path),
+                       NormalizeCanonicalPath(GetSnapshotCanonicalPath(doc)),
                        lookupCanonicalPath,
                        StringComparison.OrdinalIgnoreCase)
                    || string.Equals(
@@ -304,7 +305,7 @@ public class DocsController : Controller
         }
 
         return candidates
-            .OrderBy(doc => string.IsNullOrWhiteSpace(GetFragment(doc.CanonicalPath ?? doc.Path)) ? 0 : 1)
+            .OrderBy(doc => string.IsNullOrWhiteSpace(GetFragment(GetSnapshotCanonicalPath(doc))) ? 0 : 1)
             .ThenBy(doc => string.IsNullOrWhiteSpace(doc.Content) ? 1 : 0)
             .ThenBy(doc => doc.Path, StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault();
@@ -326,6 +327,9 @@ public class DocsController : Controller
     {
         return path.Trim().Trim('/').Replace('\\', '/');
     }
+
+    // DocsController only consumes aggregator snapshots, which always populate CanonicalPath.
+    private static string GetSnapshotCanonicalPath(DocNode doc) => doc.CanonicalPath!;
 
     private static string? GetFragment(string path)
     {
@@ -351,11 +355,11 @@ public class DocsController : Controller
             : destination.Metadata!.Summary!.Trim();
     }
 
-    private static string GetCuratedHeading(DocNode? landingDoc)
+    private static string GetCuratedHeading(DocNode landingDoc)
     {
-        var title = string.IsNullOrWhiteSpace(landingDoc?.Metadata?.Title)
-            ? landingDoc?.Title
-            : landingDoc.Metadata!.Title;
+        var title = string.IsNullOrWhiteSpace(landingDoc.Metadata!.Title)
+            ? landingDoc.Title
+            : landingDoc.Metadata.Title;
         if (string.IsNullOrWhiteSpace(title) || string.Equals(title.Trim(), "Home", StringComparison.OrdinalIgnoreCase))
         {
             return NeutralLandingHeading;
@@ -364,9 +368,9 @@ public class DocsController : Controller
         return title.Trim();
     }
 
-    private static string GetCuratedDescription(DocNode? landingDoc)
+    private static string GetCuratedDescription(DocNode landingDoc)
     {
-        var summary = landingDoc?.Metadata?.Summary;
+        var summary = landingDoc.Metadata!.Summary;
         return string.IsNullOrWhiteSpace(summary)
             ? CuratedLandingDescription
             : summary.Trim();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -251,9 +251,16 @@ public class DocsController : Controller
         return resolvedCards;
     }
 
-    private static Dictionary<string, List<DocNode>> BuildDocLookup(IEnumerable<DocNode> docs)
+    private sealed class DocLookupBucket
     {
-        var lookup = new Dictionary<string, List<DocNode>>(StringComparer.OrdinalIgnoreCase);
+        public List<DocNode> OrderedDocs { get; } = [];
+
+        public HashSet<DocNode> SeenDocs { get; } = [];
+    }
+
+    private static Dictionary<string, DocLookupBucket> BuildDocLookup(IEnumerable<DocNode> docs)
+    {
+        var lookup = new Dictionary<string, DocLookupBucket>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var doc in docs)
         {
@@ -264,31 +271,33 @@ public class DocsController : Controller
         return lookup;
     }
 
-    private static void AddLookupEntry(Dictionary<string, List<DocNode>> lookup, string key, DocNode doc)
+    private static void AddLookupEntry(Dictionary<string, DocLookupBucket> lookup, string key, DocNode doc)
     {
-        if (!lookup.TryGetValue(key, out var docs))
+        if (!lookup.TryGetValue(key, out var bucket))
         {
-            docs = [];
-            lookup[key] = docs;
+            bucket = new DocLookupBucket();
+            lookup[key] = bucket;
         }
 
-        if (!docs.Contains(doc))
+        if (bucket.SeenDocs.Add(doc))
         {
-            docs.Add(doc);
+            bucket.OrderedDocs.Add(doc);
         }
     }
 
     private static DocNode? ResolveDocByPath(
         string path,
-        IReadOnlyDictionary<string, List<DocNode>> lookup)
+        IReadOnlyDictionary<string, DocLookupBucket> lookup)
     {
         var lookupPath = NormalizeLookupPath(path);
         var lookupCanonicalPath = NormalizeCanonicalPath(path);
 
-        if (!lookup.TryGetValue(lookupPath, out var candidates) || candidates.Count == 0)
+        if (!lookup.TryGetValue(lookupPath, out var bucket) || bucket.OrderedDocs.Count == 0)
         {
             return null;
         }
+
+        var candidates = bucket.OrderedDocs;
 
         var exactCanonicalMatch = candidates.FirstOrDefault(
             doc => string.Equals(
@@ -313,7 +322,7 @@ public class DocsController : Controller
 
     private static string NormalizeLookupPath(string path)
     {
-        var sanitized = path.Trim().Trim('/').Replace('\\', '/');
+        var sanitized = path.Trim().Replace('\\', '/').Trim('/');
         var hashIndex = sanitized.IndexOf('#');
         if (hashIndex >= 0)
         {
@@ -325,11 +334,15 @@ public class DocsController : Controller
 
     private static string NormalizeCanonicalPath(string path)
     {
-        return path.Trim().Trim('/').Replace('\\', '/');
+        return path.Trim().Replace('\\', '/').Trim('/');
     }
 
-    // DocsController only consumes aggregator snapshots, which always populate CanonicalPath.
-    private static string GetSnapshotCanonicalPath(DocNode doc) => doc.CanonicalPath!;
+    private static string GetSnapshotCanonicalPath(DocNode doc)
+    {
+        return doc.CanonicalPath
+               ?? throw new InvalidOperationException(
+                   $"DocsController requires snapshot canonical paths. Doc '{doc.Path}' was missing CanonicalPath.");
+    }
 
     private static string? GetFragment(string path)
     {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -1,3 +1,4 @@
+using ForgeTrust.Runnable.Web.RazorDocs.Models;
 using ForgeTrust.Runnable.Web.RazorDocs.Services;
 using ForgeTrust.Runnable.Web.RazorWire.Bridge;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,10 @@ namespace ForgeTrust.Runnable.Web.RazorDocs.Controllers;
 /// </summary>
 public class DocsController : Controller
 {
+    private const string RootLandingSourcePath = "README.md";
+    private const string NeutralLandingHeading = "Documentation";
+    private const string NeutralLandingDescription = "Welcome to the technical documentation. Select a topic from the sidebar to verify implementation details and usage guides.";
+    private const string CuratedLandingDescription = "Start with the proof paths that answer the first evaluator questions, then drill into guides, examples, and API details.";
     private static readonly TimeSpan SearchIndexCacheDuration = DocAggregator.SnapshotCacheDuration;
 
     private readonly DocAggregator _aggregator;
@@ -27,14 +32,18 @@ public class DocsController : Controller
     }
 
     /// <summary>
-    /// Displays the documentation index view containing available documentation items.
+    /// Displays the documentation index view containing either curated proof paths from the repository-root landing doc or the neutral docs landing fallback.
     /// </summary>
-    /// <returns>A view result whose model is the collection of documentation items extracted from the repository.</returns>
+    /// <returns>
+    /// A view result whose model is a <see cref="DocLandingViewModel"/>. The model includes curated featured cards when the
+    /// repository-root <c>README.md</c> authors <c>featured_pages</c>; otherwise it includes the neutral fallback landing data.
+    /// </returns>
     public async Task<IActionResult> Index()
     {
         var docs = await _aggregator.GetDocsAsync(HttpContext.RequestAborted);
+        var viewModel = BuildLandingViewModel(docs);
 
-        return View(docs);
+        return View(viewModel);
     }
 
     /// <summary>
@@ -146,5 +155,220 @@ public class DocsController : Controller
     internal bool CanRefreshCache()
     {
         return User?.Identity?.IsAuthenticated == true;
+    }
+
+    private DocLandingViewModel BuildLandingViewModel(IReadOnlyList<DocNode> docs)
+    {
+        var visibleDocs = docs
+            .Where(d => d.Metadata?.HideFromPublicNav != true)
+            .ToList();
+        var landingDoc = docs.FirstOrDefault(
+            d => string.Equals(d.Path, RootLandingSourcePath, StringComparison.OrdinalIgnoreCase));
+        var featuredPages = ResolveFeaturedPages(landingDoc, docs);
+
+        return new DocLandingViewModel
+        {
+            Heading = featuredPages.Count > 0 ? GetCuratedHeading(landingDoc) : NeutralLandingHeading,
+            Description = featuredPages.Count > 0 ? GetCuratedDescription(landingDoc) : NeutralLandingDescription,
+            LandingDoc = landingDoc,
+            VisibleDocs = visibleDocs,
+            FeaturedPages = featuredPages
+        };
+    }
+
+    private List<DocLandingFeaturedPageViewModel> ResolveFeaturedPages(DocNode? landingDoc, IReadOnlyList<DocNode> docs)
+    {
+        if (landingDoc?.Metadata?.FeaturedPages is not { Count: > 0 } featuredDefinitions)
+        {
+            return [];
+        }
+
+        var lookup = BuildDocLookup(docs);
+        var resolvedCards = new List<DocLandingFeaturedPageViewModel>();
+        var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (definition, _) in featuredDefinitions
+                     .Select((definition, index) => (definition, index))
+                     .OrderBy(item => item.definition.Order ?? int.MaxValue)
+                     .ThenBy(item => item.index))
+        {
+            if (string.IsNullOrWhiteSpace(definition.Path))
+            {
+                _logger.LogWarning(
+                    "Skipping featured docs landing entry on {LandingPath} because it has no destination path.",
+                    landingDoc.Path);
+                continue;
+            }
+
+            var destination = ResolveDocByPath(definition.Path!, lookup);
+            if (destination is null)
+            {
+                _logger.LogWarning(
+                    "Skipping featured docs landing entry '{FeaturedPath}' on {LandingPath} because the destination page could not be resolved.",
+                    definition.Path,
+                    landingDoc.Path);
+                continue;
+            }
+
+            if (destination.Metadata?.HideFromPublicNav == true)
+            {
+                _logger.LogWarning(
+                    "Skipping featured docs landing entry '{FeaturedPath}' on {LandingPath} because the destination page is hidden from public navigation.",
+                    definition.Path,
+                    landingDoc.Path);
+                continue;
+            }
+
+            var destinationLinkPath = destination.CanonicalPath ?? destination.Path;
+            if (!seenPaths.Add(destinationLinkPath))
+            {
+                _logger.LogWarning(
+                    "Skipping duplicate featured docs landing entry '{FeaturedPath}' on {LandingPath} because its destination is already featured.",
+                    definition.Path,
+                    landingDoc.Path);
+                continue;
+            }
+
+            var destinationTitle = string.IsNullOrWhiteSpace(destination.Metadata?.Title)
+                ? destination.Title
+                : destination.Metadata!.Title!.Trim();
+            var question = string.IsNullOrWhiteSpace(definition.Question)
+                ? destinationTitle
+                : definition.Question.Trim();
+
+            resolvedCards.Add(
+                new DocLandingFeaturedPageViewModel
+                {
+                    Question = question,
+                    Title = destinationTitle,
+                    Href = $"/docs/{destinationLinkPath}",
+                    PageType = destination.Metadata?.PageType,
+                    SupportingText = GetSupportingText(definition, destination)
+                });
+        }
+
+        return resolvedCards;
+    }
+
+    private static Dictionary<string, List<DocNode>> BuildDocLookup(IEnumerable<DocNode> docs)
+    {
+        var lookup = new Dictionary<string, List<DocNode>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var doc in docs)
+        {
+            AddLookupEntry(lookup, NormalizeLookupPath(doc.Path), doc);
+            AddLookupEntry(lookup, NormalizeLookupPath(doc.CanonicalPath ?? doc.Path), doc);
+        }
+
+        return lookup;
+    }
+
+    private static void AddLookupEntry(Dictionary<string, List<DocNode>> lookup, string key, DocNode doc)
+    {
+        if (!lookup.TryGetValue(key, out var docs))
+        {
+            docs = [];
+            lookup[key] = docs;
+        }
+
+        if (!docs.Contains(doc))
+        {
+            docs.Add(doc);
+        }
+    }
+
+    private static DocNode? ResolveDocByPath(
+        string path,
+        IReadOnlyDictionary<string, List<DocNode>> lookup)
+    {
+        var lookupPath = NormalizeLookupPath(path);
+        var lookupCanonicalPath = NormalizeCanonicalPath(path);
+
+        if (!lookup.TryGetValue(lookupPath, out var candidates) || candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var exactCanonicalMatch = candidates.FirstOrDefault(
+            doc => string.Equals(
+                       NormalizeCanonicalPath(doc.CanonicalPath ?? doc.Path),
+                       lookupCanonicalPath,
+                       StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(
+                       NormalizeCanonicalPath(doc.Path),
+                       lookupCanonicalPath,
+                       StringComparison.OrdinalIgnoreCase));
+        if (exactCanonicalMatch is not null)
+        {
+            return exactCanonicalMatch;
+        }
+
+        return candidates
+            .OrderBy(doc => string.IsNullOrWhiteSpace(GetFragment(doc.CanonicalPath ?? doc.Path)) ? 0 : 1)
+            .ThenBy(doc => string.IsNullOrWhiteSpace(doc.Content) ? 1 : 0)
+            .ThenBy(doc => doc.Path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    private static string NormalizeLookupPath(string path)
+    {
+        var sanitized = path.Trim().Trim('/').Replace('\\', '/');
+        var hashIndex = sanitized.IndexOf('#');
+        if (hashIndex >= 0)
+        {
+            sanitized = sanitized[..hashIndex];
+        }
+
+        return sanitized;
+    }
+
+    private static string NormalizeCanonicalPath(string path)
+    {
+        return path.Trim().Trim('/').Replace('\\', '/');
+    }
+
+    private static string? GetFragment(string path)
+    {
+        var canonical = NormalizeCanonicalPath(path);
+        var hashIndex = canonical.IndexOf('#');
+        if (hashIndex < 0 || hashIndex == canonical.Length - 1)
+        {
+            return null;
+        }
+
+        return canonical[(hashIndex + 1)..];
+    }
+
+    private static string? GetSupportingText(DocFeaturedPageDefinition definition, DocNode destination)
+    {
+        if (!string.IsNullOrWhiteSpace(definition.SupportingCopy))
+        {
+            return definition.SupportingCopy.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(destination.Metadata?.Summary)
+            ? null
+            : destination.Metadata!.Summary!.Trim();
+    }
+
+    private static string GetCuratedHeading(DocNode? landingDoc)
+    {
+        var title = string.IsNullOrWhiteSpace(landingDoc?.Metadata?.Title)
+            ? landingDoc?.Title
+            : landingDoc.Metadata!.Title;
+        if (string.IsNullOrWhiteSpace(title) || string.Equals(title.Trim(), "Home", StringComparison.OrdinalIgnoreCase))
+        {
+            return NeutralLandingHeading;
+        }
+
+        return title.Trim();
+    }
+
+    private static string GetCuratedDescription(DocNode? landingDoc)
+    {
+        var summary = landingDoc?.Metadata?.Summary;
+        return string.IsNullOrWhiteSpace(summary)
+            ? CuratedLandingDescription
+            : summary.Trim();
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -90,6 +90,15 @@ public sealed record DocMetadata
     /// </summary>
     public IReadOnlyList<string>? Breadcrumbs { get; init; }
 
+    /// <summary>
+    /// Gets optional landing-page curation entries authored with the documentation page.
+    /// </summary>
+    /// <remarks>
+    /// RazorDocs parses this metadata on any page so the contract stays page-agnostic. The built-in docs landing
+    /// consumes these entries only from the repository-root <c>README.md</c>.
+    /// </remarks>
+    public IReadOnlyList<DocFeaturedPageDefinition>? FeaturedPages { get; init; }
+
     internal bool? PageTypeIsDerived { get; init; }
 
     internal bool? AudienceIsDerived { get; init; }
@@ -176,13 +185,14 @@ public sealed record DocMetadata
             RelatedPages = MergeLists(primary.RelatedPages, fallback.RelatedPages),
             CanonicalSlug = PreferNonBlank(primary.CanonicalSlug, fallback.CanonicalSlug),
             Breadcrumbs = breadcrumbs,
-            BreadcrumbsMatchPathTargets = breadcrumbsMatchPathTargets
+            BreadcrumbsMatchPathTargets = breadcrumbsMatchPathTargets,
+            FeaturedPages = MergeLists(primary.FeaturedPages, fallback.FeaturedPages)
         };
     }
 
-    internal static IReadOnlyList<string>? MergeLists(
-        IReadOnlyList<string>? primary,
-        IReadOnlyList<string>? fallback)
+    internal static IReadOnlyList<T>? MergeLists<T>(
+        IReadOnlyList<T>? primary,
+        IReadOnlyList<T>? fallback)
     {
         if (primary is not null)
         {
@@ -243,6 +253,107 @@ public record DocNode(
     bool IsDirectory = false,
     string? CanonicalPath = null,
     DocMetadata? Metadata = null);
+
+/// <summary>
+/// Defines one authored featured-page entry for a docs landing surface.
+/// </summary>
+public sealed record DocFeaturedPageDefinition
+{
+    /// <summary>
+    /// Gets the reader-facing evaluator question or label for the card.
+    /// </summary>
+    /// <remarks>
+    /// When this value is omitted on the built-in docs landing, RazorDocs falls back to the resolved destination
+    /// page title so the card still renders with a sensible label.
+    /// </remarks>
+    public string? Question { get; init; }
+
+    /// <summary>
+    /// Gets the source or canonical path of the destination page to feature.
+    /// </summary>
+    /// <remarks>
+    /// RazorDocs matches both source paths and canonical browser paths. Path separators are normalized during
+    /// resolution so authored forward-slash and backslash forms point to the same destination.
+    /// </remarks>
+    public string? Path { get; init; }
+
+    /// <summary>
+    /// Gets optional landing-only supporting copy shown instead of destination summary text.
+    /// </summary>
+    public string? SupportingCopy { get; init; }
+
+    /// <summary>
+    /// Gets the relative display order for the featured entry.
+    /// </summary>
+    public int? Order { get; init; }
+}
+
+/// <summary>
+/// View model for the docs landing page.
+/// </summary>
+public sealed record DocLandingViewModel
+{
+    /// <summary>
+    /// Gets the hero heading shown on the docs landing.
+    /// </summary>
+    public string Heading { get; init; } = "Documentation";
+
+    /// <summary>
+    /// Gets the supporting description shown under the hero heading.
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the repository-root landing document when one was harvested.
+    /// </summary>
+    public DocNode? LandingDoc { get; init; }
+
+    /// <summary>
+    /// Gets the visible documentation nodes used by the neutral fallback landing state.
+    /// </summary>
+    public IReadOnlyList<DocNode> VisibleDocs { get; init; } = [];
+
+    /// <summary>
+    /// Gets the resolved featured cards for the landing experience.
+    /// </summary>
+    public IReadOnlyList<DocLandingFeaturedPageViewModel> FeaturedPages { get; init; } = [];
+
+    /// <summary>
+    /// Gets a value indicating whether the landing should render curated proof-path cards.
+    /// </summary>
+    public bool HasFeaturedPages => FeaturedPages.Count > 0;
+}
+
+/// <summary>
+/// View model for one resolved featured card on the docs landing page.
+/// </summary>
+public sealed record DocLandingFeaturedPageViewModel
+{
+    /// <summary>
+    /// Gets the evaluator question or label shown on the card.
+    /// </summary>
+    public string Question { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the destination page title shown on the card.
+    /// </summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the browser-facing link to the destination page.
+    /// </summary>
+    public string Href { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the destination page type, such as guide, example, or api-reference.
+    /// </summary>
+    public string? PageType { get; init; }
+
+    /// <summary>
+    /// Gets the supporting body copy shown on the card.
+    /// </summary>
+    public string? SupportingText { get; init; }
+}
 
 /// <summary>
 /// Interface for harvesting documentation from various sources.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -26,6 +26,44 @@ Slice 1 supports source-backed docs via `RazorDocsOptions`:
 
 If `RazorDocs:Source:RepositoryRoot` is omitted, the package falls back to repository discovery from the app content root. Bundle mode is modeled but intentionally rejected until Slice 2 lands.
 
+## Landing Curation
+
+RazorDocs can turn the root docs landing into a curated proof-path surface by reading `featured_pages` from the repository-root `README.md` front matter.
+
+### Authoring contract
+
+`featured_pages` is parsed as part of `DocMetadata`, so the metadata contract stays page-agnostic. The built-in `/docs` landing consumes those entries only from the root `README.md`.
+
+```yaml
+---
+title: Runnable
+summary: Follow the proof paths that explain what this framework is for and how it composes.
+featured_pages:
+  - question: How does composition work?
+    path: guides/composition.md
+    supporting_copy: Start with the composition guide before drilling into APIs.
+    order: 10
+
+  - question: Show me an end-to-end example
+    path: examples/hello-world/README.md
+    order: 20
+---
+```
+
+### Field behavior
+
+- `question` is the reader-facing label shown on the landing card. If omitted, RazorDocs falls back to the destination page title.
+- `path` accepts either the source path or canonical docs path for the destination page. RazorDocs normalizes forward-slash and backslash separators during resolution.
+- `supporting_copy` is optional landing-only text. If omitted, RazorDocs falls back to the destination page summary.
+- `order` is optional. Lower values sort first, and ties preserve authored order.
+
+### Fallback and visibility rules
+
+- If the root `README.md` is missing, the landing stays on the neutral docs index.
+- If `featured_pages` is missing or empty, the landing stays on the neutral docs index.
+- If a featured path is missing, hidden from public navigation, or duplicated, RazorDocs skips it and logs a warning.
+- If all featured entries are skipped, RazorDocs falls back to the neutral docs index instead of rendering broken cards.
+
 ## Related Projects
 
 - [ForgeTrust.Runnable.Web.RazorDocs.Standalone](../ForgeTrust.Runnable.Web.RazorDocs.Standalone/README.md) for the runnable/exportable host used in docs export and smoke testing

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/ROADMAP.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/ROADMAP.md
@@ -28,6 +28,11 @@ GitHub milestone: [RazorDocs Phase 2: Evaluator Experience](https://github.com/f
 
 Phase 2 is the first visible product slice built on top of the metadata foundation. The goal is to help an evaluating engineer answer trust questions quickly and move from high-level orientation into concrete examples and API details.
 
+This phase should ship in two moves:
+
+1. turn the root docs landing into a metadata-driven trust-routing surface
+2. extend the same curation and landing pattern to section or pillar entry points such as `Start Here`, `Examples`, and `Troubleshooting`
+
 Primary issues:
 
 - [#101](https://github.com/forge-trust/Runnable/issues/101) Rebuild public docs navigation around user intent
@@ -45,7 +50,8 @@ Recommended shipping emphasis:
 2. evaluator-first landing
 3. page-type badges
 4. concise RazorDocs product explainer
-5. deeper content and wayfinding follow-through
+5. section and pillar landing follow-through using the same metadata contract
+6. deeper content and wayfinding follow-through
 
 ## Phase 3: Routing, Relevance, and Telemetry
 
@@ -63,5 +69,6 @@ Primary issues:
 ## Notes
 
 - These phases are intended to be additive. Phase 2 should consume the Phase 1 foundation rather than reworking it.
+- Phase 1 made the metadata pipeline page-agnostic on purpose. Phase 2 should first consume that seam from the repo-root `README.md`, then reuse it for non-root landing pages without introducing a parallel content system.
 - `Runnable` remains the first proof site, but the roadmap should favor reusable RazorDocs capabilities over one-off customizations.
 - Future phases can expand into more explicit agent-facing features once the evaluator experience and search relevance are working well.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -710,7 +710,7 @@ public class DocAggregator
     /// <returns>The normalized lookup path.</returns>
     private static string NormalizeLookupPath(string path)
     {
-        var sanitized = path.Trim().Trim('/');
+        var sanitized = path.Trim().Trim('/').Replace('\\', '/');
         var hashIndex = sanitized.IndexOf('#');
         if (hashIndex >= 0)
         {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -710,7 +710,7 @@ public class DocAggregator
     /// <returns>The normalized lookup path.</returns>
     private static string NormalizeLookupPath(string path)
     {
-        var sanitized = path.Trim().Trim('/').Replace('\\', '/');
+        var sanitized = path.Trim().Replace('\\', '/').Trim('/');
         var hashIndex = sanitized.IndexOf('#');
         if (hashIndex >= 0)
         {
@@ -727,7 +727,7 @@ public class DocAggregator
     /// <returns>The normalized canonical path.</returns>
     private static string NormalizeCanonicalPath(string path)
     {
-        return path.Trim().Trim('/').Replace('\\', '/');
+        return path.Trim().Replace('\\', '/').Trim('/');
     }
 
     private static string GetSnapshotCanonicalPath(DocNode doc) => doc.CanonicalPath!;

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
@@ -62,6 +62,7 @@ internal static class MarkdownFrontMatterParser
             RelatedPages = NormalizeList(document.RelatedPages),
             CanonicalSlug = Normalize(document.CanonicalSlug) ?? Normalize(document.Slug),
             Breadcrumbs = NormalizeList(document.Breadcrumbs),
+            FeaturedPages = NormalizeFeaturedPages(document.FeaturedPages),
             PageTypeIsDerived = document.PageType is not null ? false : null,
             AudienceIsDerived = document.Audience is not null ? false : null,
             ComponentIsDerived = document.Component is not null ? false : null,
@@ -122,6 +123,26 @@ internal static class MarkdownFrontMatterParser
         return normalized;
     }
 
+    private static IReadOnlyList<DocFeaturedPageDefinition>? NormalizeFeaturedPages(
+        List<FrontMatterFeaturedPageDefinition>? values)
+    {
+        if (values is null)
+        {
+            return null;
+        }
+
+        return values
+            .Select(
+                value => new DocFeaturedPageDefinition
+                {
+                    Question = Normalize(value.Question),
+                    Path = Normalize(value.Path),
+                    SupportingCopy = Normalize(value.SupportingCopy),
+                    Order = value.Order
+                })
+            .ToArray();
+    }
+
     private sealed class FrontMatterDocument
     {
         public string? Title { get; init; }
@@ -157,5 +178,18 @@ internal static class MarkdownFrontMatterParser
         public string? Slug { get; init; }
 
         public List<string>? Breadcrumbs { get; init; }
+
+        public List<FrontMatterFeaturedPageDefinition>? FeaturedPages { get; init; }
+    }
+
+    private sealed class FrontMatterFeaturedPageDefinition
+    {
+        public string? Question { get; init; }
+
+        public string? Path { get; init; }
+
+        public string? SupportingCopy { get; init; }
+
+        public int? Order { get; init; }
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
@@ -124,7 +124,7 @@ internal static class MarkdownFrontMatterParser
     }
 
     private static IReadOnlyList<DocFeaturedPageDefinition>? NormalizeFeaturedPages(
-        List<FrontMatterFeaturedPageDefinition>? values)
+        List<FrontMatterFeaturedPageDefinition?>? values)
     {
         if (values is null)
         {
@@ -132,10 +132,11 @@ internal static class MarkdownFrontMatterParser
         }
 
         return values
+            .Where(value => value is not null)
             .Select(
                 value => new DocFeaturedPageDefinition
                 {
-                    Question = Normalize(value.Question),
+                    Question = Normalize(value!.Question),
                     Path = Normalize(value.Path),
                     SupportingCopy = Normalize(value.SupportingCopy),
                     Order = value.Order
@@ -179,7 +180,7 @@ internal static class MarkdownFrontMatterParser
 
         public List<string>? Breadcrumbs { get; init; }
 
-        public List<FrontMatterFeaturedPageDefinition>? FeaturedPages { get; init; }
+        public List<FrontMatterFeaturedPageDefinition?>? FeaturedPages { get; init; }
     }
 
     private sealed class FrontMatterFeaturedPageDefinition

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Index.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Index.cshtml
@@ -1,8 +1,25 @@
-@model IEnumerable<ForgeTrust.Runnable.Web.RazorDocs.Models.DocNode>
+@model ForgeTrust.Runnable.Web.RazorDocs.Models.DocLandingViewModel
 @using ForgeTrust.Runnable.Web.RazorDocs.ViewComponents
 @{
     ViewData["Title"] = "Documentation Index";
-    var visibleDocs = Model.Where(d => d.Metadata?.HideFromPublicNav != true).ToList();
+    var visibleDocs = Model.VisibleDocs.ToList();
+
+    static string? FormatPageType(string? pageType)
+    {
+        if (string.IsNullOrWhiteSpace(pageType))
+        {
+            return null;
+        }
+
+        return pageType.Trim().ToLowerInvariant() switch
+        {
+            "api-reference" => "API Reference",
+            "how-to" => "How-To",
+            "start-here" => "Start Here",
+            _ => System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(
+                pageType.Replace('-', ' ').Replace('_', ' ').Trim().ToLowerInvariant())
+        };
+    }
 }
 
 <div class="flex flex-col items-center justify-center h-full p-6 sm:p-8 lg:p-12 text-center text-slate-500">
@@ -11,22 +28,58 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
         </svg>
     </div>
-    <h1 class="text-3xl font-bold text-white tracking-tight mb-3">Documentation</h1>
+    <h1 class="text-3xl font-bold text-white tracking-tight mb-3">@Model.Heading</h1>
     <p class="text-slate-400 max-w-md mx-auto mb-8">
-        Welcome to the technical documentation. Select a topic from the sidebar to verify implementation details and usage guides.
+        @Model.Description
     </p>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-lg text-left">
-        @foreach (var group in visibleDocs
-            .GroupBy(SidebarDisplayHelper.GetGroupName)
-            .OrderBy(g => g.Key, System.StringComparer.OrdinalIgnoreCase)
-            .Take(4))
-        {
-            <div class="p-4 bg-slate-800/30 rounded-lg border border-slate-800 hover:border-slate-700 transition-colors">
-                <h3 class="text-xs font-semibold text-cyan-400 uppercase tracking-wider mb-2">@group.Key</h3>
-                <span class="text-2xl font-mono text-white">@group.Count()</span>
-                <span class="text-xs text-slate-500 ml-1">articles</span>
-            </div>
-        }
-    </div>
+    @if (Model.HasFeaturedPages)
+    {
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 w-full max-w-6xl text-left">
+            @foreach (var featuredPage in Model.FeaturedPages)
+            {
+                var pageTypeLabel = FormatPageType(featuredPage.PageType);
+                <a href="@featuredPage.Href"
+                   class="group h-full rounded-2xl border border-slate-800 bg-slate-900/60 p-6 transition-colors hover:border-cyan-500/50 hover:bg-slate-900">
+                    <div class="mb-4 flex items-start justify-between gap-4">
+                        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400">@featuredPage.Question</p>
+                        @if (!string.IsNullOrWhiteSpace(pageTypeLabel))
+                        {
+                            <span class="rounded-full border border-cyan-500/30 bg-cyan-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-cyan-200">
+                                @pageTypeLabel
+                            </span>
+                        }
+                    </div>
+
+                    <h2 class="text-xl font-semibold text-white transition-colors group-hover:text-cyan-100">@featuredPage.Title</h2>
+
+                    @if (!string.IsNullOrWhiteSpace(featuredPage.SupportingText))
+                    {
+                        <p class="mt-3 text-sm leading-6 text-slate-300">@featuredPage.SupportingText</p>
+                    }
+
+                    <span class="mt-6 inline-flex items-center text-sm font-semibold text-cyan-300 group-hover:text-cyan-200">
+                        Open page
+                        <span class="ml-2 transition-transform group-hover:translate-x-1" aria-hidden="true">-&gt;</span>
+                    </span>
+                </a>
+            }
+        </div>
+    }
+    else
+    {
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-lg text-left">
+            @foreach (var group in visibleDocs
+                .GroupBy(SidebarDisplayHelper.GetGroupName)
+                .OrderBy(g => g.Key, System.StringComparer.OrdinalIgnoreCase)
+                .Take(4))
+            {
+                <div class="p-4 bg-slate-800/30 rounded-lg border border-slate-800 hover:border-slate-700 transition-colors">
+                    <h3 class="text-xs font-semibold text-cyan-400 uppercase tracking-wider mb-2">@group.Key</h3>
+                    <span class="text-2xl font-mono text-white">@group.Count()</span>
+                    <span class="text-xs text-slate-500 ml-1">articles</span>
+                </div>
+            }
+        </div>
+    }
 </div>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -312,7 +312,9 @@
     let response;
 
     try {
-      response = await fetch(indexUrl, { credentials: 'same-origin', signal: controller.signal });
+      // Keep the request credential mode aligned with the layout preload so
+      // the browser can reuse the preloaded response instead of warning.
+      response = await fetch(indexUrl, { credentials: 'include', signal: controller.signal });
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
         throw new Error('Search index request timed out.');

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.Playwright;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.IntegrationTests;
+
+[Collection(RazorDocsIntegrationCollection.Name)]
+[Trait("Category", "Integration")]
+public sealed class RazorDocsLandingPlaywrightTests
+{
+    private readonly RazorDocsPlaywrightFixture _fixture;
+
+    public RazorDocsLandingPlaywrightTests(RazorDocsPlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Landing_UsesFeaturedPagesFromRootReadme()
+    {
+        // Regression: ISSUE-001 — the flagship /docs landing silently fell back to the neutral grid instead of promoting Runnable.
+        // Found by /qa on 2026-04-17
+        // Report: .gstack/qa-reports/qa-report-localhost-5189-2026-04-17.md
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(_fixture.DocsUrl);
+
+        await page.WaitForSelectorAsync("h1", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+
+        var heading = await page.TextContentAsync("h1");
+        Assert.Equal("Runnable", heading?.Trim());
+        Assert.DoesNotContain(
+            "Welcome to the technical documentation.",
+            await page.InnerTextAsync("body"));
+
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/Web/README.md.html",
+            "How do I ship a web app with Runnable?",
+            "Web",
+            "GUIDE");
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/examples/web-app/README.md.html",
+            "Show me a working app, not just abstractions",
+            "web-app",
+            "EXAMPLE");
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/Aspire/README.md.html",
+            "How does this fit distributed systems?",
+            "Aspire",
+            "GUIDE");
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/Console/README.md.html",
+            "What about CLI and worker flows?",
+            "Console",
+            "GUIDE");
+
+    }
+
+    private static async Task AssertFeaturedCardAsync(
+        IPage page,
+        string href,
+        string question,
+        string title,
+        string badge)
+    {
+        var card = page.Locator($"main a[href='{href}']").First;
+        await card.WaitForAsync(new LocatorWaitForOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+
+        Assert.Equal(href, await card.GetAttributeAsync("href"));
+
+        var cardText = await card.InnerTextAsync();
+        Assert.Contains(question, cardText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(title, cardText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(badge, cardText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Open page", cardText, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
@@ -77,8 +77,6 @@ public sealed class RazorDocsLandingPlaywrightTests
             State = WaitForSelectorState.Visible
         });
 
-        Assert.Equal(href, await card.GetAttributeAsync("href"));
-
         var cardText = await card.InnerTextAsync();
         Assert.Contains(question, cardText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(title, cardText, StringComparison.OrdinalIgnoreCase);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreloadPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreloadPlaywrightTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Playwright;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.IntegrationTests;
+
+[Collection(RazorDocsIntegrationCollection.Name)]
+[Trait("Category", "Integration")]
+public sealed class RazorDocsSearchPreloadPlaywrightTests
+{
+    private readonly RazorDocsPlaywrightFixture _fixture;
+
+    public RazorDocsSearchPreloadPlaywrightTests(RazorDocsPlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Landing_ReusesSearchIndexPreload_WithoutCredentialMismatchWarning()
+    {
+        // Regression: ISSUE-002 — docs search preload credentials mismatch emitted browser warnings and disabled preload reuse.
+        // Found by /qa on 2026-04-18
+        // Report: .gstack/qa-reports/qa-report-localhost-5189-2026-04-18.md
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+        var preloadWarnings = new List<string>();
+
+        page.Console += (_, message) =>
+        {
+            if (message.Text.Contains("search-index.json", StringComparison.OrdinalIgnoreCase)
+                && message.Text.Contains("credentials mode does not match", StringComparison.OrdinalIgnoreCase))
+            {
+                preloadWarnings.Add(message.Text);
+            }
+        };
+
+        await page.GotoAsync(_fixture.DocsUrl);
+        await WaitForSearchIndexResourceAsync(page);
+
+        Assert.Empty(preloadWarnings);
+        await AssertSearchIndexPreloadWasReusedAsync(page);
+    }
+
+    [Fact]
+    public async Task AdvancedSearch_ReusesSearchIndexPreload_WithoutCredentialMismatchWarning()
+    {
+        // Regression: ISSUE-002 — docs search preload credentials mismatch emitted browser warnings and disabled preload reuse.
+        // Found by /qa on 2026-04-18
+        // Report: .gstack/qa-reports/qa-report-localhost-5189-2026-04-18.md
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+        var preloadWarnings = new List<string>();
+
+        page.Console += (_, message) =>
+        {
+            if (message.Text.Contains("search-index.json", StringComparison.OrdinalIgnoreCase)
+                && message.Text.Contains("credentials mode does not match", StringComparison.OrdinalIgnoreCase))
+            {
+                preloadWarnings.Add(message.Text);
+            }
+        };
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search");
+        await page.WaitForSelectorAsync("#docs-search-page-input", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        await WaitForSearchIndexResourceAsync(page);
+
+        Assert.Empty(preloadWarnings);
+        await AssertSearchIndexPreloadWasReusedAsync(page);
+    }
+
+    private static async Task WaitForSearchIndexResourceAsync(IPage page)
+    {
+        await page.WaitForFunctionAsync(
+            "() => performance.getEntriesByType('resource').some(entry => entry.name.includes('/docs/search-index.json'))",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+    }
+
+    private static async Task AssertSearchIndexPreloadWasReusedAsync(IPage page)
+    {
+        var linkEntryCount = await page.EvaluateAsync<int>(
+            "() => performance.getEntriesByType('resource').filter(entry => entry.name.includes('/docs/search-index.json') && entry.initiatorType === 'link').length");
+        var fetchEntryCount = await page.EvaluateAsync<int>(
+            "() => performance.getEntriesByType('resource').filter(entry => entry.name.includes('/docs/search-index.json') && entry.initiatorType === 'fetch').length");
+
+        Assert.True(linkEntryCount >= 1, "Expected the docs search index preload entry to be recorded.");
+        Assert.Equal(0, fetchEntryCount);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreloadPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreloadPlaywrightTests.cs
@@ -21,16 +21,7 @@ public sealed class RazorDocsSearchPreloadPlaywrightTests
         // Report: .gstack/qa-reports/qa-report-localhost-5189-2026-04-18.md
         await using var context = await _fixture.Browser.NewContextAsync();
         var page = await context.NewPageAsync();
-        var preloadWarnings = new List<string>();
-
-        page.Console += (_, message) =>
-        {
-            if (message.Text.Contains("search-index.json", StringComparison.OrdinalIgnoreCase)
-                && message.Text.Contains("credentials mode does not match", StringComparison.OrdinalIgnoreCase))
-            {
-                preloadWarnings.Add(message.Text);
-            }
-        };
+        var preloadWarnings = CaptureCredentialMismatchWarnings(page);
 
         await page.GotoAsync(_fixture.DocsUrl);
         await WaitForSearchIndexResourceAsync(page);
@@ -47,16 +38,7 @@ public sealed class RazorDocsSearchPreloadPlaywrightTests
         // Report: .gstack/qa-reports/qa-report-localhost-5189-2026-04-18.md
         await using var context = await _fixture.Browser.NewContextAsync();
         var page = await context.NewPageAsync();
-        var preloadWarnings = new List<string>();
-
-        page.Console += (_, message) =>
-        {
-            if (message.Text.Contains("search-index.json", StringComparison.OrdinalIgnoreCase)
-                && message.Text.Contains("credentials mode does not match", StringComparison.OrdinalIgnoreCase))
-            {
-                preloadWarnings.Add(message.Text);
-            }
-        };
+        var preloadWarnings = CaptureCredentialMismatchWarnings(page);
 
         await page.GotoAsync($"{_fixture.DocsUrl}/search");
         await page.WaitForSelectorAsync("#docs-search-page-input", new PageWaitForSelectorOptions
@@ -76,6 +58,21 @@ public sealed class RazorDocsSearchPreloadPlaywrightTests
             "() => performance.getEntriesByType('resource').some(entry => entry.name.includes('/docs/search-index.json'))",
             null,
             new PageWaitForFunctionOptions { Timeout = 30_000 });
+    }
+
+    private static List<string> CaptureCredentialMismatchWarnings(IPage page)
+    {
+        var warnings = new List<string>();
+        page.Console += (_, message) =>
+        {
+            if (message.Text.Contains("search-index.json", StringComparison.OrdinalIgnoreCase)
+                && message.Text.Contains("credentials mode does not match", StringComparison.OrdinalIgnoreCase))
+            {
+                warnings.Add(message.Text);
+            }
+        };
+
+        return warnings;
     }
 
     private static async Task AssertSearchIndexPreloadWasReusedAsync(IPage page)


### PR DESCRIPTION
## Summary
- add a metadata-driven curated landing for RazorDocs rooted in the repository `README.md`
- update the parser, models, controller, and landing view to resolve featured pages from a single docs snapshot with clean fallback behavior
- document the authoring contract and add unit plus Playwright regression coverage for the curated landing flow

## Why
Issue `#125` is about proving Runnable faster than the neutral internal-docs pattern. The new landing gives evaluators a direct path from the top-level docs page into the strongest proof pages.

QA also surfaced a follow-up bug: the feature was implemented, but the curated landing was never activated because the repo root `README.md` did not yet define `featured_pages`. This PR includes that activation fix and a regression test.

## Impact
- `/docs` now renders a curated `Runnable` landing when the root `README.md` includes valid `featured_pages`
- missing, invalid, hidden, or filtered featured entries degrade back to the neutral landing instead of breaking the page
- the metadata contract stays page-agnostic so Phase 2 can reuse it for section or pillar landing pages

## Validation
- `dotnet format ForgeTrust.Runnable.slnx --no-restore --include Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocModelsTests.cs Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --filter "FullyQualifiedName~RazorDocsLandingPlaywrightTests"`