### PR TITLE
docs: improve RazorWire quickstart

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
@@ -166,6 +166,9 @@ Wraps content in a `<turbo-frame>`.
 - `loading`: load strategy such as `lazy`.
 - `permanent`: persists the element across Turbo page transitions.
 - `swr`: enables stale-while-revalidate behavior.
+- `client-module`: client module path or name to mount for hybrid islands.
+- `client-strategy`: mount timing such as `load`, `visible`, or `idle`.
+- `client-props`: JSON payload passed to the client module's mount function.
 
 ```html
 <rw:island id="sidebar" src="/Reactivity/Sidebar" loading="lazy" permanent="true">

--- a/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
@@ -10,7 +10,7 @@ This quickstart assumes you are in a clone of this repository with the .NET 10 S
 dotnet run --project examples/razorwire-mvc/RazorWireWebExample.csproj
 ```
 
-Open `http://localhost:5233/Reactivity`, wait for the `Permanent Island` card to load, then click the `+` button. The `Instance Score` and `Session Score` update in place without a full page reload.
+Open `http://localhost:5233/Reactivity` (or use the URL printed in the console if the port differs), wait for the `Permanent Island` card to load, then click the `+` button. The `Instance Score` and `Session Score` update in place without a full-page reload.
 
 ## Hero Proof
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
@@ -1,143 +1,225 @@
 # RazorWire
 
-**RazorWire** is a library for building modern, reactive web applications in ASP.NET Core using an **HTML-over-the-wire** approach. It integrates seamlessly with the Runnable module system to provide real-time updates, reactive components ("Islands"), and enhanced form handling without the complexity of a full SPA framework.
+RazorWire lets ASP.NET Core MVC apps update UI by returning Razor fragments from the server instead of building a separate JSON endpoint and client-state rendering loop.
 
-## Core Concepts
+## 60-Second Quickstart
 
-### 🏝️ Islands (Turbo Frames)
+This quickstart assumes you are in a clone of this repository with the .NET 10 SDK installed. The public package install matrix is still being finalized for v0.1, so the fastest way to feel RazorWire today is the in-repo sample.
 
-Islands are isolated regions of a page that can be loaded, reloaded, or updated independently. This is achieved using Turbo Frames, allowing you to decompose complex pages into smaller, manageable pieces.
+```bash
+dotnet run --project examples/razorwire-mvc/RazorWireWebExample.csproj
+```
 
-### 📡 Real-time Streaming (Turbo Streams & SSE)
+Open `http://localhost:5233/Reactivity`, wait for the `Permanent Island` card to load, then click the `+` button. The `Instance Score` and `Session Score` update in place without a full page reload.
 
-RazorWire uses Server-Sent Events (SSE) to push updates from the server to one or more clients. These updates are delivered as Turbo Streams, which can perform actions like `append`, `prepend`, `replace`, or `remove` on specific DOM elements.
+## Hero Proof
 
-### ⚡ Form Enhancement
+`examples/razorwire-mvc/Views/Shared/Components/Counter/Default.cshtml`
 
-Standard HTML forms are enhanced to perform partial-page updates. Instead of a full page reload or redirect, forms can return Turbo Stream actions to update only the necessary parts of the UI.
+```cshtml
+<div id="instance-score-value">@Model</div>
+<div id="session-score-value">0</div>
 
-## Security & Anti-Forgery
+<form asp-controller="Reactivity" asp-action="IncrementCounter" method="post" rw-active="true">
+    <input type="hidden" name="clientCount" id="client-count-input" value="0" />
+    <button type="submit">+</button>
+</form>
+```
 
-Handling Anti-Forgery tokens correctly is critical when updating forms via Turbo Streams. See [Security & Anti-Forgery](Docs/antiforgery.md) for detailed patterns and recommendations.
+`examples/razorwire-mvc/Controllers/ReactivityController.cs`
 
-## Getting Started
+```csharp
+[HttpPost]
+[ValidateAntiForgeryToken]
+public IActionResult IncrementCounter([FromForm] int clientCount)
+{
+    CounterViewComponent.Increment();
+    clientCount++;
 
-### 1. Add the Module
+    if (Request.IsTurboRequest())
+    {
+        return this.RazorWireStream()
+            .Update("instance-score-value", CounterViewComponent.Count.ToString())
+            .Update("session-score-value", clientCount.ToString())
+            .ReplacePartial("client-count-input", "_CounterInput", clientCount)
+            .BuildResult();
+    }
 
-To enable RazorWire in your Runnable application, add the `RazorWireWebModule` to your root module or application startup:
+    var referer = Request.Headers["Referer"].ToString();
+    return Url.IsLocalUrl(referer) ? Redirect(referer) : RedirectToAction(nameof(Index));
+}
+```
+
+`examples/razorwire-mvc/Views/Reactivity/_CounterInput.cshtml`
+
+```cshtml
+<input type="hidden" name="clientCount" id="client-count-input" value="@Model" />
+```
+
+Read the [focused proof path](../../examples/razorwire-mvc/README.md#start-here-return-razor-fragments) for the file-by-file walkthrough. If copying this pattern gives you a bare `400 Bad Request`, anti-forgery is the first thing to check. See [Security & Anti-Forgery](Docs/antiforgery.md).
+
+## Add the Module
+
+Once you already reference the RazorWire package in your app, add `RazorWireWebModule` to your root module:
 
 ```csharp
 public class MyRootModule : IRunnableWebModule
 {
     public void RegisterDependentModules(ModuleDependencyBuilder builder)
     {
-        builder.Add<RazorWireWebModule>();
+        builder.AddModule<RazorWireWebModule>();
     }
 }
 ```
 
-### 2. Configure Services (Optional)
+## Enable TagHelpers and Scripts
+
+RazorWire markup only lights up when your views import the package TagHelpers and your shared layout renders the client scripts once. Without this step, `rw:island`, `rw:stream-source`, and `rw-active` forms fall back to plain HTML behavior.
+
+`Views/_ViewImports.cshtml`
+
+```cshtml
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, ForgeTrust.Runnable.Web.RazorWire
+```
+
+`Views/Shared/_Layout.cshtml`
+
+```cshtml
+<head>
+    ...
+    <rw:scripts />
+</head>
+```
+
+## Configure Services (Optional)
 
 You can customize RazorWire behavior via `RazorWireOptions`:
 
 ```csharp
-services.AddRazorWire(options => {
+services.AddRazorWire(options =>
+{
     options.Streams.BasePath = "/custom-stream-path";
 });
 ```
 
-### 3. Use in Controllers
+## Also Possible
 
-Return reactive responses directly from your MVC controllers:
+- Keep sidebars and other regions independent with `rw:island`, including lazy loading and `permanent="true"` persistence across page transitions.
+- Push live updates to connected clients with `IRazorWireStreamHub` and `rw:stream-source`.
+- Return form updates from normal MVC controllers with `this.RazorWireStream()`, not a separate JSON API.
+- See the broader [RazorWire MVC Example](../../examples/razorwire-mvc/README.md) for registration, message publishing, islands, and SSE.
+- See [Security & Anti-Forgery](Docs/antiforgery.md) for the form-update patterns that matter in production.
 
-```csharp
-// Return an Island (Frame)
-return RazorWireBridge.Frame(this, "my-island-id", "_PartialViewName", model);
+## Core Concepts
 
-// Return a Stream update
-return this.RazorWireStream()
-    .Append("chat-list", "<li>New Message</li>")
-    .BuildResult();
-```
+### Islands
 
+Islands are isolated regions of a page that can load, reload, or update independently. RazorWire renders them as Turbo Frames, so you can decompose a page into smaller Razor-backed units without introducing a separate frontend app.
+
+### Streams and SSE
+
+RazorWire can push Turbo Stream updates to one or more clients over Server-Sent Events. That makes it a good fit for counters, feeds, presence lists, and other UI that should update live while staying server-rendered.
+
+### Form Enhancement
+
+Standard HTML forms can return targeted stream updates instead of full reloads or redirect-first flows. The counter example above is the smallest version of that story: submit a normal MVC form, return RazorWire updates, and change only the DOM you care about.
+
+## Security & Anti-Forgery
+
+Handling anti-forgery tokens correctly is critical when updating forms via Turbo Streams. See [Security & Anti-Forgery](Docs/antiforgery.md) for the detailed patterns and recommendations.
 
 ## Development Experience
 
-RazorWire is designed for a fast feedback loop during development. When running in the `Development` environment:
+RazorWire is designed for a fast feedback loop during development:
 
-*   **Live Razor Views**: Razor Runtime Compilation is automatically enabled, so you can edit `.cshtml` files and see changes on refresh without rebuilding.
-*   **Versioned Assets**: Scripts and stylesheets referenced with local paths (e.g., `~/js/site.js`) automatically receive version hashes for reliable cache busting, without needing `asp-append-version="true"`.
+- Razor Runtime Compilation is automatically enabled in `Development`, so you can edit `.cshtml` files and refresh without rebuilding.
+- Local scripts and styles automatically receive version hashes for cache busting, even without `asp-append-version="true"`.
 
 ## API Reference
 
-
 ### `RazorWireBridge`
 
-- **`Frame(controller, id, viewName, model)`**: Returns a partial view wrapped in a `<turbo-frame>` with the specified ID.
+- `Frame(controller, id, viewName, model)` returns a partial view wrapped in a `<turbo-frame>` with the specified ID.
+- `FrameComponent(controller, id, componentName)` renders a view component inside a `<turbo-frame>`.
 
 ### `IRazorWireStreamHub`
 
-The central hub for publishing real-time updates to connected clients.
-- **`PublishAsync(channel, content)`**: Broadcasts a Turbo Stream fragment to all subscribers of a specific channel.
+- `PublishAsync(channel, content)` broadcasts a Turbo Stream fragment to every subscriber on a channel.
 
-### `this.RazorWireStream()` (Controller Extension)
+### `this.RazorWireStream()` (controller extension)
 
-A fluent API for building Turbo Stream responses:
-- **`Append(target, content)`**: Adds content to the end of the target element.
-- **`Prepend(target, content)`**: Adds content to the beginning.
-- **`Replace(target, content)`**: Replaces the target element entirely.
-- **`Update(target, content)`**: Replaces the inner content of the target.
-- **`Remove(target)`**: Removes the target element.
+- `Append(target, content)` adds content to the end of the target element.
+- `Prepend(target, content)` adds content to the beginning.
+- `Replace(target, content)` replaces the target element entirely.
+- `Update(target, content)` replaces the inner content of the target.
+- `Remove(target)` removes the target element.
 
 ## TagHelpers
-
-RazorWire provides several TagHelpers to simplify working with Turbo Frames and Streams in Razor views.
 
 ### `rw:island`
 
 Wraps content in a `<turbo-frame>`.
-- **`id`**: Unique identifier for the island.
-- **`src`**: URL to load content from (optional).
-- **`loading`**: Set to `lazy` for deferred loading.
-- **`permanent`**: Persists the element across page transitions.
+
+- `id`: unique identifier for the island.
+- `src`: URL to load content from.
+- `loading`: load strategy such as `lazy`.
+- `permanent`: persists the element across Turbo page transitions.
+- `swr`: enables stale-while-revalidate behavior.
 
 ```html
-<rw:island id="sidebar" src="/reactivity/sidebar" loading="lazy">
+<rw:island id="sidebar" src="/Reactivity/Sidebar" loading="lazy" permanent="true">
     <p>Loading sidebar...</p>
 </rw:island>
 ```
 
-### `rw:form`
+### `form[rw-active]`
 
-Enhances a standard form to return Turbo Stream updates.
-- **`target`**: The frame to target (optional).
+Enhances a normal form so Turbo handles the submission and optional frame targeting.
+
+- `rw-active="true"` enables RazorWire form handling.
+- `rw-target` sets the target frame when you want to constrain the response.
 
 ```html
-<rw:form asp-action="Join" method="post">
-    <input type="text" name="Username" />
-    <button type="submit">Join</button>
-</rw:form>
+<form asp-controller="Reactivity" asp-action="IncrementCounter" method="post" rw-active="true">
+    <input type="hidden" name="clientCount" value="0" />
+    <button type="submit">+</button>
+</form>
 ```
 
-### `<time>` (Local Time)
+### `rw:stream-source`
 
-The `<time>` TagHelper provides a semantic way to render UTC timestamps that are automatically localized on the client side using the browser's **Intl formatting APIs**. This ensures that users see times in their own timezone and preferred format, with support for relative times (e.g., "5 minutes ago") that update automatically.
-- **`rw-type="local"`**: Opt-in attribute to enable RazorWire local time formatting.
-- **`rw-display`**: Display mode. Valid values: `time` (default), `date`, `datetime`, or `relative` (auto-updating).
-- **`rw-format`**: Format style for absolute modes. Valid values: `short`, `medium` (default), `long`, or `full`.
+Subscribes the page to a RazorWire stream channel.
+
+- `channel`: required channel name.
+- `permanent`: keeps the stream source alive across Turbo visits.
 
 ```html
-<!-- Relative auto-updating time (e.g., "5 minutes ago") -->
+<rw:stream-source id="rw-stream-reactivity" channel="reactivity" permanent="true"></rw:stream-source>
+```
+
+### `requires-stream`
+
+Marks an element as inactive until a named stream is connected.
+
+```html
+<button type="submit" requires-stream="reactivity">Send</button>
+```
+
+### `<time rw-type="local">`
+
+Localizes UTC timestamps on the client with the browser's `Intl` APIs.
+
+- `rw-display`: `time`, `date`, `datetime`, or `relative`.
+- `rw-format`: `short`, `medium`, `long`, or `full`.
+
+```html
 <time datetime="@Model.Timestamp" rw-type="local" rw-display="relative"></time>
-
-<!-- Short local date/time -->
-<time datetime="@Model.Timestamp" rw-type="local" rw-display="datetime" rw-format="short"></time>
 ```
-
 
 ### `rw:scripts`
 
-Injects necessary RazorWire and Turbo client scripts.
+Injects the client scripts RazorWire needs, including Turbo and the RazorWire assets.
 
 ```html
 <rw:scripts />
@@ -147,29 +229,25 @@ Injects necessary RazorWire and Turbo client scripts.
 
 ### `StringUtils`
 
-Provides safe identifier generation for DOM elements and URL anchors.
-- **`ToSafeId(input, appendHash)`**: Sanitizes strings by replacing non-alphanumeric characters with hyphens and collapse consecutive hyphens. Optionally appends a deterministic hash for uniqueness.
+- `ToSafeId(input, appendHash)` sanitizes values for DOM IDs or anchors and can append a deterministic hash for uniqueness.
 
-## Client-Side Interop (Hybrid Components)
+## Client-Side Interop
 
-RazorWire supports a hybrid approach where server-rendered "Islands" can be augmented with client-side modules (e.g., React, Vue, or Vanilla JS).
-
-- **`client-module`**: The name of the JavaScript module to initialize.
-- **`client-strategy`**: Initialization strategy (e.g., `load`, `idle`, `visible`).
-- **`client-props`**: JSON properties passed to the client module.
+RazorWire also supports hybrid islands where a server-rendered region mounts a client module:
 
 ```html
-<rw:island id="interactive-chart" 
-           client-module="ChartComponent" 
-           client-strategy="visible" 
+<rw:island id="interactive-chart"
+           client-module="ChartComponent"
+           client-strategy="visible"
            client-props='{ "data": [1, 2, 3] }'>
 </rw:island>
 ```
 
 ## Static Export
 
-RazorWire can be used to generate static or hybrid sites. For more details, see the [RazorWire CLI](../../Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md).
+RazorWire can generate static or hybrid sites. For more details, see the [RazorWire CLI](../../Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md).
 
 ## Examples
 
-For a practical demonstration of these features, see the [RazorWire MVC Example](../../examples/razorwire-mvc/README.md).
+- [Focused proof path: return Razor fragments](../../examples/razorwire-mvc/README.md#start-here-return-razor-fragments)
+- [Full RazorWire MVC example](../../examples/razorwire-mvc/README.md)

--- a/examples/razorwire-mvc/README.md
+++ b/examples/razorwire-mvc/README.md
@@ -1,77 +1,133 @@
 # RazorWire MVC Example
 
-This project is a reference implementation demonstrating how to build modern, reactive web applications using **RazorWire** within an ASP.NET Core MVC architecture.
+This sample is the concrete proof behind the RazorWire package README. It shows how returned Razor fragments, islands, and SSE fit into a normal ASP.NET Core MVC app without a separate client rendering stack.
 
-It showcases the core "HTML-over-the-wire" capabilities provided by the `ForgeTrust.Runnable.Web.RazorWire` library, including Turbo Frames (Islands), Turbo Streams, and Server-Sent Events (SSE).
+## Start Here: Return Razor Fragments
 
-## Features
+1. Run the application from the repository root:
 
-#### 🏝️ Islands (Turbo Frames)
+   ```bash
+   dotnet run --project examples/razorwire-mvc/RazorWireWebExample.csproj
+   ```
 
-RazorWire allows you to isolate regions of a page ("Islands") that can load or update independently.
-*   **Example**: The Sidebar and User List in the Reactivity demo are loaded as separate frames (`<turbo-frame>`).
-*   **Code**: See `ReactivityController.Sidebar()` and `RazorWireBridge.Frame()`.
+   This assumes you are in a clone of this repository with the .NET 10 SDK installed.
 
-### 📡 Real-time Streaming (SSE)
+   If you `cd examples/razorwire-mvc` first, `dotnet run` also works from there.
 
-Updates can be pushed from the server to connected clients via Server-Sent Events.
-*   **Example**: When a user posts a message or joins, the "User List" and "Messages" sections update in real-time for all connected clients.
-*   **Hub**: The `IRazorWireStreamHub` is used to publish updates to the `reactivity` channel.
+2. Open `http://localhost:5233/Reactivity` or use the port printed in the console if it differs.
+3. Wait for the `Permanent Island` sidebar to load.
+4. Click the `+` button in the counter widget.
+5. Watch `Instance Score` and `Session Score` update in place without a full page reload.
 
-### ⚡ Form Enhancement
+That is the core RazorWire workflow in one interaction: a normal MVC form posts, the controller returns targeted Razor fragments, and the UI updates only where it needs to.
 
-Forms are enhanced to perform partial page updates without full reloads.
-*   **Example**: The "Join" and "Send Message" forms return Turbo Stream responses (appending messages, updating counts) instead of redirecting.
-*   **Code**: See `ReactivityController.RegisterUser` and usage of `this.RazorWireStream()`.
+## What Just Happened
+
+```text
+/Reactivity
+  -> loads the Permanent Island from /Reactivity/Sidebar
+  -> renders the Counter view component inside that island
+  -> posts the counter form to ReactivityController.IncrementCounter
+  -> returns a RazorWire stream with targeted updates
+  -> updates the two counters and replaces the hidden input for the next click
+```
+
+## Files Behind the Hero Flow
+
+- `examples/razorwire-mvc/Views/Reactivity/Index.cshtml` loads the permanent island with `src="/Reactivity/Sidebar"`.
+- `examples/razorwire-mvc/Views/Shared/_Sidebar.cshtml` hosts the island content and invokes the `Counter` view component.
+- `examples/razorwire-mvc/Views/Shared/Components/Counter/Default.cshtml` renders the counter values plus the `IncrementCounter` form.
+- `examples/razorwire-mvc/Controllers/ReactivityController.cs` returns the targeted stream updates.
+- `examples/razorwire-mvc/Views/Reactivity/_CounterInput.cshtml` replaces the hidden `clientCount` input after each click.
+
+## Proof Slice
+
+`examples/razorwire-mvc/Views/Shared/Components/Counter/Default.cshtml`
+
+```cshtml
+<div id="instance-score-value" class="text-2xl font-black text-indigo-600 tabular-nums">@Model</div>
+<div id="session-score-value" class="text-2xl font-black text-indigo-400 tabular-nums">0</div>
+
+<form asp-controller="Reactivity" asp-action="IncrementCounter" method="post" rw-active="true" data-counter-form>
+    <input type="hidden" name="clientCount" id="client-count-input" value="0" />
+    <button type="submit">+</button>
+</form>
+```
+
+`examples/razorwire-mvc/Controllers/ReactivityController.cs`
+
+```csharp
+[HttpPost]
+[ValidateAntiForgeryToken]
+public IActionResult IncrementCounter([FromForm] int clientCount)
+{
+    CounterViewComponent.Increment();
+    clientCount++;
+
+    if (Request.IsTurboRequest())
+    {
+        return this.RazorWireStream()
+            .Update("instance-score-value", CounterViewComponent.Count.ToString())
+            .Update("session-score-value", clientCount.ToString())
+            .ReplacePartial("client-count-input", "_CounterInput", clientCount)
+            .BuildResult();
+    }
+
+    var referer = Request.Headers["Referer"].ToString();
+    return Url.IsLocalUrl(referer) ? Redirect(referer) : RedirectToAction(nameof(Index));
+}
+```
+
+`examples/razorwire-mvc/Views/Reactivity/_CounterInput.cshtml`
+
+```cshtml
+<input type='hidden' name='clientCount' id='client-count-input' value='@Model' />
+```
+
+## If Your Result Differs
+
+- If the page loads on a different port, use the URL printed by `dotnet run`.
+- If clicking `+` gives you a bare `400 Bad Request`, check the package docs for [Security & Anti-Forgery](../../Web/ForgeTrust.Runnable.Web.RazorWire/Docs/antiforgery.md). That is the first thing to verify when you copy this pattern into another page or app.
+- If the form does not update in place, check the same anti-forgery guidance first, then confirm you are still posting with `rw-active="true"` and returning a RazorWire stream from `IncrementCounter`.
+- If you want the broader sample context instead of the focused proof, continue below.
+
+## Broader Sample Features
+
+### Islands
+
+The sample uses `rw:island` to load and persist independent UI regions.
+
+- `ReactivityController.Sidebar()` returns the permanent sidebar island.
+- `ReactivityController.UserList()` returns the `UserList` view component inside its own island.
+- `Views/Home/Index.cshtml`, `Views/Reactivity/Index.cshtml`, and `Views/Navigation/Index.cshtml` all reuse the same `permanent-island` so it can persist across page transitions.
+
+### Live Updates over SSE
+
+The sample also demonstrates live multi-client updates.
+
+- `Views/Reactivity/Index.cshtml` includes `<rw:stream-source id="rw-stream-reactivity" channel="reactivity" permanent="true" />`.
+- `ReactivityController.PublishMessage()` pushes new messages to every connected client.
+- `ReactivityController.BroadcastUserPresenceAsync()` updates the user list and online count across sessions.
+
+### Registration and Message Publishing
+
+The reactivity page includes two additional form flows:
+
+- `Views/Reactivity/_UserRegistration.cshtml` posts to `RegisterUser` and swaps the register and message forms.
+- `Views/Reactivity/_MessageForm.cshtml` posts to `PublishMessage` and prepends messages into the live feed.
+
+Those flows are richer than the counter demo, but the counter is the cleanest first proof because it does not depend on stream-hub context to feel convincing.
 
 ## Project Structure
 
-*   **Controllers/ReactivityController.cs**: The main demo controller. It handles:
-  *   Rendering the main view.
-  *   Serving partial "Islands" (Sidebar, UserList).
-  *   Handling form POSTs and returning Stream responses.
-  *   Broadcasting updates via the Stream Hub.
-*   **Views/Reactivity/**: Contains the Razor views and partials for the demo.
-*   **Services/**: Simple in-memory services (`UserPresenceService`) to simulate state for the demo.
+- `Controllers/ReactivityController.cs`: main demo controller for islands, form posts, and stream responses.
+- `Views/Reactivity/`: reactivity page plus registration, message, and counter partials.
+- `Views/Shared/`: shared island and view component rendering.
+- `ViewComponents/`: view component entry points such as `Counter` and `UserList`.
+- `Services/`: in-memory sample services such as `UserPresenceService` and `MessageStore`.
 
-## Getting Started
+## Development Notes
 
-1.  **Run the application from the repository root**:
+To enable Razor Runtime Compilation and live static asset updates in the sample, run in the `Development` environment, for example with `ASPNETCORE_ENVIRONMENT=Development`.
 
-    ```bash
-    dotnet run --project examples/razorwire-mvc/RazorWireWebExample.csproj
-    ```
-
-    If you `cd examples/razorwire-mvc` first, `dotnet run` also works from there.
-
-2.  **Open the demo**:
-    Navigate to `http://localhost:5233` (or the port indicated in the console).
-    
-    > **Note**: To enable Razor Runtime Compilation and live static asset updates (e.g. for `razorwire.js`), ensure the application is running in the `Development` environment (e.g. `ASPNETCORE_ENVIRONMENT=Development`). This allows you to edit views and internal scripts and see changes on refresh without rebuilding.
-    >
-    > **Tip**: Local assets (like `site.js` and `site.css`) automatically receive version hashes for cache busting. You can still use `asp-append-version="true"` explicitly if desired.
-3.  **Test Reactivity**:
-    *   Open the app in multiple browser tabs.
-    *   Join with a username in one tab.
-    *   Observe the "Online Users" count update instantly in other tabs.
-    *   Send a message to see it appear everywhere.
-
-## Key Concepts
-
-**RazorWire Bridge**
-Helper methods to return Turbo-compatible responses.
-```csharp
-// Return a Frame (Island)
-return RazorWireBridge.Frame(this, "my-island-id", "_PartialViewName");
-
-// Return a Stream (Update)
-return this.RazorWireStream()
-    .Append("chat-list", "<li>New Message</li>")
-    .BuildResult();
-```
-
-**Stream Hub**
-Publishing updates to subscribers.
-```csharp
-await _hub.PublishAsync("channel-name", streamHtml);
-```
+Local assets such as `site.js` and `site.css` automatically receive version hashes for cache busting. You can still use `asp-append-version="true"` explicitly if you want to make that behavior obvious in markup.


### PR DESCRIPTION
Closes #118.

## Summary

- rewrite the RazorWire package README around a 60-second quickstart and a counter-based hero proof
- make the RazorWire MVC example README the single detailed proof path for returned Razor fragments
- document the missing bootstrap details for real app adoption, including TagHelpers, `<rw:scripts />`, repo-root assumptions, and anti-forgery troubleshooting

## Verification

- manual DX audit of the documented repo-root flow against the live sample
- pre-landing review: no remaining findings on the current README diff
- no automated tests run after the final docs-only bootstrap update

## Follow-ups

- #136 improve anti-forgery failure DX beyond bare 400 responses
- #138 add automated README verification for quickstart, links, and snippet drift