### PR TITLE
feat(razor-docs): [#106] Upgrade RazorDocs search discovery

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -818,6 +818,31 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task Search_ShouldSkipHiddenFromSearchFallback_WhenBuildingRecoveryLinks()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Hidden guide",
+                "guides/hidden-guide",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    PageType = "guide",
+                    HideFromSearch = true
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Search();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
+        Assert.DoesNotContain(model.FailureFallbackLinks, link => link.Href == "/docs/guides/hidden-guide");
+        Assert.Contains(model.FailureFallbackLinks, link => link.Href == "/docs");
+    }
+
+    [Fact]
     public async Task Search_ShouldSkipDuplicateFallbackLinks_WhenOneDocMatchesMultipleBuckets()
     {
         var docs = new List<DocNode>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -705,10 +705,63 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
-    public void Search_ShouldReturnView()
+    public async Task Search_ShouldReturnViewModelWithFallbackLinks()
     {
-        var result = _controller.Search();
-        Assert.IsType<ViewResult>(result);
+        var docs = new List<DocNode>
+        {
+            new(
+                "Guide",
+                "guides/start",
+                "<p>Guide body</p>",
+                Metadata: new DocMetadata
+                {
+                    PageType = "guide",
+                    Order = 1
+                }),
+            new(
+                "Example",
+                "examples/hello",
+                "<p>Example body</p>",
+                Metadata: new DocMetadata
+                {
+                    PageType = "example",
+                    Order = 2
+                }),
+            new(
+                "API",
+                "Namespaces/ForgeTrust.Runnable.Web",
+                "<p>API body</p>",
+                Metadata: new DocMetadata
+                {
+                    PageType = "api-reference",
+                    Order = 3
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Search();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
+        Assert.Equal("Search Documentation", model.Title);
+        Assert.Equal(3, model.FailureFallbackLinks.Count);
+        Assert.Contains(model.FailureFallbackLinks, link => link.Title == "Browse guides");
+        Assert.Contains(model.FailureFallbackLinks, link => link.Title == "Open an example");
+        Assert.Contains(model.FailureFallbackLinks, link => link.Title == "Explore API reference");
+    }
+
+    [Fact]
+    public async Task Search_ShouldStillRenderShell_WhenDocAggregationFails()
+    {
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await _controller.Search();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
+        Assert.Equal("Search Documentation", model.Title);
+        Assert.Contains(model.FailureFallbackLinks, link => link.Href == "/docs");
     }
 
     [Fact]
@@ -724,10 +777,15 @@ public class DocsControllerTests : IDisposable
                 {
                     Summary = "Get started quickly.",
                     PageType = "guide",
+                    Audience = "developer",
                     Component = "Runnable",
                     Aliases = ["quickstart"],
                     Keywords = ["install"],
-                    NavGroup = "Start Here"
+                    Status = "stable",
+                    NavGroup = "Start Here",
+                    Order = 7,
+                    RelatedPages = ["examples/hello-world", "Namespaces/ForgeTrust.Runnable"],
+                    Breadcrumbs = ["Guides", "Getting Started"]
                 })
         };
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
@@ -743,10 +801,19 @@ public class DocsControllerTests : IDisposable
         Assert.Equal("guide", document.GetProperty("pageType").GetString());
         Assert.Equal("Guide", document.GetProperty("pageTypeLabel").GetString());
         Assert.Equal("guide", document.GetProperty("pageTypeVariant").GetString());
+        Assert.Equal("developer", document.GetProperty("audience").GetString());
         Assert.Equal("Runnable", document.GetProperty("component").GetString());
+        Assert.Equal("stable", document.GetProperty("status").GetString());
         Assert.Equal("Start Here", document.GetProperty("navGroup").GetString());
+        Assert.Equal(7, document.GetProperty("order").GetInt32());
         Assert.Equal("quickstart", document.GetProperty("aliases").EnumerateArray().Single().GetString());
         Assert.Equal("install", document.GetProperty("keywords").EnumerateArray().Single().GetString());
+        Assert.Equal(
+            ["examples/hello-world", "Namespaces/ForgeTrust.Runnable"],
+            document.GetProperty("relatedPages").EnumerateArray().Select(item => item.GetString() ?? string.Empty).ToArray());
+        Assert.Equal(
+            ["Guides", "Getting Started"],
+            document.GetProperty("breadcrumbs").EnumerateArray().Select(item => item.GetString() ?? string.Empty).ToArray());
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -818,7 +818,6 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task SearchIndex_ShouldReturnJsonPayload_WithNormalizedPageTypeBadgeFields()
     public async Task Search_ShouldSkipDuplicateFallbackLinks_WhenOneDocMatchesMultipleBuckets()
     {
         var docs = new List<DocNode>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -25,6 +25,7 @@ public class DocsControllerTests : IDisposable
     private readonly IMemoryCache _cache;
     private readonly IMemo _memo;
     private readonly ILogger<DocsController> _controllerLoggerFake;
+    private readonly IRazorDocsHtmlSanitizer _sanitizerFake;
 
     public DocsControllerTests()
     {
@@ -35,9 +36,9 @@ public class DocsControllerTests : IDisposable
         var options = new RazorDocsOptions();
         _cache = new MemoryCache(new MemoryCacheOptions());
         var envFake = A.Fake<IWebHostEnvironment>();
-        var sanitizerFake = A.Fake<IRazorDocsHtmlSanitizer>();
+        _sanitizerFake = A.Fake<IRazorDocsHtmlSanitizer>();
         A.CallTo(() => envFake.ContentRootPath).Returns(Path.GetTempPath());
-        A.CallTo(() => sanitizerFake.Sanitize(A<string>._))
+        A.CallTo(() => _sanitizerFake.Sanitize(A<string>._))
             .ReturnsLazily((string input) => input);
         _memo = new Memo(_cache);
 
@@ -48,7 +49,7 @@ public class DocsControllerTests : IDisposable
             options,
             envFake,
             _memo,
-            sanitizerFake,
+            _sanitizerFake,
             loggerFake
         );
 
@@ -754,7 +755,14 @@ public class DocsControllerTests : IDisposable
     public async Task Search_ShouldStillRenderShell_WhenDocAggregationFails()
     {
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._))
-            .ThrowsAsync(new InvalidOperationException("boom"));
+            .Returns(
+                [
+                    new(
+                        "Home",
+                        "README.md",
+                        "<p>Home</p>")
+                ]);
+        A.CallTo(() => _sanitizerFake.Sanitize(A<string>._)).Throws(new InvalidOperationException("boom"));
 
         var result = await _controller.Search();
 
@@ -762,13 +770,19 @@ public class DocsControllerTests : IDisposable
         var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
         Assert.Equal("Search Documentation", model.Title);
         Assert.Contains(model.FailureFallbackLinks, link => link.Href == "/docs");
+        AssertWarningLogged("fallback link generation failed");
     }
 
     [Fact]
     public async Task Search_ShouldStillRenderShell_WhenDocAggregationTimesOut()
     {
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._))
-            .ThrowsAsync(new OperationCanceledException());
+            .ReturnsLazily(
+                async (string _, CancellationToken _) =>
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(750));
+                    return (IReadOnlyList<DocNode>)Array.Empty<DocNode>();
+                });
 
         var result = await _controller.Search();
 
@@ -776,6 +790,7 @@ public class DocsControllerTests : IDisposable
         var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
         Assert.Equal("Search Documentation", model.Title);
         Assert.Contains(model.FailureFallbackLinks, link => link.Href == "/docs");
+        AssertWarningLogged("fallback link generation exceeded");
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -765,7 +765,20 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task SearchIndex_ShouldReturnJsonPayload_WithNormalizedPageTypeBadgeFields()
+    public async Task Search_ShouldStillRenderShell_WhenDocAggregationTimesOut()
+    {
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var result = await _controller.Search();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
+        Assert.Equal("Search Documentation", model.Title);
+        Assert.Contains(model.FailureFallbackLinks, link => link.Href == "/docs");
+    }
+
+    [Fact]
     public async Task Search_ShouldSkipHiddenNamespacesFallback_WhenBuildingRecoveryLinks()
     {
         var docs = new List<DocNode>
@@ -787,6 +800,34 @@ public class DocsControllerTests : IDisposable
         var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
         Assert.DoesNotContain(model.FailureFallbackLinks, link => link.Title == "Browse namespaces");
         Assert.Contains(model.FailureFallbackLinks, link => link.Href == "/docs");
+    }
+
+    [Fact]
+    public async Task SearchIndex_ShouldReturnJsonPayload_WithNormalizedPageTypeBadgeFields()
+    public async Task Search_ShouldSkipDuplicateFallbackLinks_WhenOneDocMatchesMultipleBuckets()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Shared Example",
+                "guides/shared-example",
+                "<p>Shared body</p>",
+                Metadata: new DocMetadata
+                {
+                    PageType = "example"
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Search();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
+        var sharedHref = DocAggregator.BuildSearchDocUrl("guides/shared-example");
+
+        Assert.Equal(1, model.FailureFallbackLinks.Count(link => link.Href == sharedHref));
+        Assert.Contains(model.FailureFallbackLinks, link => link.Title == "Browse guides");
+        Assert.DoesNotContain(model.FailureFallbackLinks, link => link.Title == "Open an example");
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -778,9 +778,9 @@ public class DocsControllerTests : IDisposable
     {
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._))
             .ReturnsLazily(
-                async (string _, CancellationToken _) =>
+                async (string _, CancellationToken cancellationToken) =>
                 {
-                    await Task.Delay(TimeSpan.FromMilliseconds(750));
+                    await Task.Delay(TimeSpan.FromMilliseconds(750), cancellationToken);
                     return (IReadOnlyList<DocNode>)Array.Empty<DocNode>();
                 });
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -766,6 +766,31 @@ public class DocsControllerTests : IDisposable
 
     [Fact]
     public async Task SearchIndex_ShouldReturnJsonPayload_WithNormalizedPageTypeBadgeFields()
+    public async Task Search_ShouldSkipHiddenNamespacesFallback_WhenBuildingRecoveryLinks()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Namespaces",
+                "Namespaces",
+                "<p>Namespace index</p>",
+                Metadata: new DocMetadata
+                {
+                    HideFromPublicNav = true
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Search();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<SearchPageViewModel>(viewResult.Model);
+        Assert.DoesNotContain(model.FailureFallbackLinks, link => link.Title == "Browse namespaces");
+        Assert.Contains(model.FailureFallbackLinks, link => link.Href == "/docs");
+    }
+
+    [Fact]
+    public async Task SearchIndex_ShouldReturnJsonPayload_WithNormalizedPageTypeBadgeFields()
     {
         var docs = new List<DocNode>
         {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -710,6 +710,22 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task IndexView_ShouldNotRenderSearchWorkspaceOnlyAssets()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+
+        var html = await RenderDocsViewAsync(
+            services,
+            "Index",
+            c => c.Index());
+
+        Assert.DoesNotContain("href=\"/docs/search-index.json\"", html);
+        Assert.DoesNotContain("data-rw-search-runtime=\"minisearch\"", html);
+        Assert.Contains("src=\"/docs/search-client.js\"", html);
+        Assert.Contains("id=\"docs-search-input\"", html);
+    }
+
+    [Fact]
     public async Task IndexView_ShouldRenderNamespacesWithoutNamespaceRootLink_WhenRootIsMissing()
     {
         var docs = CreateDocs().Where(d => !string.Equals(d.Path, "Namespaces", StringComparison.OrdinalIgnoreCase)).ToList();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -705,8 +705,11 @@ public class RazorDocsViewsTests
             "Search",
             c => c.Search());
 
-        Assert.Contains("href=\"/docs\"", html);
-        Assert.Contains("data-turbo-frame=\"_top\"", html);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+        var recoveryLink = document.QuerySelector("a.docs-search-page-failure-link[href='/docs']");
+
+        Assert.NotNull(recoveryLink);
+        Assert.Equal("_top", recoveryLink!.GetAttribute("data-turbo-frame"));
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -45,13 +45,12 @@ public class RazorDocsViewsTests
         Assert.Contains("'pageTypeVariant'", searchClient);
         Assert.Contains("function renderPageTypeBadge(item)", searchClient);
         Assert.Contains("docs-search-option-title-row", searchClient);
-        Assert.Contains("docs-search-result-meta", searchClient);
         Assert.Contains("docs-page-badge", searchClient);
-        Assert.Contains("const metadata = [", searchClient);
-        Assert.Contains("metadata ?", searchClient);
-        Assert.Contains("<div class=\"docs-search-result-meta\">", searchClient);
-        Assert.Contains("${metadata}", searchClient);
-        Assert.Contains(": ''", searchClient);
+        Assert.Contains("function createSearchResultArticle(doc, queryTokens)", searchClient);
+        Assert.Contains("docs-search-result-badges", searchClient);
+        Assert.Contains("createSearchResultBadge(formatFacetValue(doc.pageType))", searchClient);
+        Assert.Contains("createSearchResultBadge(formatFacetValue(doc.component))", searchClient);
+        Assert.Contains("createSearchResultBadge(formatFacetValue(doc.audience), true)", searchClient);
     }
 
     [Fact]
@@ -660,14 +659,33 @@ public class RazorDocsViewsTests
     [Fact]
     public async Task SearchView_ShouldRenderSearchPageShell()
     {
-        using var services = CreateServiceProvider(CreateDocs());
+        var docs = CreateDocs();
+        docs.Add(
+            new(
+                "Quick Example",
+                "examples/quick-start",
+                "<p>Example body</p>",
+                Metadata: new DocMetadata
+                {
+                    PageType = "example"
+                }));
+
+        using var services = CreateServiceProvider(docs);
 
         var html = await RenderDocsViewAsync(
             services,
             "Search",
-            c => Task.FromResult(c.Search()));
+            c => c.Search());
 
         Assert.Contains("id=\"docs-search-page-input\"", html);
+        Assert.Contains("id=\"docs-search-page-status\"", html);
+        Assert.Contains("id=\"docs-search-page-filters-toggle\"", html);
+        Assert.Contains("id=\"docs-search-page-filters-panel\"", html);
+        Assert.Contains("id=\"docs-search-page-starter\"", html);
+        Assert.Contains("data-rw-search-suggestion=\"getting started\"", html);
+        Assert.Contains("id=\"docs-search-page-failure\"", html);
+        Assert.Contains("id=\"docs-search-page-retry\"", html);
+        Assert.Contains("docs-search-page-failure-link", html);
         Assert.Contains("id=\"docs-search-page-results\"", html);
         Assert.Contains("Search Documentation", html);
         Assert.Contains("id=\"docs-search-input\"", html);

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -686,9 +686,27 @@ public class RazorDocsViewsTests
         Assert.Contains("id=\"docs-search-page-failure\"", html);
         Assert.Contains("id=\"docs-search-page-retry\"", html);
         Assert.Contains("docs-search-page-failure-link", html);
+        Assert.Contains("href=\"/docs/search-index.json\"", html);
+        Assert.Contains("data-rw-search-runtime=\"minisearch\"", html);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", html);
+        Assert.Contains("data-turbo-action=\"advance\"", html);
         Assert.Contains("id=\"docs-search-page-results\"", html);
         Assert.Contains("Search Documentation", html);
         Assert.Contains("id=\"docs-search-input\"", html);
+    }
+
+    [Fact]
+    public async Task SearchView_ShouldRenderTopLevelFailureFallbackLink_ForDocsIndexRecovery()
+    {
+        using var services = CreateServiceProvider([]);
+
+        var html = await RenderDocsViewAsync(
+            services,
+            "Search",
+            c => c.Search());
+
+        Assert.Contains("href=\"/docs\"", html);
+        Assert.Contains("data-turbo-frame=\"_top\"", html);
     }
 
     [Fact]
@@ -992,10 +1010,13 @@ public class RazorDocsViewsTests
         httpContext.Response.Body = new MemoryStream();
 
         var controller = ActivatorUtilities.CreateInstance<DocsController>(scopedServices);
+        var routeData = new RouteData();
+        routeData.Values["controller"] = "Docs";
+        routeData.Values["action"] = actionName;
         controller.ControllerContext = new ControllerContext
         {
             HttpContext = httpContext,
-            RouteData = new RouteData(),
+            RouteData = routeData,
             ActionDescriptor = new ControllerActionDescriptor
             {
                 ControllerName = "Docs",

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -94,9 +94,19 @@ public class DocsController : Controller
     }
 
     /// <summary>
-    /// Displays the dedicated docs search page.
+    /// Displays the dedicated docs search workspace shell.
     /// </summary>
-    /// <returns>A view result displaying the search page interface.</returns>
+    /// <remarks>
+    /// The action returns a <see cref="SearchPageViewModel"/> immediately so the workspace can render starter,
+    /// loading, and retry UI before the client downloads the search index. Fallback link generation shares a linked
+    /// cancellation token with the current request and is capped by <see cref="SearchShellFallbackBudget"/> so slow
+    /// aggregation does not block the shell from rendering. If aggregation times out or throws, the view still
+    /// renders with default recovery links.
+    /// </remarks>
+    /// <returns>
+    /// A <see cref="ViewResult"/> whose model is a <see cref="SearchPageViewModel"/> describing the search shell and
+    /// its server-rendered recovery paths.
+    /// </returns>
     public async Task<IActionResult> Search()
     {
         ViewData["Title"] = "Search";

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -402,7 +402,8 @@ public class DocsController : Controller
 
         if (links.Count < 3)
         {
-            var namespacesRoot = docs.FirstOrDefault(
+            var namespacesRoot = SelectFallbackDoc(
+                docs,
                 doc => string.Equals(doc.Path, "Namespaces", StringComparison.OrdinalIgnoreCase));
             TryAddFallbackLink(
                 links,

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -16,6 +16,7 @@ public class DocsController : Controller
     private const string NeutralLandingDescription = "Welcome to the technical documentation. Select a topic from the sidebar to verify implementation details and usage guides.";
     private const string CuratedLandingDescription = "Start with the proof paths that answer the first evaluator questions, then drill into guides, examples, and API details.";
     private static readonly TimeSpan SearchIndexCacheDuration = DocAggregator.SnapshotCacheDuration;
+    private static readonly TimeSpan SearchShellFallbackBudget = TimeSpan.FromMilliseconds(500);
 
     private readonly DocAggregator _aggregator;
     private readonly ILogger<DocsController> _logger;
@@ -96,10 +97,32 @@ public class DocsController : Controller
     /// Displays the dedicated docs search page.
     /// </summary>
     /// <returns>A view result displaying the search page interface.</returns>
-    public IActionResult Search()
+    public async Task<IActionResult> Search()
     {
         ViewData["Title"] = "Search";
-        return View();
+        IReadOnlyList<DocNode> docs = [];
+
+        try
+        {
+            using var fallbackBudgetCts = CancellationTokenSource.CreateLinkedTokenSource(HttpContext.RequestAborted);
+            fallbackBudgetCts.CancelAfter(SearchShellFallbackBudget);
+            docs = await _aggregator.GetDocsAsync(fallbackBudgetCts.Token);
+        }
+        catch (OperationCanceledException) when (!HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "Docs search shell fallback link generation exceeded the {BudgetMs}ms budget. Rendering the shell with default recovery links.",
+                SearchShellFallbackBudget.TotalMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Docs search shell fallback link generation failed. Rendering the shell with default recovery links.");
+        }
+
+        var model = BuildSearchPageViewModel(docs);
+        return View(model);
     }
 
     /// <summary>
@@ -325,6 +348,106 @@ public class DocsController : Controller
             .FirstOrDefault();
     }
 
+    private static SearchPageViewModel BuildSearchPageViewModel(IReadOnlyList<DocNode> docs)
+    {
+        return new SearchPageViewModel(
+            Title: "Search Documentation",
+            Orientation: "Search across guides, examples, and API reference, or browse by filter when you are not sure what the corpus contains yet.",
+            StarterHint: "Try a starter query, or open filters to browse by page type, component, audience, or status before typing.",
+            SearchPlaceholder: "Search by topic, component, or page type",
+            SuggestedQueries: ["getting started", "example", "api reference"],
+            FailureFallbackLinks: BuildSearchFallbackLinks(docs));
+    }
+
+    private static IReadOnlyList<SearchPageFallbackLink> BuildSearchFallbackLinks(IReadOnlyList<DocNode> docs)
+    {
+        var links = new List<SearchPageFallbackLink>();
+
+        TryAddFallbackLink(
+            links,
+            SelectFallbackDoc(
+                docs,
+                doc => HasPageType(doc, "guide", "concept", "tutorial", "troubleshooting")
+                       || doc.Path.StartsWith("guides/", StringComparison.OrdinalIgnoreCase)),
+            "Browse guides",
+            "Open a high-signal guide while search is unavailable.");
+
+        TryAddFallbackLink(
+            links,
+            SelectFallbackDoc(
+                docs,
+                doc => HasPageType(doc, "example")
+                       || doc.Path.StartsWith("examples/", StringComparison.OrdinalIgnoreCase)),
+            "Open an example",
+            "Jump into a working example to keep moving.");
+
+        TryAddFallbackLink(
+            links,
+            SelectFallbackDoc(
+                docs,
+                doc => HasPageType(doc, "api-reference", "api")
+                       || doc.Path.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase)),
+            "Explore API reference",
+            "Browse the reference surface directly while search recovers.");
+
+        if (links.Count < 3)
+        {
+            var namespacesRoot = docs.FirstOrDefault(
+                doc => string.Equals(doc.Path, "Namespaces", StringComparison.OrdinalIgnoreCase));
+            TryAddFallbackLink(
+                links,
+                namespacesRoot,
+                "Browse namespaces",
+                "Use the namespace index when you need the reference map.");
+        }
+
+        if (links.Count < 3)
+        {
+            links.Add(
+                new SearchPageFallbackLink(
+                    "Documentation index",
+                    "/docs",
+                    "Return to the docs index and keep exploring from there."));
+        }
+
+        return links;
+    }
+
+    private static void TryAddFallbackLink(
+        ICollection<SearchPageFallbackLink> links,
+        DocNode? doc,
+        string title,
+        string description)
+    {
+        if (doc is null)
+        {
+            return;
+        }
+
+        var href = DocAggregator.BuildSearchDocUrl(doc.Path);
+        if (links.Any(link => string.Equals(link.Href, href, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        links.Add(new SearchPageFallbackLink(title, href, description));
+    }
+
+    private static DocNode? SelectFallbackDoc(
+        IEnumerable<DocNode> docs,
+        Func<DocNode, bool> predicate)
+    {
+        return docs
+            .Where(
+                doc => !doc.IsDirectory
+                       && doc.Metadata?.HideFromPublicNav != true
+                       && predicate(doc))
+            .OrderBy(doc => doc.Metadata?.Order ?? int.MaxValue)
+            .ThenBy(doc => doc.Title, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(doc => doc.Path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
     private static string NormalizeLookupPath(string path)
     {
         var sanitized = path.Trim().Replace('\\', '/').Trim('/');
@@ -392,5 +515,16 @@ public class DocsController : Controller
         return string.IsNullOrWhiteSpace(summary)
             ? CuratedLandingDescription
             : summary.Trim();
+    }
+
+    private static bool HasPageType(DocNode doc, params string[] expectedTypes)
+    {
+        var pageType = doc.Metadata?.PageType;
+        if (string.IsNullOrWhiteSpace(pageType))
+        {
+            return false;
+        }
+
+        return expectedTypes.Any(expected => string.Equals(pageType, expected, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -452,6 +452,7 @@ public class DocsController : Controller
             .Where(
                 doc => !doc.IsDirectory
                        && doc.Metadata?.HideFromPublicNav != true
+                       && doc.Metadata?.HideFromSearch != true
                        && predicate(doc))
             .OrderBy(doc => doc.Metadata?.Order ?? int.MaxValue)
             .ThenBy(doc => doc.Title, StringComparer.OrdinalIgnoreCase)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/DESIGN.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/DESIGN.md
@@ -1,0 +1,107 @@
+# RazorDocs Design Language
+
+## Purpose
+
+RazorDocs should feel like a focused documentation workspace, not a marketing site and not a generic SaaS dashboard. The UI should help people orient quickly, scan densely, and move deeper into docs with very little friction.
+
+## Core Tone
+
+- Quietly technical
+- Editorial rather than card-heavy
+- Dense, but never cramped
+- Confident without looking flashy
+
+If a new surface starts to feel like a feature grid, a landing page, or an AI-generated admin template, pull it back.
+
+## Visual System
+
+### Typography
+
+- Primary typeface: `Outfit`
+- Body copy should stay clean and readable with generous line-height
+- Headings should feel compact and intentional, not oversized hero copy
+- Search results should privilege readable title hierarchy over decorative framing
+
+### Color
+
+- Base surfaces: dark slate family
+- Accent: cyan for focus, active state, and high-value calls to action
+- Borders and separators should do most of the structure work
+- Avoid adding extra accent colors unless the feature truly needs semantic differentiation
+
+### Surfaces
+
+- Prefer layered panels, separators, and subtle fills over heavy boxed cards
+- Result lists should read like an editorial index with strong rows, not isolated product cards
+- Keep shadows minimal; contrast and spacing should carry the layout
+
+## Search Workspace
+
+`/docs/search` is a search-first workspace.
+
+- Keep the primary search input visually dominant
+- Place filters directly under or adjacent to the query area
+- Keep one main results stream, ranked by relevance
+- Use badges and breadcrumbs to add context without fragmenting the scan path
+
+### Starter State
+
+The empty state should guide without feeling promotional.
+
+- Include a one-sentence orientation
+- Show clickable suggestion chips
+- Explain that filters can also be used for browse mode before typing
+
+### Results
+
+Results should be a high-information list.
+
+- Title is the strongest element
+- Breadcrumbs come first and stay subtle
+- Badges are compact metadata, not visual decoration
+- Snippets should stay short and readable
+- Highlight matches with restrained `<mark>` styling
+
+### Filters
+
+- Desktop: filters are visible within the page workspace
+- Mobile: collapse filters behind a compact toggle with active-filter summary pills
+- Disabled zero-result options should remain visible so the dataset shape stays legible
+
+## State Design
+
+Search has distinct states and they should look distinct.
+
+- First load: show skeleton rows and clear “Loading search index...” messaging
+- Refinement updates: keep prior results visible and use a subtle busy state
+- No results: explain that the search worked, then offer recovery paths
+- Failure: explain that search itself is unavailable, show retry, and provide fallback links
+
+Do not reuse the no-results treatment for actual failures.
+
+## Interaction Rules
+
+- `/` focuses the visible search input when the user is not already typing
+- `Cmd/Ctrl+K` opens the search workspace or focuses the advanced input
+- Browser history should feel natural:
+  - typing updates URL state with replace semantics
+  - deliberate filter changes create navigable history entries
+- Back/Forward must restore query, filters, and rendered results
+
+## Accessibility
+
+- Preserve semantic headings, labels, and live regions for status changes
+- Loading, failure, and no-results states must remain understandable without visual context
+- Focus should move predictably for shortcuts, retry, and suggestion chips
+- Mobile layouts should keep search and results visible without forcing long filter scrolls
+
+## Anti-Patterns
+
+Avoid these by default:
+
+- chunky boxed result cards
+- oversized marketing hero treatments
+- decorative gradients inside core reading surfaces
+- multiple competing result columns
+- hiding the corpus shape behind over-minimal filter UI
+- introducing visual styles that do not already fit the dark-slate plus cyan system

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/SearchPageViewModel.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/SearchPageViewModel.cs
@@ -7,6 +7,12 @@ namespace ForgeTrust.Runnable.Web.RazorDocs.Models;
 /// This model is rendered before the client-side search index is available so the page can show stable loading,
 /// starter, and failure states even when the search payload is slow or unavailable. All members are required and
 /// should be supplied as non-<see langword="null" /> values. The list properties render in the order provided.
+/// Use <see cref="SearchPageViewModel" /> for the server-rendered shell contract and recovery guidance, not for live
+/// search results or client-side facet state. Callers should prefer empty lists over <see langword="null" /> for
+/// <paramref name="SuggestedQueries" /> and <paramref name="FailureFallbackLinks" />.
+/// Suggested queries and fallback links are displayed in the supplied order, so place the highest-signal actions
+/// first. Avoid relying on client-side mutation of this model after render, and avoid using external absolute URLs in
+/// <see cref="SearchPageFallbackLink.Href" /> because the shell assumes app-relative navigation semantics.
 /// </remarks>
 /// <param name="Title">The primary page heading shown above the workspace controls.</param>
 /// <param name="Orientation">A short orientation sentence that explains what users can discover from the workspace.</param>
@@ -29,6 +35,9 @@ public sealed record SearchPageViewModel(
 /// These links are rendered before the client search payload is available, so each entry should be complete enough
 /// to stand on its own. Destinations under <c>/docs/...</c> continue using the docs content frame, while the docs
 /// index and non-doc routes navigate the top-level page.
+/// Keep <see cref="Href" /> app-relative and already URL-safe, and assume the UI will HTML-escape the visible text
+/// in <see cref="Title" /> and <see cref="Description" />. Prefer concise copy that fits comfortably in a compact
+/// recovery card, and do not depend on client search indexing to make the destination discoverable.
 /// </remarks>
 /// <param name="Title">Short, action-oriented label used as the visible link title.</param>
 /// <param name="Href">The app-relative destination URL to open when the user follows the recovery action.</param>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/SearchPageViewModel.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/SearchPageViewModel.cs
@@ -1,14 +1,19 @@
 namespace ForgeTrust.Runnable.Web.RazorDocs.Models;
 
 /// <summary>
-/// Server-rendered shell data for the dedicated docs search page.
+/// Describes the server-rendered shell for the dedicated docs search workspace.
 /// </summary>
-/// <param name="Title">Primary page heading.</param>
-/// <param name="Orientation">Short explanation of what the search workspace is for.</param>
-/// <param name="StarterHint">Hint shown before the user starts searching.</param>
-/// <param name="SearchPlaceholder">Placeholder copy for the advanced search input.</param>
-/// <param name="SuggestedQueries">Starter-state query suggestions.</param>
-/// <param name="FailureFallbackLinks">Fallback links shown when the search index cannot be loaded.</param>
+/// <remarks>
+/// This model is rendered before the client-side search index is available so the page can show stable loading,
+/// starter, and failure states even when the search payload is slow or unavailable. All members are required and
+/// should be supplied as non-<see langword="null" /> values. The list properties render in the order provided.
+/// </remarks>
+/// <param name="Title">The primary page heading shown above the workspace controls.</param>
+/// <param name="Orientation">A short orientation sentence that explains what users can discover from the workspace.</param>
+/// <param name="StarterHint">Helper copy shown in the starter state before a query or filter is applied.</param>
+/// <param name="SearchPlaceholder">Placeholder text for the advanced search input.</param>
+/// <param name="SuggestedQueries">Starter-state suggestions rendered as clickable chips. Empty lists are allowed, but the shell is designed around a curated set of useful first queries.</param>
+/// <param name="FailureFallbackLinks">Ordered recovery links shown when the search runtime or index cannot be loaded. Include at least one non-search path that still helps users continue through the docs set.</param>
 public sealed record SearchPageViewModel(
     string Title,
     string Orientation,
@@ -18,11 +23,16 @@ public sealed record SearchPageViewModel(
     IReadOnlyList<SearchPageFallbackLink> FailureFallbackLinks);
 
 /// <summary>
-/// Server-rendered fallback link displayed when docs search fails to initialize.
+/// Represents one server-rendered recovery action shown when docs search cannot be initialized.
 /// </summary>
-/// <param name="Title">Short link label.</param>
-/// <param name="Href">Destination URL.</param>
-/// <param name="Description">Supporting context shown under the link label.</param>
+/// <remarks>
+/// These links are rendered before the client search payload is available, so each entry should be complete enough
+/// to stand on its own. Destinations under <c>/docs/...</c> continue using the docs content frame, while the docs
+/// index and non-doc routes navigate the top-level page.
+/// </remarks>
+/// <param name="Title">Short, action-oriented label used as the visible link title.</param>
+/// <param name="Href">The app-relative destination URL to open when the user follows the recovery action.</param>
+/// <param name="Description">Supporting context that explains what the destination contains and why it helps recover from the failed search flow.</param>
 public sealed record SearchPageFallbackLink(
     string Title,
     string Href,

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/SearchPageViewModel.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/SearchPageViewModel.cs
@@ -1,0 +1,29 @@
+namespace ForgeTrust.Runnable.Web.RazorDocs.Models;
+
+/// <summary>
+/// Server-rendered shell data for the dedicated docs search page.
+/// </summary>
+/// <param name="Title">Primary page heading.</param>
+/// <param name="Orientation">Short explanation of what the search workspace is for.</param>
+/// <param name="StarterHint">Hint shown before the user starts searching.</param>
+/// <param name="SearchPlaceholder">Placeholder copy for the advanced search input.</param>
+/// <param name="SuggestedQueries">Starter-state query suggestions.</param>
+/// <param name="FailureFallbackLinks">Fallback links shown when the search index cannot be loaded.</param>
+public sealed record SearchPageViewModel(
+    string Title,
+    string Orientation,
+    string StarterHint,
+    string SearchPlaceholder,
+    IReadOnlyList<string> SuggestedQueries,
+    IReadOnlyList<SearchPageFallbackLink> FailureFallbackLinks);
+
+/// <summary>
+/// Server-rendered fallback link displayed when docs search fails to initialize.
+/// </summary>
+/// <param name="Title">Short link label.</param>
+/// <param name="Href">Destination URL.</param>
+/// <param name="Description">Supporting context shown under the link label.</param>
+public sealed record SearchPageFallbackLink(
+    string Title,
+    string Href,
+    string Description);

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Search.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Search.cshtml
@@ -1,20 +1,102 @@
+@model ForgeTrust.Runnable.Web.RazorDocs.Models.SearchPageViewModel
+
 <div id="docs-search-page" class="docs-search-page">
-    <header class="mb-6">
-        <h1 class="text-3xl font-bold text-white tracking-tight mb-2">Search Documentation</h1>
-        <p class="text-slate-400">Search all indexed documentation pages.</p>
+    <header class="docs-search-page-header">
+        <p class="docs-search-page-eyebrow">Docs Search</p>
+        <h1 class="docs-search-page-title">@Model.Title</h1>
+        <p class="docs-search-page-intro">@Model.Orientation</p>
     </header>
 
-    <div class="docs-search-page-input-wrap">
-        <label for="docs-search-page-input" class="sr-only">Search query</label>
-        <input id="docs-search-page-input"
-               type="search"
-               placeholder="Type to search..."
-               autocomplete="off"
-               aria-label="Search query" />
+    <div class="docs-search-page-query-row">
+        <div class="docs-search-page-input-wrap">
+            <label for="docs-search-page-input" class="sr-only">Search query</label>
+            <input id="docs-search-page-input"
+                   type="search"
+                   placeholder="@Model.SearchPlaceholder"
+                   autocomplete="off"
+                   spellcheck="false"
+                   aria-describedby="docs-search-page-status"
+                   aria-controls="docs-search-page-results"
+                   aria-label="Search query" />
+        </div>
+        <button id="docs-search-page-filters-toggle"
+                class="docs-search-page-filters-toggle"
+                type="button"
+                aria-controls="docs-search-page-filters-panel"
+                aria-expanded="false">
+            Filters
+        </button>
     </div>
 
     <p id="docs-search-page-status" class="docs-search-page-status" aria-live="polite">
-        Type to search across documentation.
+        Loading search index...
     </p>
-    <section id="docs-search-page-results" aria-label="Search results"></section>
+
+    <div id="docs-search-page-active-filters" class="docs-search-page-active-filters" hidden></div>
+
+    <section id="docs-search-page-filters-panel"
+             class="docs-search-page-filters-panel"
+             aria-label="Search filters">
+        <div id="docs-search-page-filters" class="docs-search-page-filters"></div>
+    </section>
+
+    <section id="docs-search-page-starter"
+             class="docs-search-page-starter"
+             hidden
+             aria-label="Search suggestions">
+        <p class="docs-search-page-starter-copy">@Model.StarterHint</p>
+        <div class="docs-search-page-starter-chips">
+            @foreach (var query in Model.SuggestedQueries)
+            {
+                <button type="button"
+                        class="docs-search-page-starter-chip"
+                        data-rw-search-suggestion="@query">
+                    @query
+                </button>
+            }
+        </div>
+    </section>
+
+    <section id="docs-search-page-failure"
+             class="docs-search-page-failure"
+             hidden
+             aria-live="polite">
+        <h2 class="docs-search-page-section-title">Search is temporarily unavailable</h2>
+        <p class="docs-search-page-failure-copy">
+            The search workspace loaded, but the index could not be fetched yet. You can retry or keep moving with one of these fallback paths.
+        </p>
+        <div class="docs-search-page-failure-actions">
+            <button id="docs-search-page-retry"
+                    class="docs-search-page-retry"
+                    type="button">
+                Retry
+            </button>
+        </div>
+        <div class="docs-search-page-failure-links">
+            @foreach (var link in Model.FailureFallbackLinks)
+            {
+                <a class="docs-search-page-failure-link" href="@link.Href">
+                    <span class="docs-search-page-failure-link-title">@link.Title</span>
+                    <span class="docs-search-page-failure-link-description">@link.Description</span>
+                </a>
+            }
+        </div>
+    </section>
+
+    <div id="docs-search-page-results-meta" class="docs-search-page-results-meta" hidden></div>
+
+    <section id="docs-search-page-results"
+             class="docs-search-page-results"
+             aria-label="Search results"
+             aria-busy="true">
+        @for (var index = 0; index < 3; index++)
+        {
+            <article class="docs-search-result docs-search-result-skeleton" aria-hidden="true">
+                <div class="docs-search-skeleton docs-search-skeleton-title"></div>
+                <div class="docs-search-skeleton docs-search-skeleton-meta"></div>
+                <div class="docs-search-skeleton docs-search-skeleton-line"></div>
+                <div class="docs-search-skeleton docs-search-skeleton-line docs-search-skeleton-line-short"></div>
+            </article>
+        }
+    </section>
 </div>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Search.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Search.cshtml
@@ -75,10 +75,26 @@
         <div class="docs-search-page-failure-links">
             @foreach (var link in Model.FailureFallbackLinks)
             {
-                <a class="docs-search-page-failure-link" href="@link.Href">
-                    <span class="docs-search-page-failure-link-title">@link.Title</span>
-                    <span class="docs-search-page-failure-link-description">@link.Description</span>
-                </a>
+                var usesDocsFrame = link.Href.StartsWith("/docs/", StringComparison.OrdinalIgnoreCase);
+                if (usesDocsFrame)
+                {
+                    <a class="docs-search-page-failure-link"
+                       href="@link.Href"
+                       data-turbo-frame="doc-content"
+                       data-turbo-action="advance">
+                        <span class="docs-search-page-failure-link-title">@link.Title</span>
+                        <span class="docs-search-page-failure-link-description">@link.Description</span>
+                    </a>
+                }
+                else
+                {
+                    <a class="docs-search-page-failure-link"
+                       href="@link.Href"
+                       data-turbo-frame="_top">
+                        <span class="docs-search-page-failure-link-title">@link.Title</span>
+                        <span class="docs-search-page-failure-link-description">@link.Description</span>
+                    </a>
+                }
             }
         </div>
     </section>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Shared/_Layout.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Shared/_Layout.cshtml
@@ -1,3 +1,9 @@
+@{
+    var isSearchPage = string.Equals(
+        ViewContext.RouteData.Values["action"]?.ToString(),
+        "Search",
+        StringComparison.OrdinalIgnoreCase);
+}
 <!DOCTYPE html>
 <html lang="en" class="h-full bg-slate-900 border-slate-800" style="scrollbar-gutter: stable;">
 <head>
@@ -329,9 +335,15 @@
         }
     </style>
     <link rel="stylesheet" href="~/docs/search.css" />
-    <link rel="preload" href="~/docs/search-index.json" as="fetch" crossorigin="use-credentials" />
+    @if (isSearchPage)
+    {
+        <link rel="preload" href="~/docs/search-index.json" as="fetch" crossorigin="use-credentials" />
+    }
     <rw:scripts/>
-    <script src="~/docs/minisearch.min.js" defer></script>
+    @if (isSearchPage)
+    {
+        <script src="~/docs/minisearch.min.js" defer data-rw-search-runtime="minisearch"></script>
+    }
     <script src="~/docs/search-client.js" defer></script>
 </head>
 <body class="h-full flex flex-col text-slate-200 overflow-hidden">
@@ -376,8 +388,9 @@
                    autocomplete="off" />
             <p id="docs-search-status" class="mt-1 text-xs text-slate-500" aria-live="polite"></p>
             <ul id="docs-search-results" class="hidden" role="listbox" aria-label="Search results"></ul>
-            <a href="/docs/search" class="mt-2 inline-block text-xs text-cyan-400 hover:text-cyan-300">
-                Advanced search
+            <a href="/docs/search" class="docs-search-shell-cta">
+                <span>Open Search Workspace</span>
+                <span class="docs-search-shell-cta-hint">Cmd/Ctrl+K</span>
             </a>
         </div>
         <nav class="flex-grow overflow-y-auto px-4 pb-4 space-y-1 min-h-0" aria-label="Documentation navigation">
@@ -402,7 +415,10 @@
                 </svg>
             </button>
             <a href="/docs" class="text-lg font-semibold text-white">RazorDocs</a>
-            <a href="/docs/search" class="ml-auto text-xs font-semibold uppercase tracking-wide text-cyan-300 hover:text-cyan-200">Search</a>
+            <a href="/docs/search" class="ml-auto inline-flex items-center gap-2 rounded-full border border-cyan-500/40 bg-cyan-500/10 px-3 py-1.5 text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-cyan-200 hover:border-cyan-400 hover:bg-cyan-500/15">
+                <span>Search</span>
+                <span aria-hidden="true">/</span>
+            </a>
         </header>
         <rw:island id="doc-content">
             <div class="max-w-6xl mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-12">

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -888,25 +888,36 @@
   }
 
   function deriveFacetState(baseDocs, filters) {
-    return facetDefinitions.map((facet) => {
-      const selectedValue = normalizeFacetValue(filters[facet.key]);
-      const siblingDocs = baseDocs.filter((doc) => matchesFilters(doc, filters, facet.key));
-      const options = searchData.facetValues[facet.key].map((value) => {
-        const count = siblingDocs.filter((doc) => normalizeFacetValue(doc[facet.key]) === value).length;
-        return {
-          value,
-          count,
-          selected: value === selectedValue,
-          disabled: count === 0 && value !== selectedValue
-        };
-      });
+    return facetDefinitions
+      .map((facet) => {
+        const selectedValue = normalizeFacetValue(filters[facet.key]);
+        const siblingDocs = baseDocs.filter((doc) => matchesFilters(doc, filters, facet.key));
+        const facetValues = [...searchData.facetValues[facet.key]];
+        if (selectedValue && !facetValues.includes(selectedValue)) {
+          facetValues.unshift(selectedValue);
+        }
 
-      return {
-        ...facet,
-        options,
-        selectedValue
-      };
-    });
+        const options = facetValues.map((value) => {
+          const count = siblingDocs.filter((doc) => normalizeFacetValue(doc[facet.key]) === value).length;
+          return {
+            value,
+            count,
+            selected: value === selectedValue,
+            disabled: count === 0 && value !== selectedValue
+          };
+        });
+
+        if (options.length === 0) {
+          return null;
+        }
+
+        return {
+          ...facet,
+          options,
+          selectedValue
+        };
+      })
+      .filter(Boolean);
   }
 
   function runRankedSearch(query, filters, maxResults = null) {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -1042,12 +1042,19 @@
       .filter(Boolean);
     const normalizedQuery = normalizeQuery(searchPageState.q);
     const isStarter = !normalizedQuery && activeFilters.length === 0;
-    const baseDocs = normalizedQuery
-      ? runRankedSearch(normalizedQuery, createEmptyFacetValues()).map((result) => searchData.docsById.get(result.id)).filter(Boolean)
-      : sortDocsForBrowse(searchData.docs);
-    const resultDocs = normalizedQuery || activeFilters.length > 0
-      ? runRankedSearch(normalizedQuery, filters).map((result) => searchData.docsById.get(result.id)).filter(Boolean)
+    const baseResults = normalizedQuery
+      ? runRankedSearch(normalizedQuery, createEmptyFacetValues())
       : [];
+    const baseDocs = normalizedQuery
+      ? baseResults.map((result) => searchData.docsById.get(result.id)).filter(Boolean)
+      : sortDocsForBrowse(searchData.docs);
+    const resultDocs = normalizedQuery
+      ? (activeFilters.length > 0
+          ? baseDocs.filter((doc) => matchesFilters(doc, filters))
+          : baseDocs)
+      : (activeFilters.length > 0
+          ? sortDocsForBrowse(searchData.docs.filter((doc) => matchesFilters(doc, filters)))
+          : []);
     const orderedResultDocs = normalizedQuery ? resultDocs : sortDocsForBrowse(resultDocs);
 
     return {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -639,6 +639,19 @@
     return false;
   }
 
+  function activateSearchEntryPoint() {
+    if (focusVisibleSearchInput()) {
+      return true;
+    }
+
+    if (!isSearchPageVisible()) {
+      navigateToSearchPageWithQuery(getCurrentSearchQuery());
+      return true;
+    }
+
+    return false;
+  }
+
   function shouldTargetDocsFrame(href) {
     const url = toUrl(href);
     return Boolean(url && url.origin === window.location.origin && isDocsPath(url.pathname) && url.pathname !== '/docs');
@@ -1676,7 +1689,7 @@
           return;
         }
 
-        if (focusVisibleSearchInput()) {
+        if (activateSearchEntryPoint()) {
           event.preventDefault();
         }
         return;

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -25,6 +25,7 @@
   const searchPageBoundAttribute = 'data-rw-search-page-bound';
   const shortcutsBoundAttribute = 'data-rw-search-shortcuts-bound';
   const popstateBoundFlag = '__rwDocsSearchPopstateBound';
+  const mobileFilterListenerBoundFlag = '__rwDocsSearchMobileFilterListenerBound';
   const mobileFilterMedia = window.matchMedia ? window.matchMedia('(max-width: 767px)') : null;
   const pageTypeSort = new Map([
     ['guide', 0],
@@ -1380,6 +1381,15 @@
     page.filtersPanel.hidden = isMobile && !searchPageState.filtersExpanded;
   }
 
+  function handleMobileFilterChange() {
+    const page = getSearchPageElements();
+    if (!page.root) {
+      return;
+    }
+
+    syncSearchPageFilterPanel(page);
+  }
+
   function setSearchPageBusy(page, isBusy) {
     page.results?.setAttribute('aria-busy', isBusy ? 'true' : 'false');
   }
@@ -1659,8 +1669,9 @@
       });
     });
 
-    if (mobileFilterMedia) {
-      mobileFilterMedia.addEventListener('change', () => syncSearchPageFilterPanel(page));
+    if (mobileFilterMedia && !window[mobileFilterListenerBoundFlag]) {
+      mobileFilterMedia.addEventListener('change', handleMobileFilterChange);
+      window[mobileFilterListenerBoundFlag] = '1';
     }
 
     if (!window[popstateBoundFlag]) {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -24,6 +24,7 @@
   const sidebarBoundAttribute = 'data-rw-search-sidebar-bound';
   const searchPageBoundAttribute = 'data-rw-search-page-bound';
   const shortcutsBoundAttribute = 'data-rw-search-shortcuts-bound';
+  const popstateBoundFlag = '__rwDocsSearchPopstateBound';
   const mobileFilterMedia = window.matchMedia ? window.matchMedia('(max-width: 767px)') : null;
   const pageTypeSort = new Map([
     ['guide', 0],
@@ -600,12 +601,16 @@
       return;
     }
 
+    const historyState = window.history.state && typeof window.history.state === 'object'
+      ? { ...window.history.state, rwDocsSearch: true }
+      : { rwDocsSearch: true };
+
     if (historyMode === 'push') {
-      window.history.pushState({ rwDocsSearch: true }, '', nextUrl);
+      window.history.pushState(historyState, '', nextUrl);
       return;
     }
 
-    window.history.replaceState({ rwDocsSearch: true }, '', nextUrl);
+    window.history.replaceState(historyState, '', nextUrl);
   }
 
   function consumeSearchPageAutofocusHash(page) {
@@ -670,6 +675,14 @@
 
     anchor.setAttribute('data-turbo-frame', '_top');
     anchor.removeAttribute('data-turbo-action');
+  }
+
+  function getDocsNavigationAttributes(href) {
+    if (shouldTargetDocsFrame(href)) {
+      return ` data-turbo-frame="${docsFrameId}" data-turbo-action="advance"`;
+    }
+
+    return ' data-turbo-frame="_top"';
   }
 
   function navigateToSearchPageWithQuery(query) {
@@ -1231,8 +1244,9 @@
     results.innerHTML = queryResults.map((item, index) => {
       const selected = index === activeIndex ? 'true' : 'false';
       const pageTypeBadge = renderPageTypeBadge(item);
+      const navigationAttributes = getDocsNavigationAttributes(item.path);
       return `<li id="docs-search-option-${index}" role="option" aria-selected="${selected}" tabindex="-1" class="docs-search-option" data-href="${escapeHtml(item.path)}">
-        <a href="${escapeHtml(item.path)}" data-turbo-frame="${docsFrameId}" data-turbo-action="advance">
+        <a href="${escapeHtml(item.path)}"${navigationAttributes}>
           <span class="docs-search-option-title-row">
             <span class="docs-search-option-title">${escapeHtml(item.title)}</span>
             ${pageTypeBadge}
@@ -1434,6 +1448,7 @@
       const button = createElement('button', null, 'Clear');
       button.type = 'button';
       button.dataset.rwClearFacetKey = filter.key;
+      button.setAttribute('aria-label', `Clear ${filter.label} filter`);
       pill.append(button);
       fragment.append(pill);
     });
@@ -1648,7 +1663,7 @@
       mobileFilterMedia.addEventListener('change', () => syncSearchPageFilterPanel(page));
     }
 
-    if (!window[shortcutsBoundAttribute]) {
+    if (!window[popstateBoundFlag]) {
       window.addEventListener('popstate', () => {
         const nextPage = getSearchPageElements();
         if (!nextPage.root) {
@@ -1662,7 +1677,7 @@
         nextPage.input.value = searchPageState.q;
         renderSearchPage();
       });
-      window[shortcutsBoundAttribute] = '1';
+      window[popstateBoundFlag] = '1';
     }
 
     renderSearchPage();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -355,6 +355,31 @@
     }
   }
 
+  function isVisibleInteractiveElement(element) {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+
+    if (element.hidden || element.closest('[inert]') || element.closest('[aria-hidden="true"]')) {
+      return false;
+    }
+
+    const styles = window.getComputedStyle(element);
+    if (styles.display === 'none' || styles.visibility === 'hidden') {
+      return false;
+    }
+
+    const rect = element.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return false;
+    }
+
+    return rect.bottom > 0
+      && rect.right > 0
+      && rect.top < window.innerHeight
+      && rect.left < window.innerWidth;
+  }
+
   function isEditableElement(target) {
     if (!(target instanceof Element)) {
       return false;
@@ -598,17 +623,40 @@
 
   function focusVisibleSearchInput() {
     const page = getSearchPageElements();
-    if (page.input) {
+    if (isVisibleInteractiveElement(page.input)) {
       page.input.focus();
       page.input.select?.();
-      return;
+      return true;
     }
 
     const sidebar = getSidebarSearchElements();
-    if (sidebar.input) {
+    if (isVisibleInteractiveElement(sidebar.input)) {
       sidebar.input.focus();
       sidebar.input.select?.();
+      return true;
     }
+
+    return false;
+  }
+
+  function shouldTargetDocsFrame(href) {
+    const url = toUrl(href);
+    return Boolean(url && url.origin === window.location.origin && isDocsPath(url.pathname) && url.pathname !== '/docs');
+  }
+
+  function applyDocsNavigationTarget(anchor, href) {
+    if (!(anchor instanceof HTMLAnchorElement)) {
+      return;
+    }
+
+    if (shouldTargetDocsFrame(href)) {
+      anchor.setAttribute('data-turbo-frame', docsFrameId);
+      anchor.setAttribute('data-turbo-action', 'advance');
+      return;
+    }
+
+    anchor.setAttribute('data-turbo-frame', '_top');
+    anchor.removeAttribute('data-turbo-action');
   }
 
   function navigateToSearchPageWithQuery(query) {
@@ -724,8 +772,7 @@
     const title = createElement('h2', 'docs-search-result-title');
     const link = createElement('a');
     link.href = doc.path;
-    link.setAttribute('data-turbo-frame', docsFrameId);
-    link.setAttribute('data-turbo-action', 'advance');
+    applyDocsNavigationTarget(link, doc.path);
     link.append(createHighlightedFragment(doc.title, queryTokens));
     title.append(link);
     article.append(title);
@@ -767,8 +814,7 @@
     view.recoveryLinks.forEach((link) => {
       const anchor = createElement('a', 'docs-search-page-no-results-link', link.title);
       anchor.href = link.href;
-      anchor.setAttribute('data-turbo-frame', docsFrameId);
-      anchor.setAttribute('data-turbo-action', 'advance');
+      applyDocsNavigationTarget(anchor, link.href);
       links.append(anchor);
     });
     container.append(links);
@@ -1613,8 +1659,9 @@
           return;
         }
 
-        event.preventDefault();
-        focusVisibleSearchInput();
+        if (focusVisibleSearchInput()) {
+          event.preventDefault();
+        }
         return;
       }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -1,9 +1,11 @@
 (() => {
   const indexUrl = '/docs/search-index.json';
+  const miniSearchUrl = '/docs/minisearch.min.js';
   const maxQueryLength = 500;
   const topResults = 8;
   const fetchTimeoutMs = 10000;
   const docsFrameId = 'doc-content';
+  const searchInputHash = '#docs-search-page-input';
   const enableDocsPartialRewrite = Boolean(
     document.querySelector('meta[name="rw-docs-static-partials"][content="1"]')
   );
@@ -12,10 +14,59 @@
     fuzzy: 0.1,
     boost: { title: 6, aliases: 4, headings: 3, keywords: 2, summary: 2, bodyText: 1 }
   };
-  let searchIndex = null;
-  let searchIndexLoadPromise = null;
+  const facetDefinitions = [
+    { key: 'pageType', label: 'Page Type', kind: 'chips' },
+    { key: 'component', label: 'Component', kind: 'select' },
+    { key: 'audience', label: 'Audience', kind: 'chips' },
+    { key: 'status', label: 'Status', kind: 'chips' }
+  ];
+  const facetKeys = facetDefinitions.map((facet) => facet.key);
   const sidebarBoundAttribute = 'data-rw-search-sidebar-bound';
   const searchPageBoundAttribute = 'data-rw-search-page-bound';
+  const shortcutsBoundAttribute = 'data-rw-search-shortcuts-bound';
+  const mobileFilterMedia = window.matchMedia ? window.matchMedia('(max-width: 767px)') : null;
+  const pageTypeSort = new Map([
+    ['guide', 0],
+    ['concept', 1],
+    ['tutorial', 2],
+    ['example', 3],
+    ['api-reference', 4],
+    ['api', 4],
+    ['troubleshooting', 5]
+  ]);
+  const statusSort = new Map([
+    ['stable', 0],
+    ['beta', 1],
+    ['preview', 2],
+    ['experimental', 3],
+    ['deprecated', 4]
+  ]);
+  const searchData = {
+    index: null,
+    docs: [],
+    docsById: new Map(),
+    facetValues: createEmptyFacetValues(),
+    loadPromise: null,
+    runtimePromise: null
+  };
+  const searchPageState = {
+    q: '',
+    pageType: '',
+    component: '',
+    audience: '',
+    status: '',
+    filtersExpanded: false,
+    loadState: 'idle'
+  };
+
+  function createEmptyFacetValues() {
+    return {
+      pageType: [],
+      component: [],
+      audience: [],
+      status: []
+    };
+  }
 
   function getSidebarSearchElements() {
     return {
@@ -26,11 +77,23 @@
   }
 
   function getSearchPageElements() {
+    const root = document.getElementById('docs-search-page');
     return {
-      root: document.getElementById('docs-search-page'),
+      root,
       input: document.getElementById('docs-search-page-input'),
+      status: document.getElementById('docs-search-page-status'),
+      filtersToggle: document.getElementById('docs-search-page-filters-toggle'),
+      filtersPanel: document.getElementById('docs-search-page-filters-panel'),
+      filters: document.getElementById('docs-search-page-filters'),
+      activeFilters: document.getElementById('docs-search-page-active-filters'),
+      starter: document.getElementById('docs-search-page-starter'),
+      failure: document.getElementById('docs-search-page-failure'),
+      retry: document.getElementById('docs-search-page-retry'),
+      resultsMeta: document.getElementById('docs-search-page-results-meta'),
       results: document.getElementById('docs-search-page-results'),
-      status: document.getElementById('docs-search-page-status')
+      suggestionButtons: root
+        ? Array.from(root.querySelectorAll('[data-rw-search-suggestion]'))
+        : []
     };
   }
 
@@ -70,8 +133,6 @@
           return headers[key] ?? null;
         }
       }
-
-      return null;
     }
 
     return null;
@@ -85,11 +146,7 @@
 
     const path = url.pathname;
 
-    if (!isDocsPath(path)) {
-      return null;
-    }
-
-    if (path === '/docs') {
+    if (!isDocsPath(path) || path === '/docs') {
       return null;
     }
 
@@ -174,11 +231,7 @@
       const requestUrl = event.detail?.url;
       const canonicalUrl = toUrl(requestUrl);
       const partialUrl = toDocsPartialUrl(canonicalUrl);
-      if (!partialUrl) {
-        return;
-      }
-
-      if (!(requestUrl instanceof URL)) {
+      if (!partialUrl || !(requestUrl instanceof URL)) {
         return;
       }
 
@@ -231,6 +284,10 @@
       .replaceAll("'", '&#39;');
   }
 
+  function escapeRegExp(value) {
+    return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
   function normalizeBadgeVariant(value) {
     const normalized = String(value ?? '')
       .trim()
@@ -250,67 +307,16 @@
     return `<span class="docs-page-badge docs-page-badge--${escapeHtml(variant)}">${escapeHtml(label)}</span>`;
   }
 
-  function renderMetadataChip(label, value) {
-    const normalizedValue = String(value ?? '').trim();
-    if (!normalizedValue) {
-      return '';
-    }
-
-    return `<span class="docs-metadata-chip">${escapeHtml(label)}: ${escapeHtml(normalizedValue)}</span>`;
-  }
-
-  function getLocationLabel(item) {
-    const context = item?.navGroup || item?.component || '';
-    const path = item?.path || '';
-
-    if (context && path) {
-      return `${context} • ${path}`;
-    }
-
-    return context || path;
-  }
-
   function normalizeQuery(value) {
     return String(value ?? '').trim().slice(0, maxQueryLength);
   }
 
+  function normalizeFacetValue(value) {
+    return String(value ?? '').trim();
+  }
+
   function formatQueryForStatus(value) {
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: strips non-printable control characters from status text
     return normalizeQuery(value).replace(/[\u0000-\u001f\u007f]/g, '').replace(/\s+/g, ' ');
-  }
-
-  async function init() {
-    try {
-      await ensureSearchIndexLoaded();
-      bindSidebar();
-      bindSearchPage();
-    } catch (err) {
-      reportInitError(err);
-    }
-  }
-
-  function reportInitError(err) {
-    console.error(err);
-    const message = getErrorMessage(err);
-    const sidebar = getSidebarSearchElements();
-    const page = getSearchPageElements();
-    setStatus(sidebar.status, message);
-    setStatus(page.status, message);
-  }
-
-  async function ensureSearchIndexLoaded() {
-    if (searchIndex) {
-      return;
-    }
-
-    if (!searchIndexLoadPromise) {
-      searchIndexLoadPromise = loadIndex().catch((err) => {
-        searchIndexLoadPromise = null;
-        throw err;
-      });
-    }
-
-    await searchIndexLoadPromise;
   }
 
   function getErrorMessage(err) {
@@ -330,7 +336,695 @@
     return 'Search is temporarily unavailable.';
   }
 
+  function createElement(tagName, className, textContent) {
+    const element = document.createElement(tagName);
+    if (className) {
+      element.className = className;
+    }
+
+    if (textContent !== undefined) {
+      element.textContent = textContent;
+    }
+
+    return element;
+  }
+
+  function setStatus(node, text) {
+    if (node) {
+      node.textContent = text;
+    }
+  }
+
+  function isEditableElement(target) {
+    if (!(target instanceof Element)) {
+      return false;
+    }
+
+    return Boolean(target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"], [role="textbox"]'));
+  }
+
+  function isSearchInputElement(target) {
+    if (!(target instanceof Element)) {
+      return false;
+    }
+
+    return Boolean(target.closest('#docs-search-input, #docs-search-page-input'));
+  }
+
+  function isSearchPageVisible() {
+    return Boolean(getSearchPageElements().root);
+  }
+
+  function getCurrentSearchQuery() {
+    const page = getSearchPageElements();
+    const pageQuery = normalizeQuery(page.input?.value);
+    if (pageQuery) {
+      return pageQuery;
+    }
+
+    return normalizeQuery(getSidebarSearchElements().input?.value);
+  }
+
+  function formatFacetValue(value) {
+    const normalized = normalizeFacetValue(value);
+    if (!normalized) {
+      return '';
+    }
+
+    const lower = normalized.toLowerCase();
+    if (lower === 'api' || lower === 'api-reference') {
+      return 'API Reference';
+    }
+
+    return normalized
+      .split(/[-_\s]+/)
+      .filter(Boolean)
+      .map((part) => part === part.toUpperCase() ? part : `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+      .join(' ');
+  }
+
+  function getLocationLabel(item) {
+    const context = item?.navGroup || item?.component || '';
+    const path = item?.path || '';
+
+    if (context && path) {
+      return `${context} • ${path}`;
+    }
+
+    return context || path;
+  }
+
+  function normalizeSearchDocument(doc) {
+    const toStringArray = (value) => Array.isArray(value)
+      ? value.map((item) => String(item ?? '').trim()).filter(Boolean)
+      : [];
+    const orderValue = Number.parseInt(String(doc?.order ?? ''), 10);
+
+    return {
+      id: String(doc?.id ?? doc?.path ?? ''),
+      path: String(doc?.path ?? ''),
+      title: String(doc?.title ?? '').trim(),
+      summary: String(doc?.summary ?? '').trim(),
+      headings: toStringArray(doc?.headings),
+      bodyText: String(doc?.bodyText ?? ''),
+      snippet: String(doc?.snippet ?? '').trim(),
+      pageType: normalizeFacetValue(doc?.pageType),
+      pageTypeLabel: String(doc?.pageTypeLabel ?? '').trim(),
+      pageTypeVariant: normalizeFacetValue(doc?.pageTypeVariant),
+      audience: normalizeFacetValue(doc?.audience),
+      component: normalizeFacetValue(doc?.component),
+      aliases: toStringArray(doc?.aliases),
+      keywords: toStringArray(doc?.keywords),
+      status: normalizeFacetValue(doc?.status),
+      navGroup: String(doc?.navGroup ?? '').trim(),
+      order: Number.isFinite(orderValue) ? orderValue : null,
+      relatedPages: toStringArray(doc?.relatedPages),
+      breadcrumbs: toStringArray(doc?.breadcrumbs)
+    };
+  }
+
+  function sortFacetValues(key, values) {
+    const list = [...values];
+    if (key === 'pageType') {
+      return list.sort((a, b) => (pageTypeSort.get(a.toLowerCase()) ?? 100) - (pageTypeSort.get(b.toLowerCase()) ?? 100) || a.localeCompare(b));
+    }
+
+    if (key === 'status') {
+      return list.sort((a, b) => (statusSort.get(a.toLowerCase()) ?? 100) - (statusSort.get(b.toLowerCase()) ?? 100) || a.localeCompare(b));
+    }
+
+    return list.sort((a, b) => a.localeCompare(b));
+  }
+
+  function deriveFacetValues(docs) {
+    const values = createEmptyFacetValues();
+    for (const doc of docs) {
+      for (const key of facetKeys) {
+        const value = normalizeFacetValue(doc[key]);
+        if (value) {
+          values[key].push(value);
+        }
+      }
+    }
+
+    for (const key of facetKeys) {
+      values[key] = sortFacetValues(key, [...new Set(values[key])]);
+    }
+
+    return values;
+  }
+
+  function getSearchFilters(state) {
+    return {
+      pageType: normalizeFacetValue(state.pageType),
+      component: normalizeFacetValue(state.component),
+      audience: normalizeFacetValue(state.audience),
+      status: normalizeFacetValue(state.status)
+    };
+  }
+
+  function hasActiveFilters(filters) {
+    return facetKeys.some((key) => Boolean(filters[key]));
+  }
+
+  function matchesFilters(doc, filters, skipKey = null) {
+    return facetKeys.every((key) => {
+      if (key === skipKey) {
+        return true;
+      }
+
+      const expected = normalizeFacetValue(filters[key]);
+      if (!expected) {
+        return true;
+      }
+
+      return normalizeFacetValue(doc[key]) === expected;
+    });
+  }
+
+  function matchesStoredResult(result, filters) {
+    return facetKeys.every((key) => {
+      const expected = normalizeFacetValue(filters[key]);
+      if (!expected) {
+        return true;
+      }
+
+      return normalizeFacetValue(result?.[key]) === expected;
+    });
+  }
+
+  function compareBrowseDocs(left, right) {
+    const leftTypeRank = pageTypeSort.get((left.pageType || '').toLowerCase()) ?? 100;
+    const rightTypeRank = pageTypeSort.get((right.pageType || '').toLowerCase()) ?? 100;
+    if (leftTypeRank !== rightTypeRank) {
+      return leftTypeRank - rightTypeRank;
+    }
+
+    const leftOrder = left.order ?? Number.MAX_SAFE_INTEGER;
+    const rightOrder = right.order ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrder !== rightOrder) {
+      return leftOrder - rightOrder;
+    }
+
+    return left.title.localeCompare(right.title, undefined, { sensitivity: 'base' })
+      || left.path.localeCompare(right.path, undefined, { sensitivity: 'base' });
+  }
+
+  function sortDocsForBrowse(docs) {
+    return [...docs].sort(compareBrowseDocs);
+  }
+
+  function readSearchPageStateFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      q: normalizeQuery(params.get('q')),
+      pageType: normalizeFacetValue(params.get('pageType')),
+      component: normalizeFacetValue(params.get('component')),
+      audience: normalizeFacetValue(params.get('audience')),
+      status: normalizeFacetValue(params.get('status'))
+    };
+  }
+
+  function writeSearchPageUrl(historyMode = 'replace') {
+    if (!isSearchPageVisible()) {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    const filters = getSearchFilters(searchPageState);
+    const query = normalizeQuery(searchPageState.q);
+
+    if (query) {
+      url.searchParams.set('q', query);
+    } else {
+      url.searchParams.delete('q');
+    }
+
+    for (const key of facetKeys) {
+      if (filters[key]) {
+        url.searchParams.set(key, filters[key]);
+      } else {
+        url.searchParams.delete(key);
+      }
+    }
+
+    url.hash = '';
+    const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+    const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    if (currentUrl === nextUrl) {
+      return;
+    }
+
+    if (historyMode === 'push') {
+      window.history.pushState({ rwDocsSearch: true }, '', nextUrl);
+      return;
+    }
+
+    window.history.replaceState({ rwDocsSearch: true }, '', nextUrl);
+  }
+
+  function consumeSearchPageAutofocusHash(page) {
+    if (!page.input || window.location.hash !== searchInputHash) {
+      return;
+    }
+
+    page.input.focus();
+    page.input.select?.();
+
+    const url = new URL(window.location.href);
+    url.hash = '';
+    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}`);
+  }
+
+  function focusVisibleSearchInput() {
+    const page = getSearchPageElements();
+    if (page.input) {
+      page.input.focus();
+      page.input.select?.();
+      return;
+    }
+
+    const sidebar = getSidebarSearchElements();
+    if (sidebar.input) {
+      sidebar.input.focus();
+      sidebar.input.select?.();
+    }
+  }
+
+  function navigateToSearchPageWithQuery(query) {
+    const url = new URL('/docs/search', window.location.origin);
+    const normalized = normalizeQuery(query);
+    if (normalized) {
+      url.searchParams.set('q', normalized);
+    }
+
+    url.hash = searchInputHash;
+    window.location.assign(url.toString());
+  }
+
+  function getHighlightTokens(query) {
+    return [...new Set(
+      normalizeQuery(query)
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter((token) => token.length > 1)
+    )].sort((left, right) => right.length - left.length);
+  }
+
+  function createHighlightedFragment(text, tokens) {
+    const fragment = document.createDocumentFragment();
+    const source = String(text ?? '');
+    if (!source) {
+      return fragment;
+    }
+
+    if (!tokens.length) {
+      fragment.append(source);
+      return fragment;
+    }
+
+    const regex = new RegExp(`(${tokens.map(escapeRegExp).join('|')})`, 'ig');
+    let lastIndex = 0;
+
+    for (const match of source.matchAll(regex)) {
+      const index = match.index ?? 0;
+      if (index > lastIndex) {
+        fragment.append(source.slice(lastIndex, index));
+      }
+
+      const mark = createElement('mark');
+      mark.textContent = match[0];
+      fragment.append(mark);
+      lastIndex = index + match[0].length;
+    }
+
+    if (lastIndex < source.length) {
+      fragment.append(source.slice(lastIndex));
+    }
+
+    return fragment;
+  }
+
+  function buildBreadcrumbLabels(doc) {
+    if (Array.isArray(doc.breadcrumbs) && doc.breadcrumbs.length > 0) {
+      return doc.breadcrumbs;
+    }
+
+    const fallback = [];
+    if (doc.navGroup) {
+      fallback.push(doc.navGroup);
+    }
+
+    const path = String(doc.path ?? '');
+    const pathPart = path.split('#')[0];
+    const pathSegments = pathPart
+      .replace(/^\/docs\/?/i, '')
+      .split('/')
+      .map((segment) => {
+        try {
+          return decodeURIComponent(segment);
+        } catch {
+          return segment;
+        }
+      })
+      .filter(Boolean);
+
+    if (pathSegments.length > 1) {
+      fallback.push(pathSegments[pathSegments.length - 2]);
+    }
+
+    return [...new Set(fallback.filter(Boolean))];
+  }
+
+  function createSearchResultBadge(text, secondary = false) {
+    const badge = createElement(
+      'span',
+      secondary ? 'docs-search-result-badge docs-search-result-badge-secondary' : 'docs-search-result-badge',
+      text
+    );
+    return badge;
+  }
+
+  function createSearchResultArticle(doc, queryTokens) {
+    const article = createElement('article', 'docs-search-result');
+
+    const breadcrumbs = buildBreadcrumbLabels(doc);
+    if (breadcrumbs.length > 0) {
+      const breadcrumbRow = createElement('div', 'docs-search-result-breadcrumbs');
+      breadcrumbs.forEach((label, index) => {
+        if (index > 0) {
+          breadcrumbRow.append(createElement('span', 'docs-search-result-breadcrumb-separator', '/'));
+        }
+
+        breadcrumbRow.append(createElement('span', null, label));
+      });
+      article.append(breadcrumbRow);
+    }
+
+    const title = createElement('h2', 'docs-search-result-title');
+    const link = createElement('a');
+    link.href = doc.path;
+    link.setAttribute('data-turbo-frame', docsFrameId);
+    link.setAttribute('data-turbo-action', 'advance');
+    link.append(createHighlightedFragment(doc.title, queryTokens));
+    title.append(link);
+    article.append(title);
+
+    const badgeRow = createElement('div', 'docs-search-result-badges');
+    if (doc.pageType) {
+      badgeRow.append(createSearchResultBadge(formatFacetValue(doc.pageType)));
+    }
+
+    if (doc.component) {
+      badgeRow.append(createSearchResultBadge(formatFacetValue(doc.component)));
+    }
+
+    if (doc.audience) {
+      badgeRow.append(createSearchResultBadge(formatFacetValue(doc.audience), true));
+    }
+
+    if (doc.status) {
+      badgeRow.append(createSearchResultBadge(formatFacetValue(doc.status), true));
+    }
+
+    if (badgeRow.childNodes.length > 0) {
+      article.append(badgeRow);
+    }
+
+    const snippet = createElement('p', 'docs-search-result-snippet');
+    snippet.append(createHighlightedFragment(doc.summary || doc.snippet || '', queryTokens));
+    article.append(snippet);
+
+    return article;
+  }
+
+  function createNoResultsRecovery(view) {
+    const container = createElement('section', 'docs-search-page-no-results');
+    container.append(createElement('h2', 'docs-search-page-section-title', 'No pages matched this exact combination.'));
+    container.append(createElement('p', 'docs-search-page-starter-copy', 'Try a broader query, clear one filter, or follow one of these recovery paths.'));
+
+    const links = createElement('div', 'docs-search-page-no-results-links');
+    view.recoveryLinks.forEach((link) => {
+      const anchor = createElement('a', 'docs-search-page-no-results-link', link.title);
+      anchor.href = link.href;
+      anchor.setAttribute('data-turbo-frame', docsFrameId);
+      anchor.setAttribute('data-turbo-action', 'advance');
+      links.append(anchor);
+    });
+    container.append(links);
+    return container;
+  }
+
+  function createLoadingSkeletons(count = 3) {
+    const fragment = document.createDocumentFragment();
+    for (let index = 0; index < count; index += 1) {
+      const article = createElement('article', 'docs-search-result docs-search-result-skeleton');
+      article.setAttribute('aria-hidden', 'true');
+      article.append(createElement('div', 'docs-search-skeleton docs-search-skeleton-title'));
+      article.append(createElement('div', 'docs-search-skeleton docs-search-skeleton-meta'));
+      article.append(createElement('div', 'docs-search-skeleton docs-search-skeleton-line'));
+      article.append(createElement('div', 'docs-search-skeleton docs-search-skeleton-line docs-search-skeleton-line-short'));
+      fragment.append(article);
+    }
+    return fragment;
+  }
+
+  function selectRecoveryDoc(docs, predicate) {
+    return sortDocsForBrowse(docs.filter(predicate))[0] ?? null;
+  }
+
+  function normalizeDocReference(value) {
+    return String(value ?? '')
+      .trim()
+      .replace(/^\/docs\/?/i, '')
+      .replace(/\.html$/i, '')
+      .replace(/\.md$/i, '')
+      .replace(/^\/+/, '')
+      .toLowerCase();
+  }
+
+  function resolveRelatedDoc(reference) {
+    const normalizedReference = normalizeDocReference(reference);
+    if (!normalizedReference) {
+      return null;
+    }
+
+    const directMatch = searchData.docsById.get(reference);
+    if (directMatch) {
+      return directMatch;
+    }
+
+    return searchData.docs.find((doc) => {
+      const idReference = normalizeDocReference(doc.id);
+      const pathReference = normalizeDocReference(doc.path);
+      const titleReference = String(doc.title ?? '').trim().toLowerCase();
+      return normalizedReference === idReference
+        || normalizedReference === pathReference
+        || normalizedReference === titleReference;
+    }) ?? null;
+  }
+
+  function buildRecoveryLinks(sourceDocs) {
+    const preferredDocs = sourceDocs.length > 0 ? sourceDocs : searchData.docs;
+    const allDocs = searchData.docs;
+    const links = [];
+
+    const pushLink = (doc, title = null) => {
+      if (!doc) {
+        return;
+      }
+
+      if (links.some((link) => link.href === doc.path)) {
+        return;
+      }
+
+      links.push({ title: title || doc.title, href: doc.path });
+    };
+
+    const pushRelatedLinks = (docs) => {
+      for (const doc of docs.slice(0, 5)) {
+        for (const reference of doc.relatedPages || []) {
+          pushLink(resolveRelatedDoc(reference));
+          if (links.length >= 3) {
+            return;
+          }
+        }
+      }
+    };
+
+    pushRelatedLinks(preferredDocs);
+
+    if (links.length < 3) {
+      pushLink(
+        selectRecoveryDoc(
+          preferredDocs,
+          (doc) => ['guide', 'concept', 'tutorial', 'troubleshooting'].includes((doc.pageType || '').toLowerCase())
+            || doc.path.includes('/guides/')),
+        'Browse guides');
+      pushLink(
+        selectRecoveryDoc(
+          preferredDocs,
+          (doc) => (doc.pageType || '').toLowerCase() === 'example'
+            || doc.path.includes('/examples/')),
+        'Open an example');
+      pushLink(
+        selectRecoveryDoc(
+          preferredDocs,
+          (doc) => ['api', 'api-reference'].includes((doc.pageType || '').toLowerCase())
+            || doc.path.includes('/Namespaces/')),
+        'Explore API reference');
+    }
+
+    if (links.length < 3) {
+      const namespacesDoc = selectRecoveryDoc(allDocs, (doc) => doc.path.endsWith('/Namespaces.html') || doc.path === '/docs/Namespaces');
+      pushLink(namespacesDoc, 'Browse namespaces');
+    }
+
+    if (links.length < 3) {
+      links.push({ title: 'Documentation index', href: '/docs' });
+    }
+
+    return links;
+  }
+
+  function deriveFacetState(baseDocs, filters) {
+    return facetDefinitions.map((facet) => {
+      const selectedValue = normalizeFacetValue(filters[facet.key]);
+      const siblingDocs = baseDocs.filter((doc) => matchesFilters(doc, filters, facet.key));
+      const options = searchData.facetValues[facet.key].map((value) => {
+        const count = siblingDocs.filter((doc) => normalizeFacetValue(doc[facet.key]) === value).length;
+        return {
+          value,
+          count,
+          selected: value === selectedValue,
+          disabled: count === 0 && value !== selectedValue
+        };
+      });
+
+      return {
+        ...facet,
+        options,
+        selectedValue
+      };
+    });
+  }
+
+  function runRankedSearch(query, filters, maxResults = null) {
+    if (!searchData.index) {
+      return [];
+    }
+
+    const normalizedQuery = normalizeQuery(query);
+    const filterFn = hasActiveFilters(filters)
+      ? (result) => matchesStoredResult(result, filters)
+      : undefined;
+
+    let results;
+    if (normalizedQuery) {
+      results = searchData.index.search(normalizedQuery, {
+        ...defaultSearchOptions,
+        filter: filterFn
+      });
+    } else if (hasActiveFilters(filters)) {
+      results = sortDocsForBrowse(searchData.docs.filter((doc) => matchesFilters(doc, filters)))
+        .map((doc) => ({ id: doc.id }));
+    } else {
+      results = [];
+    }
+
+    if (typeof maxResults === 'number') {
+      return results.slice(0, maxResults);
+    }
+
+    return results;
+  }
+
+  function buildSearchView() {
+    const filters = getSearchFilters(searchPageState);
+    const activeFilters = facetDefinitions
+      .map((facet) => {
+        const value = normalizeFacetValue(filters[facet.key]);
+        if (!value) {
+          return null;
+        }
+
+        return {
+          key: facet.key,
+          label: facet.label,
+          value,
+          displayValue: formatFacetValue(value)
+        };
+      })
+      .filter(Boolean);
+    const normalizedQuery = normalizeQuery(searchPageState.q);
+    const isStarter = !normalizedQuery && activeFilters.length === 0;
+    const baseDocs = normalizedQuery
+      ? runRankedSearch(normalizedQuery, createEmptyFacetValues()).map((result) => searchData.docsById.get(result.id)).filter(Boolean)
+      : sortDocsForBrowse(searchData.docs);
+    const resultDocs = normalizedQuery || activeFilters.length > 0
+      ? runRankedSearch(normalizedQuery, filters).map((result) => searchData.docsById.get(result.id)).filter(Boolean)
+      : [];
+    const orderedResultDocs = normalizedQuery ? resultDocs : sortDocsForBrowse(resultDocs);
+
+    return {
+      normalizedQuery,
+      activeFilters,
+      facets: deriveFacetState(baseDocs, filters),
+      resultDocs: orderedResultDocs,
+      isStarter,
+      recoveryLinks: buildRecoveryLinks(baseDocs)
+    };
+  }
+
+  function ensureMiniSearchLoaded() {
+    if (window.MiniSearch) {
+      return Promise.resolve(window.MiniSearch);
+    }
+
+    if (!searchData.runtimePromise) {
+      const existing = document.querySelector('script[data-rw-search-runtime="minisearch"]');
+      searchData.runtimePromise = new Promise((resolve, reject) => {
+        const script = existing || document.createElement('script');
+
+        const cleanup = () => {
+          script.removeEventListener('load', onLoad);
+          script.removeEventListener('error', onError);
+        };
+
+        const onLoad = () => {
+          cleanup();
+          if (window.MiniSearch) {
+            resolve(window.MiniSearch);
+          } else {
+            reject(new Error('MiniSearch runtime is not available.'));
+          }
+        };
+
+        const onError = () => {
+          cleanup();
+          reject(new Error('MiniSearch runtime is not available.'));
+        };
+
+        script.addEventListener('load', onLoad, { once: true });
+        script.addEventListener('error', onError, { once: true });
+
+        if (!existing) {
+          script.src = miniSearchUrl;
+          script.defer = true;
+          script.dataset.rwSearchRuntime = 'minisearch';
+          document.head.append(script);
+        }
+      }).catch((error) => {
+        searchData.runtimePromise = null;
+        throw error;
+      });
+    }
+
+    return searchData.runtimePromise;
+  }
+
   async function loadIndex() {
+    await ensureMiniSearchLoaded();
     if (!window.MiniSearch) {
       throw new Error('MiniSearch runtime is not available.');
     }
@@ -343,12 +1037,12 @@
       // Keep the request credential mode aligned with the layout preload so
       // the browser can reuse the preloaded response instead of warning.
       response = await fetch(indexUrl, { credentials: 'include', signal: controller.signal });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
         throw new Error('Search index request timed out.');
       }
 
-      throw err;
+      throw error;
     } finally {
       window.clearTimeout(timeout);
     }
@@ -358,41 +1052,129 @@
     }
 
     const payload = await response.json();
-    const docs = Array.isArray(payload.documents) ? payload.documents : [];
+    const docs = Array.isArray(payload.documents)
+      ? payload.documents.map(normalizeSearchDocument).filter((doc) => doc.id && doc.path && doc.title)
+      : [];
 
     const MiniSearch = window.MiniSearch;
-    searchIndex = new MiniSearch({
+    const index = new MiniSearch({
       fields: ['title', 'aliases', 'keywords', 'summary', 'headings', 'bodyText'],
       storeFields: ['id', 'path', 'title', 'snippet', 'summary', 'pageType', 'pageTypeLabel', 'pageTypeVariant', 'component', 'audience', 'status', 'navGroup'],
       searchOptions: defaultSearchOptions
     });
 
-    searchIndex.addAll(docs.map((d) => ({
-      id: d.id,
-      path: d.path,
-      title: d.title,
-      aliases: Array.isArray(d.aliases) ? d.aliases.join(' ') : '',
-      keywords: Array.isArray(d.keywords) ? d.keywords.join(' ') : '',
-      summary: d.summary ?? '',
-      headings: Array.isArray(d.headings) ? d.headings.join(' ') : '',
-      bodyText: d.bodyText ?? '',
-      snippet: d.snippet ?? '',
-      pageType: d.pageType ?? '',
-      pageTypeLabel: d.pageTypeLabel ?? '',
-      pageTypeVariant: d.pageTypeVariant ?? '',
-      component: d.component ?? '',
-      audience: d.audience ?? '',
-      status: d.status ?? '',
-      navGroup: d.navGroup ?? ''
+    index.addAll(docs.map((doc) => ({
+      id: doc.id,
+      path: doc.path,
+      title: doc.title,
+      aliases: doc.aliases.join(' '),
+      keywords: doc.keywords.join(' '),
+      summary: doc.summary,
+      headings: doc.headings.join(' '),
+      bodyText: doc.bodyText,
+      snippet: doc.snippet,
+      pageType: doc.pageType,
+      pageTypeLabel: doc.pageTypeLabel ?? '',
+      pageTypeVariant: doc.pageTypeVariant ?? '',
+      component: doc.component,
+      audience: doc.audience,
+      status: doc.status,
+      navGroup: doc.navGroup
     })));
+
+    searchData.index = index;
+    searchData.docs = docs;
+    searchData.docsById = new Map(docs.map((doc) => [doc.id, doc]));
+    searchData.facetValues = deriveFacetValues(docs);
   }
 
-  function query(q, max = topResults) {
-    if (!searchIndex || !q || !q.trim()) {
-      return [];
+  function ensureSearchResourcesLoaded() {
+    if (searchData.index) {
+      return Promise.resolve();
     }
 
-    return searchIndex.search(q.trim(), defaultSearchOptions).slice(0, max);
+    if (!searchData.loadPromise) {
+      searchData.loadPromise = loadIndex().catch((error) => {
+        searchData.loadPromise = null;
+        throw error;
+      });
+    }
+
+    return searchData.loadPromise;
+  }
+
+  function clearSidebarResults(sidebar) {
+    if (!sidebar.results) {
+      return;
+    }
+
+    sidebar.results.innerHTML = '';
+    sidebar.results.classList.add('hidden');
+    sidebar.input?.removeAttribute('aria-activedescendant');
+  }
+
+  function renderSidebarMessage(sidebar, message) {
+    if (!sidebar.results) {
+      return;
+    }
+
+    sidebar.results.classList.remove('hidden');
+    sidebar.results.innerHTML = `<li class="docs-search-empty" role="presentation">${escapeHtml(message)}</li>`;
+    setStatus(sidebar.status, message);
+  }
+
+  function renderSidebarResults(sidebar, queryResults, query, activeIndex = -1) {
+    const { input, results, status } = sidebar;
+    if (!results) {
+      return;
+    }
+
+    if (!query) {
+      clearSidebarResults(sidebar);
+      setStatus(status, '');
+      return;
+    }
+
+    if (!queryResults.length) {
+      renderSidebarMessage(sidebar, 'No matching docs found.');
+      return;
+    }
+
+    results.classList.remove('hidden');
+    results.innerHTML = queryResults.map((item, index) => {
+      const selected = index === activeIndex ? 'true' : 'false';
+      const pageTypeBadge = renderPageTypeBadge(item);
+      return `<li id="docs-search-option-${index}" role="option" aria-selected="${selected}" tabindex="-1" class="docs-search-option" data-href="${escapeHtml(item.path)}">
+        <a href="${escapeHtml(item.path)}" data-turbo-frame="${docsFrameId}" data-turbo-action="advance">
+          <span class="docs-search-option-title-row">
+            <span class="docs-search-option-title">${escapeHtml(item.title)}</span>
+            ${pageTypeBadge}
+          </span>
+          <span class="docs-search-option-path">${escapeHtml(getLocationLabel(item))}</span>
+        </a>
+      </li>`;
+    }).join('');
+
+    setStatus(status, `${queryResults.length} result(s).`);
+    if (activeIndex >= 0 && input) {
+      input.setAttribute('aria-activedescendant', `docs-search-option-${activeIndex}`);
+    }
+  }
+
+  function setActiveSidebarOption(items, activeIndex, input) {
+    items.forEach((item, index) => {
+      const selected = index === activeIndex;
+      item.setAttribute('aria-selected', selected ? 'true' : 'false');
+      item.classList.toggle('active', selected);
+    });
+
+    if (activeIndex >= 0 && items[activeIndex] && input) {
+      input.setAttribute('aria-activedescendant', items[activeIndex].id);
+      items[activeIndex].scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+      return;
+    }
+
+    input?.removeAttribute('aria-activedescendant');
   }
 
   function bindSidebar() {
@@ -407,27 +1189,56 @@
     }
 
     input.setAttribute(sidebarBoundAttribute, '1');
-
     let activeIndex = -1;
     let lastRenderedQuery = '';
 
-    const runSearch = debounce(() => {
-      const q = normalizeQuery(input.value);
-      const queryResults = query(q, topResults);
-      activeIndex = queryResults.length > 0 ? 0 : -1;
-      renderSidebarResults(sidebar, queryResults, q, activeIndex);
-      lastRenderedQuery = q;
+    const performSearch = debounce(async () => {
+      const query = normalizeQuery(input.value);
+      if (query !== input.value) {
+        input.value = query;
+      }
+
+      if (!query) {
+        activeIndex = -1;
+        lastRenderedQuery = '';
+        clearSidebarResults(sidebar);
+        setStatus(sidebar.status, '');
+        return;
+      }
+
+      try {
+        if (!searchData.index) {
+          renderSidebarMessage(sidebar, 'Loading search index...');
+        }
+
+        await ensureSearchResourcesLoaded();
+        const queryResults = runRankedSearch(query, createEmptyFacetValues(), topResults);
+        activeIndex = queryResults.length > 0 ? 0 : -1;
+        renderSidebarResults(sidebar, queryResults, query, activeIndex);
+        lastRenderedQuery = query;
+      } catch (error) {
+        activeIndex = -1;
+        renderSidebarMessage(sidebar, getErrorMessage(error));
+      }
     }, 120);
+
+    input.addEventListener('focus', () => {
+      ensureSearchResourcesLoaded().catch((error) => {
+        if (normalizeQuery(input.value)) {
+          renderSidebarMessage(sidebar, getErrorMessage(error));
+        }
+      });
+    });
 
     input.addEventListener('input', () => {
       activeIndex = -1;
-      runSearch();
+      performSearch();
     });
 
-    input.addEventListener('keydown', (event) => {
+    input.addEventListener('keydown', async (event) => {
       const currentQuery = normalizeQuery(input.value);
-      if (currentQuery !== lastRenderedQuery) {
-        const refreshed = query(currentQuery, topResults);
+      if (currentQuery && currentQuery !== lastRenderedQuery && searchData.index) {
+        const refreshed = runRankedSearch(currentQuery, createEmptyFacetValues(), topResults);
         activeIndex = refreshed.length > 0 ? 0 : -1;
         renderSidebarResults(sidebar, refreshed, currentQuery, activeIndex);
         lastRenderedQuery = currentQuery;
@@ -450,27 +1261,221 @@
         if (activeIndex >= 0 && items[activeIndex]) {
           event.preventDefault();
           const anchor = items[activeIndex].querySelector('a');
-          if (anchor && typeof anchor.click === 'function') {
-            anchor.click();
-          } else {
-            const href = items[activeIndex].getAttribute('data-href');
-            if (href) {
-              window.location.assign(href);
-            }
-          }
+          anchor?.click();
         }
       } else if (event.key === 'Escape') {
-        results.innerHTML = '';
-        results.classList.add('hidden');
-        input.removeAttribute('aria-activedescendant');
+        clearSidebarResults(sidebar);
       }
     });
   }
 
+  function syncSearchPageFilterPanel(page) {
+    if (!page.filtersPanel || !page.filtersToggle) {
+      return;
+    }
+
+    const isMobile = mobileFilterMedia ? mobileFilterMedia.matches : window.innerWidth < 768;
+    page.filtersToggle.setAttribute('aria-expanded', isMobile && searchPageState.filtersExpanded ? 'true' : 'false');
+    page.filtersPanel.hidden = isMobile && !searchPageState.filtersExpanded;
+  }
+
+  function setSearchPageBusy(page, isBusy) {
+    page.results?.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+  }
+
+  function renderSearchPageFilters(page, view) {
+    if (!page.filters) {
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    view.facets.forEach((facet) => {
+      const group = createElement('section', 'docs-search-page-filter-group');
+      group.append(createElement('h2', 'docs-search-page-filter-label', facet.label));
+
+      if (facet.kind === 'select') {
+        const select = createElement('select', 'docs-search-page-select');
+        select.dataset.rwFacetKey = facet.key;
+        const emptyOption = createElement('option', null, `All ${facet.label}`);
+        emptyOption.value = '';
+        select.append(emptyOption);
+
+        facet.options.forEach((option) => {
+          const optionElement = createElement('option', null, `${formatFacetValue(option.value)}${option.count > 0 ? ` (${option.count})` : ''}`);
+          optionElement.value = option.value;
+          optionElement.selected = option.selected;
+          optionElement.disabled = option.disabled;
+          select.append(optionElement);
+        });
+
+        group.append(select);
+      } else {
+        const row = createElement('div', 'docs-search-page-chip-row');
+        facet.options.forEach((option) => {
+          const chip = createElement('button', 'docs-search-page-chip', formatFacetValue(option.value));
+          chip.type = 'button';
+          chip.dataset.rwFacetKey = facet.key;
+          chip.dataset.rwFacetValue = option.value;
+          chip.setAttribute('aria-pressed', option.selected ? 'true' : 'false');
+          chip.disabled = option.disabled;
+          row.append(chip);
+        });
+        group.append(row);
+      }
+
+      fragment.append(group);
+    });
+
+    page.filters.replaceChildren(fragment);
+  }
+
+  function renderSearchPageActiveFilters(page, view) {
+    if (!page.activeFilters) {
+      return;
+    }
+
+    if (view.activeFilters.length === 0) {
+      page.activeFilters.hidden = true;
+      page.activeFilters.replaceChildren();
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    view.activeFilters.forEach((filter) => {
+      const pill = createElement('div', 'docs-search-page-active-filter');
+      pill.append(createElement('span', null, `${filter.label}: ${filter.displayValue}`));
+      const button = createElement('button', null, 'Clear');
+      button.type = 'button';
+      button.dataset.rwClearFacetKey = filter.key;
+      pill.append(button);
+      fragment.append(pill);
+    });
+
+    page.activeFilters.hidden = false;
+    page.activeFilters.replaceChildren(fragment);
+  }
+
+  function renderSearchPageResults(page, view) {
+    if (!page.results || !page.resultsMeta) {
+      return;
+    }
+
+    const queryTokens = getHighlightTokens(view.normalizedQuery);
+
+    if (view.isStarter) {
+      page.resultsMeta.hidden = true;
+      page.results.replaceChildren();
+      return;
+    }
+
+    if (view.resultDocs.length === 0) {
+      const descriptor = view.normalizedQuery
+        ? `No results for "${formatQueryForStatus(view.normalizedQuery)}".`
+        : 'No results for the current filters.';
+      page.resultsMeta.hidden = false;
+      page.resultsMeta.textContent = descriptor;
+      page.results.replaceChildren(createNoResultsRecovery(view));
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    view.resultDocs.forEach((doc) => {
+      fragment.append(createSearchResultArticle(doc, queryTokens));
+    });
+
+    page.resultsMeta.hidden = false;
+    page.resultsMeta.textContent = view.normalizedQuery
+      ? `${view.resultDocs.length} result(s) for "${formatQueryForStatus(view.normalizedQuery)}".`
+      : `${view.resultDocs.length} page(s) for the current filters.`;
+    page.results.replaceChildren(fragment);
+  }
+
+  function renderSearchPage() {
+    const page = getSearchPageElements();
+    if (!page.root || !page.status || !page.results) {
+      return;
+    }
+
+    syncSearchPageFilterPanel(page);
+
+    if (searchPageState.loadState === 'loading' && !searchData.index) {
+      setStatus(page.status, 'Loading search index...');
+      page.failure.hidden = true;
+      page.starter.hidden = true;
+      page.resultsMeta.hidden = true;
+      page.results.replaceChildren(createLoadingSkeletons());
+      setSearchPageBusy(page, true);
+      return;
+    }
+
+    if (searchPageState.loadState === 'error' && !searchData.index) {
+      setStatus(page.status, 'Search is temporarily unavailable.');
+      page.failure.hidden = false;
+      page.starter.hidden = true;
+      page.resultsMeta.hidden = true;
+      page.results.replaceChildren();
+      setSearchPageBusy(page, false);
+      return;
+    }
+
+    if (!searchData.index) {
+      return;
+    }
+
+    const view = buildSearchView();
+    renderSearchPageFilters(page, view);
+    renderSearchPageActiveFilters(page, view);
+    page.failure.hidden = true;
+    page.starter.hidden = !view.isStarter;
+    setSearchPageBusy(page, false);
+
+    if (view.isStarter) {
+      setStatus(page.status, 'Search is ready. Try a starter query or browse by filter.');
+      page.resultsMeta.hidden = true;
+      page.results.replaceChildren();
+      return;
+    }
+
+    setStatus(page.status, view.resultDocs.length > 0
+      ? 'Search results updated.'
+      : 'Try loosening one filter or using a broader term.');
+    renderSearchPageResults(page, view);
+  }
+
+  function setSearchPageState(nextState, historyMode = 'replace') {
+    Object.assign(searchPageState, nextState);
+
+    const page = getSearchPageElements();
+    if (page.input && searchPageState.q !== page.input.value) {
+      page.input.value = searchPageState.q;
+    }
+
+    if (historyMode !== 'none') {
+      writeSearchPageUrl(historyMode);
+    }
+
+    renderSearchPage();
+  }
+
+  async function loadSearchPageData() {
+    searchPageState.loadState = 'loading';
+    renderSearchPage();
+
+    try {
+      await ensureSearchResourcesLoaded();
+      searchPageState.loadState = 'ready';
+      renderSearchPage();
+    } catch (error) {
+      console.error(error);
+      searchPageState.loadState = 'error';
+      renderSearchPage();
+    }
+  }
+
   function bindSearchPage() {
     const page = getSearchPageElements();
-    const { root, input, results } = page;
-    if (!root || !input || !results) {
+    const { root, input, filters, activeFilters, retry, filtersToggle, suggestionButtons } = page;
+    if (!root || !input || !filters || !activeFilters || !retry || !filtersToggle) {
       return;
     }
 
@@ -479,130 +1484,142 @@
     }
 
     root.setAttribute(searchPageBoundAttribute, '1');
-
-    const params = new URLSearchParams(window.location.search);
-    const initialQuery = normalizeQuery(params.get('q'));
-    input.value = initialQuery;
-    renderSearchPageResults(page, initialQuery);
+    Object.assign(searchPageState, readSearchPageStateFromUrl());
+    searchPageState.loadState = searchData.index ? 'ready' : 'loading';
+    input.value = searchPageState.q;
 
     const onInput = debounce(() => {
-      const q = normalizeQuery(input.value);
-      if (q !== input.value) {
-        input.value = q;
+      const query = normalizeQuery(input.value);
+      setSearchPageState({ q: query }, 'replace');
+    }, 140);
+
+    input.addEventListener('input', () => {
+      if (searchData.index) {
+        setSearchPageBusy(page, true);
       }
-
-      const url = new URL(window.location.href);
-      if (q) {
-        url.searchParams.set('q', q);
-      } else {
-        url.searchParams.delete('q');
-      }
-
-      window.history.replaceState({}, '', url);
-      renderSearchPageResults(page, q);
-    }, 120);
-
-    input.addEventListener('input', onInput);
-  }
-
-  function renderSidebarResults(sidebar, queryResults, q, activeIndex = -1) {
-    const { input, results, status } = sidebar;
-    if (!results) {
-      return;
-    }
-
-    if (!q || !q.trim()) {
-      results.innerHTML = '';
-      results.classList.add('hidden');
-      input?.removeAttribute('aria-activedescendant');
-      setStatus(status, '');
-      return;
-    }
-
-    if (!queryResults.length) {
-      results.classList.remove('hidden');
-      results.innerHTML = '<li class="docs-search-empty" role="presentation">No matching docs found.</li>';
-      input?.removeAttribute('aria-activedescendant');
-      setStatus(status, 'No matching docs found.');
-      return;
-    }
-
-    results.classList.remove('hidden');
-    results.innerHTML = queryResults.map((item, index) => {
-      const selected = index === activeIndex ? 'true' : 'false';
-      const pageTypeBadge = renderPageTypeBadge(item);
-      return `<li id="docs-search-option-${index}" role="option" aria-selected="${selected}" tabindex="-1" class="docs-search-option" data-href="${escapeHtml(item.path)}">
-        <a href="${escapeHtml(item.path)}" data-turbo-frame="doc-content" data-turbo-action="advance">
-          <span class="docs-search-option-title-row">
-            <span class="docs-search-option-title">${escapeHtml(item.title)}</span>
-            ${pageTypeBadge}
-          </span>
-          <span class="docs-search-option-path">${escapeHtml(getLocationLabel(item))}</span>
-        </a>
-      </li>`;
-    }).join('');
-
-    setStatus(status, `${queryResults.length} result(s).`);
-  }
-
-  function setActiveSidebarOption(items, activeIndex, input) {
-    items.forEach((item, i) => {
-      const selected = i === activeIndex;
-      item.setAttribute('aria-selected', selected ? 'true' : 'false');
-      item.classList.toggle('active', selected);
+      onInput();
     });
 
-    if (activeIndex >= 0 && items[activeIndex] && input) {
-      input.setAttribute('aria-activedescendant', items[activeIndex].id);
-      items[activeIndex].scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
-    } else {
-      input?.removeAttribute('aria-activedescendant');
+    filters.addEventListener('click', (event) => {
+      const chip = event.target.closest('[data-rw-facet-key][data-rw-facet-value]');
+      if (!(chip instanceof HTMLButtonElement)) {
+        return;
+      }
+
+      const key = chip.dataset.rwFacetKey;
+      const value = normalizeFacetValue(chip.dataset.rwFacetValue);
+      if (!key) {
+        return;
+      }
+
+      const nextValue = normalizeFacetValue(searchPageState[key]) === value ? '' : value;
+      setSearchPageState({ [key]: nextValue }, 'push');
+    });
+
+    filters.addEventListener('change', (event) => {
+      const select = event.target;
+      if (!(select instanceof HTMLSelectElement) || !select.dataset.rwFacetKey) {
+        return;
+      }
+
+      setSearchPageState({ [select.dataset.rwFacetKey]: normalizeFacetValue(select.value) }, 'push');
+    });
+
+    activeFilters.addEventListener('click', (event) => {
+      const button = event.target.closest('[data-rw-clear-facet-key]');
+      if (!(button instanceof HTMLButtonElement)) {
+        return;
+      }
+
+      const key = button.dataset.rwClearFacetKey;
+      if (!key) {
+        return;
+      }
+
+      setSearchPageState({ [key]: '' }, 'push');
+    });
+
+    retry.addEventListener('click', () => {
+      loadSearchPageData().catch((error) => console.error(error));
+    });
+
+    filtersToggle.addEventListener('click', () => {
+      searchPageState.filtersExpanded = !searchPageState.filtersExpanded;
+      syncSearchPageFilterPanel(page);
+    });
+
+    suggestionButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const query = normalizeQuery(button.dataset.rwSearchSuggestion);
+        setSearchPageState({ q: query }, 'push');
+        input.focus();
+        input.select?.();
+      });
+    });
+
+    if (mobileFilterMedia) {
+      mobileFilterMedia.addEventListener('change', () => syncSearchPageFilterPanel(page));
     }
+
+    if (!window[shortcutsBoundAttribute]) {
+      window.addEventListener('popstate', () => {
+        const nextPage = getSearchPageElements();
+        if (!nextPage.root) {
+          return;
+        }
+
+        Object.assign(searchPageState, readSearchPageStateFromUrl());
+        searchPageState.loadState = searchData.index
+          ? 'ready'
+          : (searchData.loadPromise ? 'loading' : 'error');
+        nextPage.input.value = searchPageState.q;
+        renderSearchPage();
+      });
+      window[shortcutsBoundAttribute] = '1';
+    }
+
+    renderSearchPage();
+    consumeSearchPageAutofocusHash(page);
+    loadSearchPageData().catch((error) => console.error(error));
   }
 
-  function renderSearchPageResults(page, q) {
-    const { results, status } = page;
-    if (!results) {
+  function bindGlobalSearchShortcuts() {
+    if (document.documentElement.getAttribute(shortcutsBoundAttribute) === '1') {
       return;
     }
 
-    if (!q || !q.trim()) {
-      setStatus(status, 'Type to search across documentation.');
-      results.innerHTML = '';
-      return;
-    }
+    document.documentElement.setAttribute(shortcutsBoundAttribute, '1');
+    document.addEventListener('keydown', (event) => {
+      if (event.defaultPrevented) {
+        return;
+      }
 
-    const queryResults = query(q, 100);
-    const safeQuery = formatQueryForStatus(q);
-    setStatus(status, `${queryResults.length} result(s) for "${safeQuery}".`);
+      const editableTarget = isEditableElement(event.target);
+      const searchInputTarget = isSearchInputElement(event.target);
 
-    if (!queryResults.length) {
-      results.innerHTML = '<p class="docs-search-empty">No results found.</p>';
-      return;
-    }
+      if (!event.metaKey && !event.ctrlKey && !event.altKey && event.key === '/') {
+        if (editableTarget) {
+          return;
+        }
 
-    results.innerHTML = queryResults.map((item) => {
-      const metadata = [
-        renderPageTypeBadge(item),
-        renderMetadataChip('Component', item.component),
-        renderMetadataChip('Audience', item.audience)
-      ].filter(Boolean).join('');
+        event.preventDefault();
+        focusVisibleSearchInput();
+        return;
+      }
 
-      return `
-      <article class="docs-search-result">
-        ${metadata ? `<div class="docs-search-result-meta">${metadata}</div>` : ''}
-        <h2><a href="${escapeHtml(item.path)}">${escapeHtml(item.title)}</a></h2>
-        <p class="docs-search-result-path">${escapeHtml(getLocationLabel(item))}</p>
-        <p class="docs-search-result-snippet">${escapeHtml(item.summary || item.snippet || '')}</p>
-      </article>
-    `;
-    }).join('');
-  }
+      if ((event.metaKey || event.ctrlKey) && !event.shiftKey && String(event.key).toLowerCase() === 'k') {
+        if (editableTarget && !searchInputTarget) {
+          return;
+        }
 
-  function setStatus(node, text) {
-    if (node) {
-      node.textContent = text;
-    }
+        event.preventDefault();
+        if (isSearchPageVisible()) {
+          focusVisibleSearchInput();
+        } else {
+          navigateToSearchPageWithQuery(getCurrentSearchQuery());
+        }
+      }
+    });
   }
 
   function initOnTurboFrameLoad(event) {
@@ -611,11 +1628,13 @@
       return;
     }
 
-    init().catch((err) => console.error('Search init failed:', err));
+    init().catch((error) => console.error('Search init failed:', error));
   }
 
-  function runInit() {
-    init().catch((err) => console.error('Search init failed:', err));
+  async function init() {
+    bindGlobalSearchShortcuts();
+    bindSidebar();
+    bindSearchPage();
   }
 
   function getCurrentUrlKey() {
@@ -628,6 +1647,10 @@
       || typeof window.Turbo !== 'undefined'
       || document.documentElement.hasAttribute('data-turbo'));
   let lastInitializedUrlKey = null;
+
+  function runInit() {
+    init().catch((error) => console.error('Search init failed:', error));
+  }
 
   function runInitForCurrentUrl() {
     runInit();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -1039,42 +1039,59 @@
     }
 
     if (!searchData.runtimePromise) {
-      const existing = document.querySelector('script[data-rw-search-runtime="minisearch"]');
-      searchData.runtimePromise = new Promise((resolve, reject) => {
-        const script = existing || document.createElement('script');
+      const poisonedScripts = Array.from(
+        document.querySelectorAll('script[data-rw-search-runtime="minisearch"]:not([data-rw-search-failed="true"])')
+      );
 
-        const cleanup = () => {
-          script.removeEventListener('load', onLoad);
-          script.removeEventListener('error', onError);
-        };
+      if (poisonedScripts.length > 0) {
+        poisonedScripts.forEach((script) => {
+          script.dataset.rwSearchFailed = 'true';
+        });
 
-        const onLoad = () => {
-          cleanup();
-          if (window.MiniSearch) {
-            resolve(window.MiniSearch);
-          } else {
+        searchData.runtimePromise = Promise.reject(new Error('MiniSearch runtime is not available.')).catch((error) => {
+          searchData.runtimePromise = null;
+          throw error;
+        });
+      } else {
+        document
+          .querySelectorAll('script[data-rw-search-runtime="minisearch"][data-rw-search-failed="true"]')
+          .forEach((script) => script.remove());
+
+        searchData.runtimePromise = new Promise((resolve, reject) => {
+          const script = document.createElement('script');
+
+          const cleanup = () => {
+            script.removeEventListener('load', onLoad);
+            script.removeEventListener('error', onError);
+          };
+
+          const onLoad = () => {
+            cleanup();
+            if (window.MiniSearch) {
+              resolve(window.MiniSearch);
+            } else {
+              script.dataset.rwSearchFailed = 'true';
+              reject(new Error('MiniSearch runtime is not available.'));
+            }
+          };
+
+          const onError = () => {
+            cleanup();
+            script.dataset.rwSearchFailed = 'true';
             reject(new Error('MiniSearch runtime is not available.'));
-          }
-        };
+          };
 
-        const onError = () => {
-          cleanup();
-          reject(new Error('MiniSearch runtime is not available.'));
-        };
-
-        script.addEventListener('load', onLoad, { once: true });
-        script.addEventListener('error', onError, { once: true });
-
-        if (!existing) {
+          script.addEventListener('load', onLoad, { once: true });
+          script.addEventListener('error', onError, { once: true });
           script.src = miniSearchUrl;
           script.defer = true;
           script.dataset.rwSearchRuntime = 'minisearch';
           document.head.append(script);
-        }
-      }).catch((error) => {
-        searchData.runtimePromise = null;
-        throw error;
-      });
+        }).catch((error) => {
+          searchData.runtimePromise = null;
+          throw error;
+        });
+      }
     }
 
     return searchData.runtimePromise;

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -1400,12 +1400,17 @@
     }
 
     const fragment = document.createDocumentFragment();
-    view.facets.forEach((facet) => {
+    view.facets.forEach((facet, index) => {
       const group = createElement('section', 'docs-search-page-filter-group');
-      group.append(createElement('h2', 'docs-search-page-filter-label', facet.label));
+      const heading = createElement('h2', 'docs-search-page-filter-label', facet.label);
+      const headingId = `docs-search-page-filter-label-${facet.key || `facet-${index}`}`;
+      heading.id = headingId;
+      group.append(heading);
 
       if (facet.kind === 'select') {
         const select = createElement('select', 'docs-search-page-select');
+        select.id = `docs-search-page-select-${facet.key || `facet-${index}`}`;
+        select.setAttribute('aria-labelledby', headingId);
         select.dataset.rwFacetKey = facet.key;
         const emptyOption = createElement('option', null, `All ${facet.label}`);
         emptyOption.value = '';
@@ -1458,7 +1463,7 @@
       const button = createElement('button', null, 'Clear');
       button.type = 'button';
       button.dataset.rwClearFacetKey = filter.key;
-      button.setAttribute('aria-label', `Clear ${filter.label} filter`);
+      button.setAttribute('aria-label', `Clear ${filter.label} filter${filter.displayValue ? `: ${filter.displayValue}` : ''}`);
       pill.append(button);
       fragment.append(pill);
     });
@@ -1570,6 +1575,12 @@
   }
 
   async function loadSearchPageData() {
+    if (searchData.index) {
+      searchPageState.loadState = 'ready';
+      renderSearchPage();
+      return;
+    }
+
     searchPageState.loadState = 'loading';
     renderSearchPage();
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
@@ -553,6 +553,13 @@
     animation: docs-search-skeleton 1.4s ease-in-out infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .docs-search-skeleton {
+        animation: none;
+        background-position: 0 0;
+    }
+}
+
 .docs-search-skeleton-title {
     height: 1rem;
     width: min(20rem, 60%);

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
@@ -1,20 +1,31 @@
+[hidden] {
+    display: none !important;
+}
+
 #docs-search-shell {
     margin-bottom: 0.75rem;
 }
 
 #docs-search-input,
-#docs-search-page-input {
+#docs-search-page-input,
+.docs-search-page-select {
     width: 100%;
     border: 1px solid #334155;
     background: #020617;
     color: #e2e8f0;
-    border-radius: 0.5rem;
-    padding: 0.55rem 0.75rem;
+    border-radius: 0.75rem;
+    padding: 0.65rem 0.8rem;
     outline: none;
 }
 
 #docs-search-input:focus,
-#docs-search-page-input:focus {
+#docs-search-page-input:focus,
+.docs-search-page-select:focus,
+.docs-search-page-chip:focus,
+.docs-search-page-starter-chip:focus,
+.docs-search-page-filters-toggle:focus,
+.docs-search-page-retry:focus,
+.docs-search-shell-cta:focus {
     border-color: #22d3ee;
     box-shadow: 0 0 0 1px #22d3ee inset;
 }
@@ -22,7 +33,7 @@
 #docs-search-results {
     margin-top: 0.5rem;
     border: 1px solid #1e293b;
-    border-radius: 0.5rem;
+    border-radius: 0.75rem;
     background: #020617;
     overflow: hidden;
     max-height: 18rem;
@@ -102,7 +113,7 @@
 
 .docs-search-option a {
     display: block;
-    padding: 0.55rem 0.65rem;
+    padding: 0.65rem 0.75rem;
     text-decoration: none;
 }
 
@@ -116,13 +127,15 @@
 .docs-search-option-title {
     display: block;
     color: #e2e8f0;
-    font-size: 0.88rem;
+    font-size: 0.9rem;
+    line-height: 1.35;
 }
 
 .docs-search-option-path {
     display: block;
     color: #64748b;
-    font-size: 0.7rem;
+    font-size: 0.74rem;
+    margin-top: 0.2rem;
 }
 
 .docs-search-option.active,
@@ -132,61 +145,441 @@
 
 .docs-search-empty {
     color: #94a3b8;
-    font-size: 0.8rem;
-    padding: 0.65rem;
+    font-size: 0.84rem;
+    padding: 0.8rem;
+}
+
+.docs-search-shell-cta {
+    margin-top: 0.7rem;
+    display: inline-flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border: 1px solid rgba(34, 211, 238, 0.28);
+    border-radius: 0.8rem;
+    background: linear-gradient(180deg, rgba(8, 47, 73, 0.6), rgba(8, 47, 73, 0.2));
+    color: #cffafe;
+    padding: 0.7rem 0.8rem;
+    text-decoration: none;
+    font-size: 0.82rem;
+    font-weight: 600;
+}
+
+.docs-search-shell-cta:hover {
+    border-color: rgba(34, 211, 238, 0.55);
+    background: linear-gradient(180deg, rgba(8, 47, 73, 0.72), rgba(8, 47, 73, 0.28));
+}
+
+.docs-search-shell-cta-hint {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #67e8f9;
 }
 
 .docs-search-page {
-    max-width: 52rem;
+    max-width: 60rem;
     margin: 0 auto;
+    display: grid;
+    gap: 1rem;
+}
+
+.docs-search-page-header {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.docs-search-page-eyebrow {
+    margin: 0;
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: #67e8f9;
+    font-weight: 600;
+}
+
+.docs-search-page-title {
+    margin: 0;
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.02;
+    color: #f8fafc;
+    font-weight: 700;
+}
+
+.docs-search-page-intro {
+    margin: 0;
+    max-width: 52rem;
+    color: #94a3b8;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.docs-search-page-query-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.85rem;
+    align-items: start;
 }
 
 .docs-search-page-input-wrap {
-    margin-bottom: 1rem;
+    min-width: 0;
 }
 
-.docs-search-page-status {
+#docs-search-page-input {
+    font-size: 1rem;
+    min-height: 3rem;
+}
+
+.docs-search-page-filters-toggle {
+    min-height: 3rem;
+    border: 1px solid #334155;
+    border-radius: 0.8rem;
+    background: rgba(15, 23, 42, 0.86);
+    color: #e2e8f0;
+    padding: 0.7rem 1rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.docs-search-page-filters-toggle:hover {
+    border-color: rgba(34, 211, 238, 0.45);
+    color: #cffafe;
+}
+
+.docs-search-page-status,
+.docs-search-page-results-meta {
+    margin: 0;
     color: #94a3b8;
-    margin-bottom: 1rem;
-    font-size: 0.9rem;
+    font-size: 0.92rem;
+}
+
+.docs-search-page-active-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.docs-search-page-active-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 1px solid rgba(34, 211, 238, 0.3);
+    background: rgba(8, 47, 73, 0.35);
+    border-radius: 999px;
+    padding: 0.35rem 0.7rem;
+    color: #cffafe;
+    font-size: 0.76rem;
+}
+
+.docs-search-page-active-filter button {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    padding: 0;
+}
+
+.docs-search-page-filters-panel,
+.docs-search-page-starter,
+.docs-search-page-failure {
+    border: 1px solid #1e293b;
+    border-radius: 1rem;
+    background: rgba(2, 6, 23, 0.78);
+    padding: 1rem;
+}
+
+.docs-search-page-filters {
+    display: grid;
+    gap: 1rem;
+}
+
+.docs-search-page-filter-group {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.docs-search-page-filter-label {
+    margin: 0;
+    font-size: 0.73rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #94a3b8;
+    font-weight: 600;
+}
+
+.docs-search-page-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.docs-search-page-chip,
+.docs-search-page-starter-chip,
+.docs-search-page-retry {
+    appearance: none;
+    border: 1px solid #334155;
+    background: #020617;
+    color: #e2e8f0;
+    border-radius: 999px;
+    padding: 0.5rem 0.8rem;
+    font: inherit;
+    cursor: pointer;
+    min-height: 2.75rem;
+}
+
+.docs-search-page-chip {
+    font-size: 0.82rem;
+}
+
+.docs-search-page-chip:hover,
+.docs-search-page-starter-chip:hover,
+.docs-search-page-retry:hover {
+    border-color: rgba(34, 211, 238, 0.45);
+    color: #cffafe;
+}
+
+.docs-search-page-chip[aria-pressed="true"] {
+    border-color: rgba(34, 211, 238, 0.42);
+    background: rgba(8, 47, 73, 0.45);
+    color: #cffafe;
+}
+
+.docs-search-page-chip:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.docs-search-page-starter {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.docs-search-page-starter-copy,
+.docs-search-page-failure-copy {
+    margin: 0;
+    color: #cbd5e1;
+    line-height: 1.55;
+}
+
+.docs-search-page-starter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.docs-search-page-starter-chip {
+    background: rgba(15, 23, 42, 0.88);
+    font-size: 0.84rem;
+}
+
+.docs-search-page-section-title {
+    margin: 0 0 0.55rem;
+    font-size: 1rem;
+    color: #f8fafc;
+}
+
+.docs-search-page-failure {
+    display: grid;
+    gap: 1rem;
+}
+
+.docs-search-page-failure-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.docs-search-page-retry {
+    border-radius: 0.8rem;
+    padding-inline: 1rem;
+    font-size: 0.84rem;
+    font-weight: 600;
+}
+
+.docs-search-page-failure-links {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.docs-search-page-failure-link {
+    display: grid;
+    gap: 0.25rem;
+    border: 1px solid #1e293b;
+    border-radius: 0.85rem;
+    padding: 0.85rem 0.95rem;
+    background: rgba(15, 23, 42, 0.55);
+    text-decoration: none;
+}
+
+.docs-search-page-failure-link:hover {
+    border-color: rgba(34, 211, 238, 0.35);
+    background: rgba(8, 47, 73, 0.2);
+}
+
+.docs-search-page-failure-link-title {
+    color: #67e8f9;
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.docs-search-page-failure-link-description {
+    color: #94a3b8;
+    font-size: 0.82rem;
+    line-height: 1.45;
+}
+
+.docs-search-page-results {
+    display: grid;
+    gap: 0.9rem;
 }
 
 .docs-search-result {
+    display: grid;
+    gap: 0.55rem;
+    padding: 0.05rem 0 1rem;
+    border-bottom: 1px solid #1e293b;
+}
+
+.docs-search-result:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.docs-search-result-title {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.3;
+}
+
+.docs-search-result-title a {
+    color: #e2e8f0;
+    text-decoration: none;
+}
+
+.docs-search-result-title a:hover {
+    color: #67e8f9;
+}
+
+.docs-search-result-breadcrumbs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    color: #64748b;
+    font-size: 0.78rem;
+}
+
+.docs-search-result-breadcrumb-separator {
+    color: #475569;
+}
+
+.docs-search-result-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.docs-search-result-badge {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #334155;
+    border-radius: 999px;
+    padding: 0.22rem 0.55rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #bfdbfe;
+    background: rgba(15, 23, 42, 0.72);
+    font-weight: 600;
+}
+
+.docs-search-result-badge-secondary {
+    color: #cbd5e1;
+}
+
+.docs-search-result-snippet {
+    margin: 0;
+    color: #cbd5e1;
+    line-height: 1.6;
+}
+
+.docs-search-result mark {
+    background: rgba(34, 211, 238, 0.25);
+    color: #ecfeff;
+    border-radius: 0.18rem;
+    padding: 0.02rem 0.12rem;
+}
+
+.docs-search-page-no-results {
+    display: grid;
+    gap: 0.85rem;
     border: 1px solid #1e293b;
-    border-radius: 0.75rem;
+    border-radius: 1rem;
     padding: 1rem;
-    margin-bottom: 0.75rem;
-    background: #020617;
+    background: rgba(2, 6, 23, 0.65);
 }
 
-.docs-search-result-meta {
-    margin-bottom: 0.65rem;
+.docs-search-page-no-results-links {
+    display: grid;
+    gap: 0.65rem;
 }
 
-.docs-search-result h2 {
-    margin: 0 0 0.15rem;
-    font-size: 1.05rem;
-}
-
-.docs-search-result h2 a {
+.docs-search-page-no-results-link {
     color: #67e8f9;
     text-decoration: none;
 }
 
-.docs-search-result h2 a:hover {
-    text-decoration: underline;
+.docs-search-page-no-results-link:hover {
+    color: #a5f3fc;
 }
 
-.docs-search-result-path {
-    color: #64748b;
-    font-size: 0.8rem;
-    margin: 0.35rem 0;
+.docs-search-page-results[aria-busy="true"] .docs-search-result:not(.docs-search-result-skeleton) {
+    opacity: 0.72;
 }
 
-.docs-search-result-snippet {
-    color: #cbd5e1;
-    margin: 0;
-    line-height: 1.4;
+.docs-search-result-skeleton {
+    padding-block: 0.25rem 1rem;
+}
+
+.docs-search-skeleton {
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(30, 41, 59, 0.9), rgba(51, 65, 85, 0.55), rgba(30, 41, 59, 0.9));
+    background-size: 200% 100%;
+    animation: docs-search-skeleton 1.4s ease-in-out infinite;
+}
+
+.docs-search-skeleton-title {
+    height: 1rem;
+    width: min(20rem, 60%);
+}
+
+.docs-search-skeleton-meta {
+    height: 0.72rem;
+    width: min(16rem, 46%);
+}
+
+.docs-search-skeleton-line {
+    height: 0.78rem;
+    width: 100%;
+}
+
+.docs-search-skeleton-line-short {
+    width: 72%;
+}
+
+@keyframes docs-search-skeleton {
+    0% {
+        background-position: 200% 0;
+    }
+
+    100% {
+        background-position: -200% 0;
+    }
 }
 
 @media (max-width: 767px) {
@@ -196,9 +589,32 @@
 
     .docs-search-page {
         max-width: 100%;
+        gap: 0.9rem;
+    }
+
+    .docs-search-page-query-row {
+        grid-template-columns: 1fr;
+    }
+
+    .docs-search-page-filters-toggle {
+        width: fit-content;
+    }
+
+    .docs-search-page-filters-panel {
+        padding: 0.9rem;
     }
 
     .docs-search-result {
-        padding: 0.85rem;
+        padding-bottom: 0.85rem;
+    }
+}
+
+@media (min-width: 768px) {
+    .docs-search-page-filters-toggle {
+        display: none;
+    }
+
+    .docs-search-page-failure-links {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchFacets.regression-1.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchFacets.regression-1.test.cs
@@ -10,6 +10,7 @@ namespace ForgeTrust.Runnable.Web.RazorWire.IntegrationTests;
 [Trait("Category", "Integration")]
 public sealed class RazorDocsSearchFacetsRegression1Tests
 {
+    private const string SearchIndexPath = "/docs/search-index.json";
     private readonly RazorDocsPlaywrightFixture _fixture;
 
     public RazorDocsSearchFacetsRegression1Tests(RazorDocsPlaywrightFixture fixture)
@@ -22,18 +23,87 @@ public sealed class RazorDocsSearchFacetsRegression1Tests
     {
         await using var context = await _fixture.Browser.NewContextAsync();
         var page = await context.NewPageAsync();
+        var payload = CreateSearchPayload(
+            new
+            {
+                id = "guides/getting-started",
+                path = "/docs/guides/getting-started",
+                title = "Getting Started",
+                summary = "Start here",
+                headings = Array.Empty<string>(),
+                bodyText = "setup and install",
+                snippet = "setup and install",
+                pageType = "guide",
+                audience = string.Empty,
+                component = string.Empty,
+                aliases = Array.Empty<string>(),
+                keywords = Array.Empty<string>(),
+                status = string.Empty,
+                navGroup = "Guides",
+                order = 1,
+                relatedPages = Array.Empty<string>(),
+                breadcrumbs = Array.Empty<string>()
+            },
+            new
+            {
+                id = "examples/quick-start",
+                path = "/docs/examples/quick-start",
+                title = "Quick Start",
+                summary = "Run the example",
+                headings = Array.Empty<string>(),
+                bodyText = "example walk-through",
+                snippet = "example walk-through",
+                pageType = "example",
+                audience = string.Empty,
+                component = string.Empty,
+                aliases = Array.Empty<string>(),
+                keywords = Array.Empty<string>(),
+                status = string.Empty,
+                navGroup = "Examples",
+                order = 2,
+                relatedPages = Array.Empty<string>(),
+                breadcrumbs = Array.Empty<string>()
+            });
+
+        await page.RouteAsync(
+            $"**{SearchIndexPath}",
+            async route =>
+            {
+                await route.FulfillAsync(new RouteFulfillOptions
+                {
+                    Status = 200,
+                    ContentType = "application/json",
+                    Body = payload
+                });
+            });
 
         await page.GotoAsync($"{_fixture.DocsUrl}/search");
         await WaitForSearchPageSettledAsync(page);
 
+        Assert.Equal(0, await page.GetByRole(AriaRole.Heading, new() { Name = "Status" }).CountAsync());
         Assert.Equal(0, await page.Locator("[data-rw-facet-key='status']").CountAsync());
 
         await page.GotoAsync($"{_fixture.DocsUrl}/search?status=beta");
         await WaitForSearchPageSettledAsync(page);
 
+        Assert.Equal(1, await page.GetByRole(AriaRole.Heading, new() { Name = "Status" }).CountAsync());
         var selectedStatusFacet = page.Locator("[data-rw-facet-key='status'][data-rw-facet-value='beta']");
         Assert.Equal(1, await selectedStatusFacet.CountAsync());
         Assert.Equal("true", await selectedStatusFacet.First.GetAttributeAsync("aria-pressed"));
+    }
+
+    private static string CreateSearchPayload(params object[] documents)
+    {
+        return System.Text.Json.JsonSerializer.Serialize(new
+        {
+            metadata = new
+            {
+                generatedAtUtc = DateTimeOffset.UtcNow.ToString("O"),
+                version = "1",
+                engine = "minisearch"
+            },
+            documents
+        });
     }
 
     private static async Task WaitForSearchPageSettledAsync(IPage page)

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchFacets.regression-1.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchFacets.regression-1.test.cs
@@ -35,7 +35,7 @@ public sealed class RazorDocsSearchFacetsRegression1Tests
                 snippet = "setup and install",
                 pageType = "guide",
                 audience = string.Empty,
-                component = string.Empty,
+                component = "CLI",
                 aliases = Array.Empty<string>(),
                 keywords = Array.Empty<string>(),
                 status = string.Empty,
@@ -55,7 +55,7 @@ public sealed class RazorDocsSearchFacetsRegression1Tests
                 snippet = "example walk-through",
                 pageType = "example",
                 audience = string.Empty,
-                component = string.Empty,
+                component = "SDK",
                 aliases = Array.Empty<string>(),
                 keywords = Array.Empty<string>(),
                 status = string.Empty,
@@ -82,6 +82,11 @@ public sealed class RazorDocsSearchFacetsRegression1Tests
 
         Assert.Equal(0, await page.GetByRole(AriaRole.Heading, new() { Name = "Status" }).CountAsync());
         Assert.Equal(0, await page.Locator("[data-rw-facet-key='status']").CountAsync());
+        var componentSelect = page.Locator("select[data-rw-facet-key='component']");
+        Assert.Equal(1, await componentSelect.CountAsync());
+        var componentLabelId = await componentSelect.First.GetAttributeAsync("aria-labelledby");
+        Assert.False(string.IsNullOrWhiteSpace(componentLabelId));
+        Assert.Equal("Component", await page.Locator($"#{componentLabelId}").TextContentAsync());
 
         await page.GotoAsync($"{_fixture.DocsUrl}/search?status=beta");
         await WaitForSearchPageSettledAsync(page);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchFacets.regression-1.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchFacets.regression-1.test.cs
@@ -1,0 +1,56 @@
+using Microsoft.Playwright;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.IntegrationTests;
+
+// Regression: ISSUE-002 — the search workspace rendered an empty Status filter group.
+// Found by /qa on 2026-04-18
+// Report: .gstack/qa-reports/qa-report-localhost-5000-2026-04-18.md
+
+[Collection(RazorDocsIntegrationCollection.Name)]
+[Trait("Category", "Integration")]
+public sealed class RazorDocsSearchFacetsRegression1Tests
+{
+    private readonly RazorDocsPlaywrightFixture _fixture;
+
+    public RazorDocsSearchFacetsRegression1Tests(RazorDocsPlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task SearchPage_HidesEmptyStatusFacetGroup_AndPreservesSelectedStatusFromUrl()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search");
+        await WaitForSearchPageSettledAsync(page);
+
+        Assert.Equal(0, await page.Locator("[data-rw-facet-key='status']").CountAsync());
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search?status=beta");
+        await WaitForSearchPageSettledAsync(page);
+
+        var selectedStatusFacet = page.Locator("[data-rw-facet-key='status'][data-rw-facet-value='beta']");
+        Assert.Equal(1, await selectedStatusFacet.CountAsync());
+        Assert.Equal("true", await selectedStatusFacet.First.GetAttributeAsync("aria-pressed"));
+    }
+
+    private static async Task WaitForSearchPageSettledAsync(IPage page)
+    {
+        await page.WaitForSelectorAsync("#docs-search-page-input", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Attached
+        });
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const results = document.getElementById('docs-search-page-results');
+              return results && results.getAttribute('aria-busy') === 'false';
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
@@ -19,6 +19,7 @@ public sealed class RazorDocsIntegrationCollection : ICollectionFixture<RazorDoc
 public sealed class RazorDocsSearchPlaywrightTests
 {
     private const string SearchIndexPath = "/docs/search-index.json";
+    private const string MiniSearchRuntimePath = "/docs/minisearch.min.js";
     private readonly RazorDocsPlaywrightFixture _fixture;
 
     public RazorDocsSearchPlaywrightTests(RazorDocsPlaywrightFixture fixture)
@@ -320,6 +321,52 @@ public sealed class RazorDocsSearchPlaywrightTests
         await page.ClickAsync("#docs-search-page-retry");
         await WaitForSearchPageSettledAsync(page);
 
+        Assert.False(await page.Locator("#docs-search-page-failure").IsVisibleAsync());
+        Assert.True(await page.Locator("#docs-search-page-starter").IsVisibleAsync());
+    }
+
+    [Fact]
+    public async Task SearchPage_RetryRecovers_WhenMiniSearchRuntimeFirstLoadDoesNotInitialize()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+        var runtimeRequests = 0;
+
+        await page.RouteAsync(
+            $"**{MiniSearchRuntimePath}",
+            async route =>
+            {
+                var attempt = System.Threading.Interlocked.Increment(ref runtimeRequests);
+                if (attempt == 1)
+                {
+                    await route.FulfillAsync(new RouteFulfillOptions
+                    {
+                        Status = 200,
+                        ContentType = "application/javascript",
+                        Body = "window.__rwMiniSearchRuntimeIntercept = 1;"
+                    });
+                    return;
+                }
+
+                await route.ContinueAsync();
+            });
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search");
+        await page.WaitForSelectorAsync("#docs-search-page-failure", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+
+        Assert.Equal(1, runtimeRequests);
+        Assert.Equal(
+            "true",
+            await page.GetAttributeAsync("script[data-rw-search-runtime=\"minisearch\"]", "data-rw-search-failed"));
+
+        await page.ClickAsync("#docs-search-page-retry");
+        await WaitForSearchPageSettledAsync(page);
+
+        Assert.Equal(2, runtimeRequests);
         Assert.False(await page.Locator("#docs-search-page-failure").IsVisibleAsync());
         Assert.True(await page.Locator("#docs-search-page-starter").IsVisibleAsync());
     }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
@@ -70,6 +70,27 @@ public sealed class RazorDocsSearchPlaywrightTests
     }
 
     [Fact]
+    public async Task SlashShortcut_DoesNotFocusHiddenSidebarInput_OnMobileDocsPage()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 390,
+                Height = 844
+            }
+        });
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(_fixture.DocsUrl);
+        await WaitForSidebarSearchReadyAsync(page);
+        await page.FocusAsync("#docs-sidebar-open");
+
+        await page.Keyboard.PressAsync("/");
+        await ExpectActiveElementIdAsync(page, "docs-sidebar-open");
+    }
+
+    [Fact]
     public async Task SearchShortcut_NavigatesToWorkspace_AndPreservesSidebarQuery()
     {
         await using var context = await _fixture.Browser.NewContextAsync();
@@ -183,6 +204,74 @@ public sealed class RazorDocsSearchPlaywrightTests
 
         Assert.Equal(chipQuery, await page.InputValueAsync("#docs-search-page-input"));
         Assert.False(await page.Locator("#docs-search-page-starter").IsVisibleAsync());
+    }
+
+    [Fact]
+    public async Task SearchPage_UsesTopLevelNavigation_ForDocumentationIndexRecoveryLink()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+        var payload = JsonSerializer.Serialize(new
+        {
+            metadata = new
+            {
+                generatedAtUtc = DateTimeOffset.UtcNow.ToString("O"),
+                version = "1",
+                engine = "minisearch"
+            },
+            documents = new[]
+            {
+                new
+                {
+                    id = "misc/overview",
+                    path = "/docs/misc/overview",
+                    title = "Misc Overview",
+                    summary = "Misc summary",
+                    headings = Array.Empty<string>(),
+                    bodyText = "miscellaneous body",
+                    snippet = "miscellaneous body",
+                    pageType = "reference-note",
+                    audience = string.Empty,
+                    component = string.Empty,
+                    aliases = Array.Empty<string>(),
+                    keywords = Array.Empty<string>(),
+                    status = string.Empty,
+                    navGroup = "Misc",
+                    order = 1,
+                    relatedPages = Array.Empty<string>(),
+                    breadcrumbs = Array.Empty<string>()
+                }
+            }
+        });
+
+        await page.RouteAsync(
+            $"**{SearchIndexPath}",
+            async route =>
+            {
+                await route.FulfillAsync(new RouteFulfillOptions
+                {
+                    Status = 200,
+                    ContentType = "application/json",
+                    Body = payload
+                });
+            });
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search?q={Uri.EscapeDataString("no-such-query")}");
+        await WaitForSearchPageSettledAsync(page);
+
+        var docsIndexLink = page.GetByRole(AriaRole.Link, new PageGetByRoleOptions
+        {
+            Name = "Documentation index",
+            Exact = true
+        });
+
+        await docsIndexLink.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = 30_000
+        });
+
+        Assert.Equal("_top", await docsIndexLink.GetAttributeAsync("data-turbo-frame"));
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
@@ -145,6 +145,8 @@ public sealed class RazorDocsSearchPlaywrightTests
             "() => document.querySelectorAll('#docs-search-page-results .docs-search-result').length > 0",
             null,
             new PageWaitForFunctionOptions { Timeout = 30_000 });
+        var initialResultCount = await page.Locator("#docs-search-page-results .docs-search-result").CountAsync();
+        Assert.True(initialResultCount > 0);
 
         var filterValue = await page.Locator("[data-rw-facet-key='pageType']:not([disabled])")
             .First
@@ -157,6 +159,12 @@ public sealed class RazorDocsSearchPlaywrightTests
             "(expected) => new URLSearchParams(window.location.search).get('pageType') === expected",
             filterValue,
             new PageWaitForFunctionOptions { Timeout = 15_000 });
+        await page.WaitForFunctionAsync(
+            "() => document.querySelectorAll('#docs-search-page-results .docs-search-result').length > 0",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+        var filteredResultCount = await page.Locator("#docs-search-page-results .docs-search-result").CountAsync();
+        Assert.True(filteredResultCount > 0);
 
         await page.GoBackAsync();
         await page.WaitForFunctionAsync(
@@ -164,9 +172,14 @@ public sealed class RazorDocsSearchPlaywrightTests
             _fixture.SearchQuery,
             new PageWaitForFunctionOptions { Timeout = 15_000 });
         await WaitForSearchPageSettledAsync(page);
+        await page.WaitForFunctionAsync(
+            "() => document.querySelectorAll('#docs-search-page-results .docs-search-result').length > 0",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
 
         Assert.Equal(_fixture.SearchQuery, await page.InputValueAsync("#docs-search-page-input"));
         Assert.False(await page.Locator("#docs-search-page-active-filters").IsVisibleAsync());
+        Assert.True(await page.Locator("#docs-search-page-results .docs-search-result").CountAsync() > 0);
 
         await page.GoForwardAsync();
         await page.WaitForFunctionAsync(
@@ -174,9 +187,14 @@ public sealed class RazorDocsSearchPlaywrightTests
             new { query = _fixture.SearchQuery, pageType = filterValue },
             new PageWaitForFunctionOptions { Timeout = 15_000 });
         await WaitForSearchPageSettledAsync(page);
+        await page.WaitForFunctionAsync(
+            "() => document.querySelectorAll('#docs-search-page-results .docs-search-result').length > 0",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
 
         Assert.Equal(_fixture.SearchQuery, await page.InputValueAsync("#docs-search-page-input"));
         Assert.True(await page.Locator("#docs-search-page-active-filters").IsVisibleAsync());
+        Assert.True(await page.Locator("#docs-search-page-results .docs-search-result").CountAsync() > 0);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
@@ -18,6 +18,7 @@ public sealed class RazorDocsIntegrationCollection : ICollectionFixture<RazorDoc
 [Trait("Category", "Integration")]
 public sealed class RazorDocsSearchPlaywrightTests
 {
+    private const string SearchIndexPath = "/docs/search-index.json";
     private readonly RazorDocsPlaywrightFixture _fixture;
 
     public RazorDocsSearchPlaywrightTests(RazorDocsPlaywrightFixture fixture)
@@ -35,15 +36,231 @@ public sealed class RazorDocsSearchPlaywrightTests
         await WaitForSidebarSearchReadyAsync(page);
         await RunSidebarSearchAndAssertResultsAsync(page, _fixture.SearchQuery);
 
-        await page.GetByRole(AriaRole.Link, new PageGetByRoleOptions
-        {
-            Name = "Advanced search",
-            Exact = true
-        }).First.ClickAsync();
+        await page.ClickAsync(".docs-search-shell-cta");
         await WaitForPathAsync(page, "/docs/search");
-
+        await WaitForSearchPageSettledAsync(page);
         await RunAdvancedSearchAndAssertResultsAsync(page, _fixture.SearchQuery);
         await RunSidebarSearchAndAssertResultsAsync(page, _fixture.SearchQuery);
+    }
+
+    [Fact]
+    public async Task SlashShortcut_FocusesVisibleSearchInput_WithoutStealingEditableFocus()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(_fixture.DocsUrl);
+        await WaitForSidebarSearchReadyAsync(page);
+
+        await page.Keyboard.PressAsync("/");
+        await ExpectActiveElementIdAsync(page, "docs-search-input");
+
+        await page.EvaluateAsync(
+            """
+            () => {
+              const textarea = document.createElement('textarea');
+              textarea.id = 'qa-editable';
+              document.body.append(textarea);
+              textarea.focus();
+            }
+            """);
+
+        await page.Keyboard.PressAsync("/");
+        await ExpectActiveElementIdAsync(page, "qa-editable");
+    }
+
+    [Fact]
+    public async Task SearchShortcut_NavigatesToWorkspace_AndPreservesSidebarQuery()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(_fixture.DocsUrl);
+        await WaitForSidebarSearchReadyAsync(page);
+        await RunSidebarSearchAndAssertResultsAsync(page, _fixture.SearchQuery);
+
+        await page.Keyboard.PressAsync(GetSearchWorkspaceShortcut());
+        await WaitForPathAsync(page, "/docs/search");
+        await WaitForSearchPageSettledAsync(page);
+
+        Assert.Equal(_fixture.SearchQuery, await page.InputValueAsync("#docs-search-page-input"));
+        Assert.Contains($"q={Uri.EscapeDataString(_fixture.SearchQuery)}", page.Url, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SearchPage_SupportsFilterOnlyBrowse_FromSharedUrl()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        var url = $"{_fixture.DocsUrl}/search?pageType={Uri.EscapeDataString(_fixture.BrowsePageType)}";
+        await page.GotoAsync(url);
+        await WaitForSearchPageSettledAsync(page);
+        await page.WaitForFunctionAsync(
+            "() => document.querySelectorAll('#docs-search-page-results .docs-search-result').length > 0",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+
+        Assert.Equal(string.Empty, await page.InputValueAsync("#docs-search-page-input"));
+        Assert.Contains("pageType=", page.Url, StringComparison.Ordinal);
+        Assert.Contains(
+            "page(s) for the current filters.",
+            await page.TextContentAsync("#docs-search-page-results-meta"),
+            StringComparison.Ordinal);
+        Assert.False(await page.GetByText("Search is temporarily unavailable").IsVisibleAsync());
+    }
+
+    [Fact]
+    public async Task SearchPage_BackAndForward_RestoreQueryFiltersAndResults()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search?q={Uri.EscapeDataString(_fixture.SearchQuery)}");
+        await WaitForSearchPageSettledAsync(page);
+        await page.WaitForFunctionAsync(
+            "() => document.querySelectorAll('#docs-search-page-results .docs-search-result').length > 0",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+
+        var filterValue = await page.Locator("[data-rw-facet-key='pageType']:not([disabled])")
+            .First
+            .EvaluateAsync<string>("element => element.getAttribute('data-rw-facet-value') || ''");
+
+        Assert.False(string.IsNullOrWhiteSpace(filterValue));
+
+        await page.ClickAsync($"[data-rw-facet-key='pageType'][data-rw-facet-value='{filterValue}']");
+        await page.WaitForFunctionAsync(
+            "(expected) => new URLSearchParams(window.location.search).get('pageType') === expected",
+            filterValue,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        await page.GoBackAsync();
+        await page.WaitForFunctionAsync(
+            "(query) => { const params = new URLSearchParams(window.location.search); return params.get('q') === query && !params.get('pageType'); }",
+            _fixture.SearchQuery,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+        await WaitForSearchPageSettledAsync(page);
+
+        Assert.Equal(_fixture.SearchQuery, await page.InputValueAsync("#docs-search-page-input"));
+        Assert.False(await page.Locator("#docs-search-page-active-filters").IsVisibleAsync());
+
+        await page.GoForwardAsync();
+        await page.WaitForFunctionAsync(
+            "(args) => { const params = new URLSearchParams(window.location.search); return params.get('q') === args.query && params.get('pageType') === args.pageType; }",
+            new { query = _fixture.SearchQuery, pageType = filterValue },
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+        await WaitForSearchPageSettledAsync(page);
+
+        Assert.Equal(_fixture.SearchQuery, await page.InputValueAsync("#docs-search-page-input"));
+        Assert.True(await page.Locator("#docs-search-page-active-filters").IsVisibleAsync());
+    }
+
+    [Fact]
+    public async Task SearchPage_StarterChips_PopulateQueryAndRunImmediately()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search");
+        await WaitForSearchPageSettledAsync(page);
+        await page.WaitForSelectorAsync("#docs-search-page-starter", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+
+        var chip = page.Locator("[data-rw-search-suggestion]").Nth(1);
+        var chipQuery = await chip.GetAttributeAsync("data-rw-search-suggestion");
+        Assert.False(string.IsNullOrWhiteSpace(chipQuery));
+
+        await chip.ClickAsync();
+        await page.WaitForFunctionAsync(
+            "(expected) => new URLSearchParams(window.location.search).get('q') === expected",
+            chipQuery,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+        await WaitForSearchPageSettledAsync(page);
+
+        Assert.Equal(chipQuery, await page.InputValueAsync("#docs-search-page-input"));
+        Assert.False(await page.Locator("#docs-search-page-starter").IsVisibleAsync());
+    }
+
+    [Fact]
+    public async Task SearchPage_ShowsFailureState_AndRetryRecovers()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.RouteAsync(
+            $"**{SearchIndexPath}",
+            async route =>
+            {
+                await route.FulfillAsync(new RouteFulfillOptions
+                {
+                    Status = 503,
+                    ContentType = "application/json",
+                    Body = "{}"
+                });
+            });
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search");
+        await page.WaitForSelectorAsync("#docs-search-page-failure", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+
+        Assert.True(await page.Locator("#docs-search-page-retry").IsVisibleAsync());
+        Assert.True(await page.Locator(".docs-search-page-failure-link").First.IsVisibleAsync());
+
+        await page.EvaluateAsync(
+            """
+            () => {
+              history.pushState({ rwDocsSearch: true }, "", `${window.location.pathname}?q=retry-test&pageType=guide`);
+              history.back();
+            }
+            """);
+        await page.WaitForSelectorAsync("#docs-search-page-failure", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        Assert.Equal("false", await page.GetAttributeAsync("#docs-search-page-results", "aria-busy"));
+
+        await page.UnrouteAsync($"**{SearchIndexPath}");
+        await page.ClickAsync("#docs-search-page-retry");
+        await WaitForSearchPageSettledAsync(page);
+
+        Assert.False(await page.Locator("#docs-search-page-failure").IsVisibleAsync());
+        Assert.True(await page.Locator("#docs-search-page-starter").IsVisibleAsync());
+    }
+
+    [Fact]
+    public async Task SidebarSearch_LazyLoadsResources_OnOrdinaryDocsPages()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+        var searchIndexRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        page.Request += (_, request) =>
+        {
+            if (request.Url.Contains(SearchIndexPath, StringComparison.Ordinal))
+            {
+                searchIndexRequested.TrySetResult();
+            }
+        };
+
+        await page.GotoAsync(_fixture.DocsUrl);
+        await WaitForSidebarSearchReadyAsync(page);
+        Assert.False(await page.EvaluateAsync<bool>("() => Boolean(document.querySelector('script[data-rw-search-runtime=\"minisearch\"]'))"));
+
+        await page.WaitForTimeoutAsync(500);
+        Assert.False(searchIndexRequested.Task.IsCompleted);
+
+        await page.FocusAsync("#docs-search-input");
+        await WaitForTaskAsync(searchIndexRequested.Task, TimeSpan.FromSeconds(15));
+
+        Assert.True(await page.EvaluateAsync<bool>("() => Boolean(document.querySelector('script[data-rw-search-runtime=\"minisearch\"]'))"));
     }
 
     private static async Task WaitForSidebarSearchReadyAsync(IPage page)
@@ -53,11 +270,10 @@ public sealed class RazorDocsSearchPlaywrightTests
             Timeout = 30_000,
             State = WaitForSelectorState.Attached
         });
-        await page.WaitForSelectorAsync("#docs-search-results", new PageWaitForSelectorOptions
-        {
-            Timeout = 30_000,
-            State = WaitForSelectorState.Attached
-        });
+        await page.WaitForFunctionAsync(
+            "() => document.documentElement.getAttribute('data-rw-search-shortcuts-bound') === '1'",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
     }
 
     private static async Task RunSidebarSearchAndAssertResultsAsync(IPage page, string query)
@@ -71,16 +287,52 @@ public sealed class RazorDocsSearchPlaywrightTests
 
     private static async Task RunAdvancedSearchAndAssertResultsAsync(IPage page, string query)
     {
-        await page.WaitForSelectorAsync("#docs-search-page-input", new PageWaitForSelectorOptions
-        {
-            Timeout = 30_000,
-            State = WaitForSelectorState.Attached
-        });
+        await WaitForSearchPageSettledAsync(page);
         await page.FillAsync("#docs-search-page-input", query);
         await page.WaitForFunctionAsync(
             "() => document.querySelectorAll('#docs-search-page-results .docs-search-result').length > 0",
             null,
             new PageWaitForFunctionOptions { Timeout = 30_000 });
+    }
+
+    private static async Task WaitForSearchPageSettledAsync(IPage page)
+    {
+        await page.WaitForSelectorAsync("#docs-search-page-input", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Attached
+        });
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const results = document.getElementById('docs-search-page-results');
+              return results && results.getAttribute('aria-busy') === 'false';
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+    }
+
+    private static async Task ExpectActiveElementIdAsync(IPage page, string expectedId)
+    {
+        await page.WaitForFunctionAsync(
+            "(expectedId) => document.activeElement && document.activeElement.id === expectedId",
+            expectedId,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+    }
+
+    private static async Task WaitForTaskAsync(Task task, TimeSpan timeout)
+    {
+        var completedTask = await Task.WhenAny(task, Task.Delay(timeout));
+        Assert.True(
+            ReferenceEquals(completedTask, task),
+            $"Timed out after {timeout.TotalSeconds} seconds waiting for the expected browser event.");
+        await task;
+    }
+
+    private static string GetSearchWorkspaceShortcut()
+    {
+        return OperatingSystem.IsMacOS() ? "Meta+K" : "Control+K";
     }
 
     private static async Task WaitForPathAsync(IPage page, string expectedPath)
@@ -112,6 +364,7 @@ public sealed class RazorDocsPlaywrightFixture : IAsyncLifetime
     public IBrowser Browser { get; private set; } = null!;
     public string DocsUrl { get; private set; } = string.Empty;
     public string SearchQuery { get; private set; } = "Namespaces";
+    public string BrowsePageType { get; private set; } = "guide";
 
     public async Task InitializeAsync()
     {
@@ -275,6 +528,7 @@ public sealed class RazorDocsPlaywrightFixture : IAsyncLifetime
 
                 await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
                 using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+                BrowsePageType = ResolveBrowsePageType(payload.RootElement);
                 resolvedQuery = ResolveSearchQuery(payload.RootElement);
                 return true;
             });
@@ -355,6 +609,29 @@ public sealed class RazorDocsPlaywrightFixture : IAsyncLifetime
         }
 
         return "Namespaces";
+    }
+
+    private static string ResolveBrowsePageType(JsonElement payload)
+    {
+        if (!payload.TryGetProperty("documents", out var documents) || documents.ValueKind != JsonValueKind.Array)
+        {
+            return "guide";
+        }
+
+        foreach (var document in documents.EnumerateArray())
+        {
+            if (document.TryGetProperty("pageType", out var pageType)
+                && pageType.ValueKind == JsonValueKind.String)
+            {
+                var value = pageType.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+        }
+
+        return "guide";
     }
 
     private static IEnumerable<string> EnumerateCandidateText(JsonElement document)

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
@@ -71,7 +71,7 @@ public sealed class RazorDocsSearchPlaywrightTests
     }
 
     [Fact]
-    public async Task SlashShortcut_DoesNotFocusHiddenSidebarInput_OnMobileDocsPage()
+    public async Task SlashShortcut_NavigatesToWorkspace_WhenSidebarSearchIsHidden_OnMobileDocsPage()
     {
         await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
         {
@@ -85,10 +85,11 @@ public sealed class RazorDocsSearchPlaywrightTests
 
         await page.GotoAsync(_fixture.DocsUrl);
         await WaitForSidebarSearchReadyAsync(page);
-        await page.FocusAsync("#docs-sidebar-open");
 
         await page.Keyboard.PressAsync("/");
-        await ExpectActiveElementIdAsync(page, "docs-sidebar-open");
+        await WaitForPathAsync(page, "/docs/search");
+        await WaitForSearchPageSettledAsync(page);
+        await ExpectActiveElementIdAsync(page, "docs-search-page-input");
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreload.regression-1.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreload.regression-1.test.cs
@@ -35,7 +35,7 @@ public sealed class RazorDocsSearchPreloadRegression1Tests
 
         await page.GotoAsync($"{_fixture.DocsUrl}/search");
         await WaitForSearchPageSettledAsync(page);
-        await page.WaitForTimeoutAsync(500);
+        await page.WaitForTimeoutAsync(3000);
 
         Assert.DoesNotContain(
             warnings,

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreload.regression-1.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreload.regression-1.test.cs
@@ -54,7 +54,14 @@ public sealed class RazorDocsSearchPreloadRegression1Tests
             """
             () => {
               const results = document.getElementById('docs-search-page-results');
-              return results && results.getAttribute('aria-busy') === 'false';
+              const failure = document.getElementById('docs-search-page-failure');
+              const hasIndexResource = performance
+                .getEntriesByType('resource')
+                .some(entry => entry.name.includes('/docs/search-index.json'));
+              return results
+                && results.getAttribute('aria-busy') === 'false'
+                && (!failure || failure.hidden)
+                && hasIndexResource;
             }
             """,
             null,

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreload.regression-1.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreload.regression-1.test.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+using Microsoft.Playwright;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.IntegrationTests;
+
+// Regression: ISSUE-001 — /docs/search emitted an unused preload warning on initial load.
+// Found by /qa on 2026-04-18
+// Report: .gstack/qa-reports/qa-report-localhost-5000-2026-04-18.md
+
+[Collection(RazorDocsIntegrationCollection.Name)]
+[Trait("Category", "Integration")]
+public sealed class RazorDocsSearchPreloadRegression1Tests
+{
+    private readonly RazorDocsPlaywrightFixture _fixture;
+
+    public RazorDocsSearchPreloadRegression1Tests(RazorDocsPlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task SearchPage_DoesNotEmitPreloadCredentialMismatchWarnings()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+        var warnings = new ConcurrentQueue<string>();
+
+        page.Console += (_, message) =>
+        {
+            if (string.Equals(message.Type, "warning", StringComparison.OrdinalIgnoreCase))
+            {
+                warnings.Enqueue(message.Text);
+            }
+        };
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search");
+        await WaitForSearchPageSettledAsync(page);
+        await page.WaitForTimeoutAsync(500);
+
+        Assert.DoesNotContain(
+            warnings,
+            warning => warning.Contains("preload", StringComparison.OrdinalIgnoreCase)
+                || warning.Contains("credentials mode", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static async Task WaitForSearchPageSettledAsync(IPage page)
+    {
+        await page.WaitForSelectorAsync("#docs-search-page-input", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Attached
+        });
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const results = document.getElementById('docs-search-page-results');
+              return results && results.getAttribute('aria-busy') === 'false';
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreloadPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPreloadPlaywrightTests.cs
@@ -14,20 +14,20 @@ public sealed class RazorDocsSearchPreloadPlaywrightTests
     }
 
     [Fact]
-    public async Task Landing_ReusesSearchIndexPreload_WithoutCredentialMismatchWarning()
+    public async Task Landing_LazyLoadsSearchIndexWithoutCredentialMismatchWarning()
     {
-        // Regression: ISSUE-002 — docs search preload credentials mismatch emitted browser warnings and disabled preload reuse.
-        // Found by /qa on 2026-04-18
-        // Report: .gstack/qa-reports/qa-report-localhost-5189-2026-04-18.md
+        // Ordinary docs pages now lazy-load search after focus/input/shortcut rather than preloading on first paint.
         await using var context = await _fixture.Browser.NewContextAsync();
         var page = await context.NewPageAsync();
         var preloadWarnings = CaptureCredentialMismatchWarnings(page);
 
         await page.GotoAsync(_fixture.DocsUrl);
+        await AssertSearchIndexResourceAbsentAsync(page);
+        await page.FocusAsync("#docs-search-input");
         await WaitForSearchIndexResourceAsync(page);
 
         Assert.Empty(preloadWarnings);
-        await AssertSearchIndexPreloadWasReusedAsync(page);
+        await AssertSearchIndexWasFetchedOnDemandAsync(page);
     }
 
     [Fact]
@@ -60,6 +60,14 @@ public sealed class RazorDocsSearchPreloadPlaywrightTests
             new PageWaitForFunctionOptions { Timeout = 30_000 });
     }
 
+    private static async Task AssertSearchIndexResourceAbsentAsync(IPage page)
+    {
+        var resourcePresent = await page.EvaluateAsync<bool>(
+            "() => performance.getEntriesByType('resource').some(entry => entry.name.includes('/docs/search-index.json'))");
+
+        Assert.False(resourcePresent);
+    }
+
     private static List<string> CaptureCredentialMismatchWarnings(IPage page)
     {
         var warnings = new List<string>();
@@ -84,5 +92,16 @@ public sealed class RazorDocsSearchPreloadPlaywrightTests
 
         Assert.True(linkEntryCount >= 1, "Expected the docs search index preload entry to be recorded.");
         Assert.Equal(0, fetchEntryCount);
+    }
+
+    private static async Task AssertSearchIndexWasFetchedOnDemandAsync(IPage page)
+    {
+        var linkEntryCount = await page.EvaluateAsync<int>(
+            "() => performance.getEntriesByType('resource').filter(entry => entry.name.includes('/docs/search-index.json') && entry.initiatorType === 'link').length");
+        var fetchEntryCount = await page.EvaluateAsync<int>(
+            "() => performance.getEntriesByType('resource').filter(entry => entry.name.includes('/docs/search-index.json') && entry.initiatorType === 'fetch').length");
+
+        Assert.Equal(0, linkEntryCount);
+        Assert.True(fetchEntryCount >= 1, "Expected the docs search index to be fetched after sidebar focus.");
     }
 }


### PR DESCRIPTION
## What changed

This PR upgrades RazorDocs search from a lightweight sidebar helper into a dedicated discovery workspace.

It adds:
- a server-rendered `/docs/search` shell with starter, loading, failure, and retry states
- URL-backed query and facet state, including filter-only browse and back/forward restoration
- richer search result presentation with breadcrumbs, badges, and safe term highlighting
- lazy search runtime/index loading on ordinary docs pages while keeping the advanced search page eager
- package-level search design documentation in `Web/ForgeTrust.Runnable.Web.RazorDocs/DESIGN.md`
- expanded RazorDocs controller/view coverage plus Playwright coverage for shortcuts, recovery, history, lazy loading, and retry behavior

## Why it changed

The existing docs search flow made it hard to discover content unless users already knew exactly what to type. The new flow gives RazorDocs a real search workspace with shareable filters, stronger entry points, and clearer recovery paths when search data is unavailable.

The final fix in this branch also addresses a retry-path bug where a preloaded `minisearch.min.js` script could fail without initializing `window.MiniSearch`, leaving the retry path stuck unless the loader replaced that spent script with a fresh runtime request.

## Impact

- Docs users can browse guides/examples/API with or without a text query.
- Keyboard shortcuts `/` and `Cmd/Ctrl+K` now work as first-class search entry points.
- Search failure states are recoverable instead of leaving the page stranded.
- Ordinary docs pages no longer pay the full search asset cost until users actually engage search.

## Validation

- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --filter FullyQualifiedName~RazorDocsSearch`

The focused Playwright search suite is green with 13 tests after the MiniSearch retry fix.