### PR TITLE
feat: add RazorDocs page type badges

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
@@ -1,0 +1,46 @@
+using ForgeTrust.Runnable.Web.RazorDocs.Models;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
+
+public sealed class DocMetadataPresentationTests
+{
+    [Theory]
+    [InlineData("guide", "Guide", "guide")]
+    [InlineData(" example ", "Example", "example")]
+    [InlineData("api_reference", "API Reference", "api-reference")]
+    [InlineData("how to", "How-To", "how-to")]
+    [InlineData("start-here", "Start Here", "start-here")]
+    [InlineData("faq", "FAQ", "glossary")]
+    public void ResolvePageTypeBadge_ShouldNormalizeKnownValues(string rawValue, string expectedLabel, string expectedVariant)
+    {
+        var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);
+
+        Assert.NotNull(badge);
+        Assert.Equal(expectedLabel, badge!.Label);
+        Assert.Equal(expectedVariant, badge.Variant);
+    }
+
+    [Theory]
+    [InlineData("custom_reference", "Custom Reference")]
+    [InlineData("cli_sdk", "CLI SDK")]
+    public void ResolvePageTypeBadge_ShouldFallbackToNeutralTitleCase_ForUnknownValues(string rawValue, string expectedLabel)
+    {
+        var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);
+
+        Assert.NotNull(badge);
+        Assert.Equal(expectedLabel, badge!.Label);
+        Assert.Equal("neutral", badge.Variant);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("__")]
+    public void ResolvePageTypeBadge_ShouldReturnNull_ForBlankValues(string? rawValue)
+    {
+        var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);
+
+        Assert.Null(badge);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
@@ -5,36 +5,45 @@ namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
 public sealed class DocMetadataPresentationTests
 {
     [Theory]
-    [InlineData("guide", "Guide", "guide")]
-    [InlineData(" example ", "Example", "example")]
-    [InlineData("api_reference", "API Reference", "api-reference")]
-    [InlineData("internals", "Internals", "internals")]
-    [InlineData("how to", "How-To", "how-to")]
-    [InlineData("start-here", "Start Here", "start-here")]
-    [InlineData("troubleshooting", "Troubleshooting", "troubleshooting")]
-    [InlineData("glossary", "Glossary", "glossary")]
-    [InlineData("faq", "FAQ", "faq")]
-    public void ResolvePageTypeBadge_ShouldNormalizeKnownValues(string rawValue, string expectedLabel, string expectedVariant)
+    [InlineData("guide", "guide", "Guide", "guide")]
+    [InlineData(" example ", "example", "Example", "example")]
+    [InlineData("api_reference", "api-reference", "API Reference", "api-reference")]
+    [InlineData("internals", "internals", "Internals", "internals")]
+    [InlineData("how to", "how-to", "How-To", "how-to")]
+    [InlineData("start-here", "start-here", "Start Here", "start-here")]
+    [InlineData("troubleshooting", "troubleshooting", "Troubleshooting", "troubleshooting")]
+    [InlineData("glossary", "glossary", "Glossary", "glossary")]
+    [InlineData("faq", "faq", "FAQ", "faq")]
+    public void ResolvePageTypeBadge_ShouldNormalizeKnownValues(
+        string rawValue,
+        string expectedValue,
+        string expectedLabel,
+        string expectedVariant)
     {
         var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);
 
         Assert.NotNull(badge);
-        Assert.Equal(expectedLabel, badge!.Label);
+        Assert.Equal(expectedValue, badge!.Value);
+        Assert.Equal(expectedLabel, badge.Label);
         Assert.Equal(expectedVariant, badge.Variant);
     }
 
     [Theory]
-    [InlineData("api_surface", "API Surface")]
-    [InlineData("custom_reference", "Custom Reference")]
-    [InlineData("cli_sdk", "CLI SDK")]
-    [InlineData("faq_overview", "FAQ Overview")]
-    [InlineData("ui_ux", "UI UX")]
-    public void ResolvePageTypeBadge_ShouldFallbackToNeutralTitleCase_ForUnknownValues(string rawValue, string expectedLabel)
+    [InlineData("api_surface", "api-surface", "API Surface")]
+    [InlineData("custom_reference", "custom-reference", "Custom Reference")]
+    [InlineData("cli_sdk", "cli-sdk", "CLI SDK")]
+    [InlineData("faq_overview", "faq-overview", "FAQ Overview")]
+    [InlineData("ui_ux", "ui-ux", "UI UX")]
+    public void ResolvePageTypeBadge_ShouldFallbackToNeutralTitleCase_ForUnknownValues(
+        string rawValue,
+        string expectedValue,
+        string expectedLabel)
     {
         var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);
 
         Assert.NotNull(badge);
-        Assert.Equal(expectedLabel, badge!.Label);
+        Assert.Equal(expectedValue, badge!.Value);
+        Assert.Equal(expectedLabel, badge.Label);
         Assert.Equal("neutral", badge.Variant);
     }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
@@ -13,7 +13,7 @@ public sealed class DocMetadataPresentationTests
     [InlineData("start-here", "Start Here", "start-here")]
     [InlineData("troubleshooting", "Troubleshooting", "troubleshooting")]
     [InlineData("glossary", "Glossary", "glossary")]
-    [InlineData("faq", "FAQ", "glossary")]
+    [InlineData("faq", "FAQ", "faq")]
     public void ResolvePageTypeBadge_ShouldNormalizeKnownValues(string rawValue, string expectedLabel, string expectedVariant)
     {
         var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataPresentationTests.cs
@@ -8,8 +8,11 @@ public sealed class DocMetadataPresentationTests
     [InlineData("guide", "Guide", "guide")]
     [InlineData(" example ", "Example", "example")]
     [InlineData("api_reference", "API Reference", "api-reference")]
+    [InlineData("internals", "Internals", "internals")]
     [InlineData("how to", "How-To", "how-to")]
     [InlineData("start-here", "Start Here", "start-here")]
+    [InlineData("troubleshooting", "Troubleshooting", "troubleshooting")]
+    [InlineData("glossary", "Glossary", "glossary")]
     [InlineData("faq", "FAQ", "glossary")]
     public void ResolvePageTypeBadge_ShouldNormalizeKnownValues(string rawValue, string expectedLabel, string expectedVariant)
     {
@@ -21,8 +24,11 @@ public sealed class DocMetadataPresentationTests
     }
 
     [Theory]
+    [InlineData("api_surface", "API Surface")]
     [InlineData("custom_reference", "Custom Reference")]
     [InlineData("cli_sdk", "CLI SDK")]
+    [InlineData("faq_overview", "FAQ Overview")]
+    [InlineData("ui_ux", "UI UX")]
     public void ResolvePageTypeBadge_ShouldFallbackToNeutralTitleCase_ForUnknownValues(string rawValue, string expectedLabel)
     {
         var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);
@@ -42,5 +48,13 @@ public sealed class DocMetadataPresentationTests
         var badge = DocMetadataPresentation.ResolvePageTypeBadge(rawValue);
 
         Assert.Null(badge);
+    }
+
+    [Fact]
+    public void NormalizeToken_ShouldReturnNull_WhenValueHasOnlySeparators()
+    {
+        var normalized = DocMetadataPresentation.NormalizeToken(" - _ \t ");
+
+        Assert.Null(normalized);
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -779,6 +779,7 @@ public class DocsControllerTests : IDisposable
         Assert.Equal(JsonValueKind.Null, document.GetProperty("component").ValueKind);
         Assert.Equal(JsonValueKind.Null, document.GetProperty("audience").ValueKind);
         Assert.Equal("Guide", document.GetProperty("pageTypeLabel").GetString());
+        Assert.Equal("guide", document.GetProperty("pageTypeVariant").GetString());
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -712,7 +712,7 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task SearchIndex_ShouldReturnJsonPayload()
+    public async Task SearchIndex_ShouldReturnJsonPayload_WithNormalizedPageTypeBadgeFields()
     {
         var docs = new List<DocNode>
         {
@@ -741,10 +741,44 @@ public class DocsControllerTests : IDisposable
         var document = Assert.Single(documents.EnumerateArray());
         Assert.Equal("Get started quickly.", document.GetProperty("summary").GetString());
         Assert.Equal("guide", document.GetProperty("pageType").GetString());
+        Assert.Equal("Guide", document.GetProperty("pageTypeLabel").GetString());
+        Assert.Equal("guide", document.GetProperty("pageTypeVariant").GetString());
         Assert.Equal("Runnable", document.GetProperty("component").GetString());
         Assert.Equal("Start Here", document.GetProperty("navGroup").GetString());
         Assert.Equal("quickstart", document.GetProperty("aliases").EnumerateArray().Single().GetString());
         Assert.Equal("install", document.GetProperty("keywords").EnumerateArray().Single().GetString());
+    }
+
+    [Fact]
+    public async Task SearchIndex_ShouldSuppressDerivedAudienceAndComponentFields()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Getting Started",
+                "guides/start",
+                "<h2>Install</h2><p>First steps.</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "Get started quickly.",
+                    PageType = "guide",
+                    Component = "Runnable",
+                    ComponentIsDerived = true,
+                    Audience = "implementer",
+                    AudienceIsDerived = true
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.SearchIndex();
+        var json = Assert.IsType<JsonResult>(result);
+
+        var payload = JsonSerializer.Serialize(json.Value);
+        using var doc = JsonDocument.Parse(payload);
+        var document = Assert.Single(doc.RootElement.GetProperty("documents").EnumerateArray());
+        Assert.Equal(JsonValueKind.Null, document.GetProperty("component").ValueKind);
+        Assert.Equal(JsonValueKind.Null, document.GetProperty("audience").ValueKind);
+        Assert.Equal("Guide", document.GetProperty("pageTypeLabel").GetString());
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -37,6 +37,21 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public void SearchClient_ShouldPersistAndRenderPageTypeBadgeFields()
+    {
+        var searchClient = ReadSearchClientMarkup();
+
+        Assert.Contains("'pageTypeLabel'", searchClient);
+        Assert.Contains("'pageTypeVariant'", searchClient);
+        Assert.Contains("function renderPageTypeBadge(item)", searchClient);
+        Assert.Contains("docs-search-option-title-row", searchClient);
+        Assert.Contains("docs-search-result-meta", searchClient);
+        Assert.Contains("docs-page-badge", searchClient);
+        Assert.Contains("const metadata = [", searchClient);
+        Assert.Contains("${metadata ? `<div class=\"docs-search-result-meta\">${metadata}</div>` : ''}", searchClient);
+    }
+
+    [Fact]
     public void Layout_ShouldKeepSidebarVisibleByDefault_ForNoScriptFallback()
     {
         var layout = ReadLayoutMarkup();
@@ -130,6 +145,7 @@ public class RazorDocsViewsTests
         Assert.Contains(">Composition</h2>", html);
         Assert.Contains("Follow the composition model.", html);
         Assert.Contains("Guide", html);
+        Assert.Contains("docs-page-badge--guide", html);
         Assert.Contains("href=\"/docs/guides/composition.md.html\"", html);
     }
 
@@ -173,7 +189,7 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
-    public async Task IndexView_ShouldFormatKnownPageTypes_AndHideCardBadgeWhenPageTypeIsMissing()
+    public async Task IndexView_ShouldFormatKnownAndUnknownPageTypes_AndHideCardBadgeWhenPageTypeIsMissing()
     {
         var docs = new List<DocNode>
         {
@@ -204,13 +220,19 @@ public class RazorDocsViewsTests
                         {
                             Question = "Untyped card",
                             Path = "guides/plain.md"
+                        },
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Custom card",
+                            Path = "guides/custom.md"
                         }
                     ]
                 }),
             new("API Page", "guides/api.md", "<p>API body</p>", Metadata: new DocMetadata { PageType = "api-reference" }),
             new("How-To Page", "guides/how-to.md", "<p>How-to body</p>", Metadata: new DocMetadata { PageType = "how-to" }),
             new("Start Page", "guides/start.md", "<p>Start body</p>", Metadata: new DocMetadata { PageType = "start-here" }),
-            new("Plain Page", "guides/plain.md", "<p>Plain body</p>")
+            new("Plain Page", "guides/plain.md", "<p>Plain body</p>"),
+            new("Custom Page", "guides/custom.md", "<p>Custom body</p>", Metadata: new DocMetadata { PageType = "custom_reference" })
         };
         using var services = CreateServiceProvider(docs);
 
@@ -219,17 +241,23 @@ public class RazorDocsViewsTests
 
         Assert.Equal(
             "API Reference",
-            document.QuerySelector("a.group[href='/docs/guides/api.md.html'] span.rounded-full")?.TextContent.Trim());
+            document.QuerySelector("a.group[href='/docs/guides/api.md.html'] span.docs-page-badge")?.TextContent.Trim());
         Assert.Equal(
             "How-To",
-            document.QuerySelector("a.group[href='/docs/guides/how-to.md.html'] span.rounded-full")?.TextContent.Trim());
+            document.QuerySelector("a.group[href='/docs/guides/how-to.md.html'] span.docs-page-badge")?.TextContent.Trim());
         Assert.Equal(
             "Start Here",
-            document.QuerySelector("a.group[href='/docs/guides/start.md.html'] span.rounded-full")?.TextContent.Trim());
+            document.QuerySelector("a.group[href='/docs/guides/start.md.html'] span.docs-page-badge")?.TextContent.Trim());
+        Assert.Equal(
+            "Custom Reference",
+            document.QuerySelector("a.group[href='/docs/guides/custom.md.html'] span.docs-page-badge")?.TextContent.Trim());
+        Assert.Contains(
+            "docs-page-badge--neutral",
+            document.QuerySelector("a.group[href='/docs/guides/custom.md.html'] span.docs-page-badge")?.ClassName ?? string.Empty);
 
         var untypedCard = document.QuerySelector("a.group[href='/docs/guides/plain.md.html']");
         Assert.NotNull(untypedCard);
-        Assert.Null(untypedCard!.QuerySelector("span.rounded-full"));
+        Assert.Null(untypedCard!.QuerySelector("span.docs-page-badge"));
         Assert.Null(untypedCard.QuerySelector("p.mt-3"));
     }
 
@@ -428,6 +456,64 @@ public class RazorDocsViewsTests
             doc);
 
         Assert.Contains("<p class=\"mt-3 max-w-3xl text-base text-slate-400\">This is the summary paragraph.</p>", html);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldRenderPageTypeBadge_AndMetadataContextChips()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Quickstart",
+            "guides/quickstart.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                PageType = "api-reference",
+                Component = "RazorDocs",
+                Audience = "Evaluators"
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        Assert.Equal("API Reference", document.QuerySelector(".docs-page-meta .docs-page-badge")?.TextContent.Trim());
+        Assert.Contains(
+            "docs-page-badge--api-reference",
+            document.QuerySelector(".docs-page-meta .docs-page-badge")?.ClassName ?? string.Empty);
+        Assert.Contains("Component: RazorDocs", html);
+        Assert.Contains("Audience: Evaluators", html);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldSuppressDerivedAudienceAndComponentChips()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Quickstart",
+            "guides/quickstart.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                PageType = "guide",
+                Component = "Runnable",
+                ComponentIsDerived = true,
+                Audience = "implementer",
+                AudienceIsDerived = true
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        Assert.Equal("Guide", document.QuerySelector(".docs-page-meta .docs-page-badge")?.TextContent.Trim());
+        Assert.DoesNotContain("Component: Runnable", html);
+        Assert.DoesNotContain("Audience: implementer", html);
+        Assert.Null(document.QuerySelector(".docs-page-meta .docs-metadata-chip"));
     }
 
     [Fact]
@@ -716,6 +802,20 @@ public class RazorDocsViewsTests
             "_Layout.cshtml");
 
         return File.ReadAllText(layoutPath);
+    }
+
+    private static string ReadSearchClientMarkup()
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var searchClientPath = Path.Combine(
+            repoRoot,
+            "Web",
+            "ForgeTrust.Runnable.Web.RazorDocs",
+            "wwwroot",
+            "docs",
+            "search-client.js");
+
+        return File.ReadAllText(searchClientPath);
     }
 
     private static async Task<string> RenderDocsViewAsync(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -367,6 +367,49 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task DetailsView_ShouldFallbackToModelTitle_WhenMetadataTitleIsNull()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Fallback Title",
+            "guides/null-title.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Title = null
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">Fallback Title</h1>", html);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldRenderTrimmedMetadataTitle_WhenMetadataTitleIsPresent()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Fallback Title",
+            "guides/trimmed-title.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Title = "  Authored Title  "
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">Authored Title</h1>", html);
+        Assert.DoesNotContain(">Fallback Title</h1>", html);
+    }
+
+    [Fact]
     public async Task DetailsView_ShouldFallbackToPathBreadcrumbLabels_WhenMetadataTargetsCannotBeVerified()
     {
         using var services = CreateServiceProvider(CreateDocs());
@@ -388,6 +431,54 @@ public class RazorDocsViewsTests
         Assert.Contains(">Quickstart</h1>", html);
         Assert.Contains(">quickstart.md</span>", html);
         Assert.DoesNotContain("Start Here", html);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldFallbackToPathBreadcrumbLabels_WhenMetadataBreadcrumbCountDoesNotMatchPath()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Quickstart",
+            "guides/quickstart.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Breadcrumbs = ["Start Here", "Quickstart", "Extra"],
+                BreadcrumbsMatchPathTargets = true
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">guides</a>", html);
+        Assert.Contains(">quickstart.md</span>", html);
+        Assert.DoesNotContain(">Start Here</a>", html);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldFallbackToPathBreadcrumbLabels_WhenMetadataBreadcrumbsCollapseToEmpty()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Quickstart",
+            "guides/quickstart.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Breadcrumbs = ["   ", "\t"],
+                BreadcrumbsMatchPathTargets = true
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">guides</a>", html);
+        Assert.Contains(">quickstart.md</span>", html);
+        Assert.DoesNotContain(">Start Here</a>", html);
     }
 
     [Fact]
@@ -448,6 +539,27 @@ public class RazorDocsViewsTests
             {
                 Summary = "This is the summary paragraph.",
                 SummaryIsDerived = false
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains("<p class=\"mt-3 max-w-3xl text-base text-slate-400\">This is the summary paragraph.</p>", html);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldRenderSummaryBlurb_WhenDerivedFlagIsUnset()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Quickstart",
+            "guides/quickstart.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Summary = "This is the summary paragraph."
             });
 
         var html = await RenderViewAsync(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -48,7 +48,10 @@ public class RazorDocsViewsTests
         Assert.Contains("docs-search-result-meta", searchClient);
         Assert.Contains("docs-page-badge", searchClient);
         Assert.Contains("const metadata = [", searchClient);
-        Assert.Contains("${metadata ? `<div class=\"docs-search-result-meta\">${metadata}</div>` : ''}", searchClient);
+        Assert.Contains("metadata ?", searchClient);
+        Assert.Contains("<div class=\"docs-search-result-meta\">", searchClient);
+        Assert.Contains("${metadata}", searchClient);
+        Assert.Contains(": ''", searchClient);
     }
 
     [Fact]
@@ -626,6 +629,32 @@ public class RazorDocsViewsTests
         Assert.DoesNotContain("Component: Runnable", html);
         Assert.DoesNotContain("Audience: implementer", html);
         Assert.Null(document.QuerySelector(".docs-page-meta .docs-metadata-chip"));
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldNotRenderMetaContainer_WhenBadgeAndChipsAreUnavailable()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Quickstart",
+            "guides/quickstart.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                PageType = "   ",
+                Component = "Runnable",
+                ComponentIsDerived = true,
+                Audience = "implementer",
+                AudienceIsDerived = true
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        Assert.Null(document.QuerySelector(".docs-page-meta"));
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -105,7 +105,10 @@ public class DocsController : Controller
     /// <summary>
     /// Returns docs search index data for live-hosted docs.
     /// </summary>
-    /// <returns>A JSON result containing searchable document metadata and content fields.</returns>
+    /// <returns>
+    /// A JSON result containing searchable document metadata, including normalized page-type badge fields that keep search
+    /// result rendering consistent with the built-in landing and details experiences.
+    /// </returns>
     [HttpGet]
     public async Task<IActionResult> SearchIndex()
     {
@@ -236,6 +239,7 @@ public class DocsController : Controller
             var question = string.IsNullOrWhiteSpace(definition.Question)
                 ? destinationTitle
                 : definition.Question.Trim();
+            var pageTypeBadge = DocMetadataPresentation.ResolvePageTypeBadge(destination.Metadata?.PageType);
 
             resolvedCards.Add(
                 new DocLandingFeaturedPageViewModel
@@ -244,6 +248,7 @@ public class DocsController : Controller
                     Title = destinationTitle,
                     Href = $"/docs/{destinationLinkPath}",
                     PageType = destination.Metadata?.PageType,
+                    PageTypeBadge = pageTypeBadge,
                     SupportingText = GetSupportingText(definition, destination)
                 });
         }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocMetadataPresentation.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocMetadataPresentation.cs
@@ -58,7 +58,7 @@ public static class DocMetadataPresentation
             "start-here" => ("Start Here", "start-here"),
             "troubleshooting" => ("Troubleshooting", "troubleshooting"),
             "glossary" => ("Glossary", "glossary"),
-            "faq" => ("FAQ", "glossary"),
+            "faq" => ("FAQ", "faq"),
             _ => (BuildFallbackLabel(normalizedValue), "neutral")
         };
 
@@ -70,6 +70,18 @@ public static class DocMetadataPresentation
         };
     }
 
+    /// <summary>
+    /// Normalizes a raw metadata token into a lowercase dash-delimited value.
+    /// </summary>
+    /// <param name="value">Raw metadata token that may contain whitespace, underscores, dashes, or line breaks.</param>
+    /// <returns>
+    /// A normalized token, or <see langword="null"/> when <paramref name="value"/> is null, whitespace, or produces
+    /// no non-delimiter segments after trimming and splitting.
+    /// </returns>
+    /// <remarks>
+    /// RazorDocs trims the input, splits on spaces, tabs, carriage returns, line feeds, underscores, and hyphens,
+    /// removes empty segments, lowercases each remaining segment, and rejoins them with <c>-</c>.
+    /// </remarks>
     internal static string? NormalizeToken(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocMetadataPresentation.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocMetadataPresentation.cs
@@ -1,0 +1,113 @@
+using System.Globalization;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Models;
+
+/// <summary>
+/// Presentation metadata for one normalized documentation page-type badge.
+/// </summary>
+public sealed record DocPageTypeBadgePresentation
+{
+    /// <summary>
+    /// Gets the normalized machine-readable page-type value.
+    /// </summary>
+    public string Value { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the human-readable badge label.
+    /// </summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the badge variant suffix used by built-in RazorDocs CSS classes such as <c>docs-page-badge--guide</c>.
+    /// </summary>
+    public string Variant { get; init; } = "neutral";
+}
+
+/// <summary>
+/// Converts raw documentation metadata values into consistent UI-facing labels and badge variants.
+/// </summary>
+/// <remarks>
+/// Use this helper from Razor views, search payload generation, or custom UI surfaces when you want the built-in
+/// RazorDocs page-type treatment to remain consistent across landing, detail, and search experiences.
+/// </remarks>
+public static class DocMetadataPresentation
+{
+    /// <summary>
+    /// Resolves the built-in RazorDocs page-type badge presentation for a raw metadata value.
+    /// </summary>
+    /// <param name="pageType">The raw page-type metadata value, such as <c>guide</c> or <c>api-reference</c>.</param>
+    /// <returns>
+    /// A normalized badge presentation when <paramref name="pageType"/> is non-empty; otherwise, <see langword="null"/>.
+    /// Unknown page types fall back to a neutral badge with a title-cased label.
+    /// </returns>
+    public static DocPageTypeBadgePresentation? ResolvePageTypeBadge(string? pageType)
+    {
+        var normalizedValue = NormalizeToken(pageType);
+        if (normalizedValue is null)
+        {
+            return null;
+        }
+
+        var (label, variant) = normalizedValue switch
+        {
+            "guide" => ("Guide", "guide"),
+            "example" => ("Example", "example"),
+            "api-reference" => ("API Reference", "api-reference"),
+            "internals" => ("Internals", "internals"),
+            "how-to" => ("How-To", "how-to"),
+            "start-here" => ("Start Here", "start-here"),
+            "troubleshooting" => ("Troubleshooting", "troubleshooting"),
+            "glossary" => ("Glossary", "glossary"),
+            "faq" => ("FAQ", "glossary"),
+            _ => (BuildFallbackLabel(normalizedValue), "neutral")
+        };
+
+        return new DocPageTypeBadgePresentation
+        {
+            Value = normalizedValue,
+            Label = label,
+            Variant = variant
+        };
+    }
+
+    internal static string? NormalizeToken(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var segments = value
+            .Trim()
+            .Split([' ', '\t', '\r', '\n', '_', '-'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return segments.Length == 0
+            ? null
+            : string.Join("-", segments.Select(segment => segment.ToLowerInvariant()));
+    }
+
+    private static string BuildFallbackLabel(string normalizedValue)
+    {
+        var textInfo = CultureInfo.InvariantCulture.TextInfo;
+
+        static string FormatSegment(TextInfo textInfo, string segment)
+        {
+            return segment switch
+            {
+                "api" => "API",
+                "cli" => "CLI",
+                "faq" => "FAQ",
+                "sdk" => "SDK",
+                "ui" => "UI",
+                "ux" => "UX",
+                _ => textInfo.ToTitleCase(segment)
+            };
+        }
+
+        return string.Join(
+            " ",
+            normalizedValue
+                .Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(segment => FormatSegment(textInfo, segment)));
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -350,6 +350,11 @@ public sealed record DocLandingFeaturedPageViewModel
     public string? PageType { get; init; }
 
     /// <summary>
+    /// Gets the normalized badge presentation for <see cref="PageType"/> when RazorDocs can render one.
+    /// </summary>
+    public DocPageTypeBadgePresentation? PageTypeBadge { get; init; }
+
+    /// <summary>
     /// Gets the supporting body copy shown on the card.
     /// </summary>
     public string? SupportingText { get; init; }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -64,6 +64,25 @@ featured_pages:
 - If a featured path is missing, hidden from public navigation, or duplicated, RazorDocs skips it and logs a warning.
 - If all featured entries are skipped, RazorDocs falls back to the neutral docs index instead of rendering broken cards.
 
+## Metadata-Driven Page Type Display
+
+RazorDocs treats `page_type` metadata as structured UI input, not just as opaque search metadata. The built-in landing cards, detail pages, and search results all normalize the same metadata through `DocMetadataPresentation.ResolvePageTypeBadge()`.
+
+### Built-in normalization
+
+- Known values such as `guide`, `example`, `api-reference`, `internals`, `how-to`, `start-here`, `troubleshooting`, and `glossary` render with stable labels and intentional badge variants.
+- Unknown values still render safely: RazorDocs normalizes whitespace, underscores, and dashes, then falls back to a neutral title-cased badge.
+- Missing or blank `page_type` values render no badge at all instead of leaving empty chrome behind.
+
+### Search payload contract
+
+The `/docs/search-index.json` payload continues to emit the raw `pageType` metadata value and now also includes:
+
+- `pageTypeLabel` for the normalized display label used by the built-in search UI
+- `pageTypeVariant` for the built-in badge variant suffix used by CSS classes such as `docs-page-badge--guide`
+
+These fields let custom search clients stay visually aligned with the landing and detail experiences without re-implementing the mapping table.
+
 ## Related Projects
 
 - [ForgeTrust.Runnable.Web.RazorDocs.Standalone](../ForgeTrust.Runnable.Web.RazorDocs.Standalone/README.md) for the runnable/exportable host used in docs export and smoke testing

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -70,7 +70,7 @@ RazorDocs treats `page_type` metadata as structured UI input, not just as opaque
 
 ### Built-in normalization
 
-- Known values such as `guide`, `example`, `api-reference`, `internals`, `how-to`, `start-here`, `troubleshooting`, and `glossary` render with stable labels and intentional badge variants.
+- Known values such as `guide`, `example`, `api-reference`, `internals`, `how-to`, `start-here`, `troubleshooting`, `glossary`, and `faq` render with stable labels and intentional badge variants.
 - Unknown values still render safely: RazorDocs normalizes whitespace, underscores, and dashes, then falls back to a neutral title-cased badge.
 - Missing or blank `page_type` values render no badge at all instead of leaving empty chrome behind.
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -341,6 +341,7 @@ public class DocAggregator
                         .Distinct(StringComparer.OrdinalIgnoreCase)
                         .Take(MaxHeadingsPerDocument)
                         .ToList();
+                    var pageTypeBadge = DocMetadataPresentation.ResolvePageTypeBadge(d.Metadata?.PageType);
 
                     return new
                     {
@@ -352,8 +353,10 @@ public class DocAggregator
                         bodyText,
                         snippet,
                         pageType = d.Metadata?.PageType,
-                        audience = d.Metadata?.Audience,
-                        component = d.Metadata?.Component,
+                        pageTypeLabel = pageTypeBadge?.Label,
+                        pageTypeVariant = pageTypeBadge?.Variant,
+                        audience = d.Metadata?.AudienceIsDerived == true ? null : d.Metadata?.Audience,
+                        component = d.Metadata?.ComponentIsDerived == true ? null : d.Metadata?.Component,
                         aliases = d.Metadata?.Aliases ?? [],
                         keywords = d.Metadata?.Keywords ?? [],
                         status = d.Metadata?.Status,

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
@@ -1,23 +1,26 @@
 @model ForgeTrust.Runnable.Web.RazorDocs.Models.DocNode
 @{
-    var resolvedTitle = string.IsNullOrWhiteSpace(Model.Metadata?.Title)
+    var metadata = Model.Metadata;
+    var resolvedTitle = string.IsNullOrWhiteSpace(metadata?.Title)
         ? Model.Title
-        : Model.Metadata!.Title!.Trim();
-    var summary = Model.Metadata?.Summary;
-    var showSummary = !string.IsNullOrWhiteSpace(summary) && Model.Metadata?.SummaryIsDerived != true;
+        : metadata!.Title!.Trim();
+    var summary = metadata?.Summary;
+    var hasSummary = !string.IsNullOrWhiteSpace(summary);
+    var summaryIsDerived = metadata?.SummaryIsDerived == true;
+    var showSummary = hasSummary && !summaryIsDerived;
     ViewData["Title"] = resolvedTitle;
     var isCSharpApiDoc = Model.Path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
-    var pageTypeBadge = DocMetadataPresentation.ResolvePageTypeBadge(Model.Metadata?.PageType);
-    var component = Model.Metadata?.ComponentIsDerived == true || string.IsNullOrWhiteSpace(Model.Metadata?.Component)
+    var pageTypeBadge = DocMetadataPresentation.ResolvePageTypeBadge(metadata?.PageType);
+    var component = metadata?.ComponentIsDerived == true || string.IsNullOrWhiteSpace(metadata?.Component)
         ? null
-        : Model.Metadata!.Component!.Trim();
-    var audience = Model.Metadata?.AudienceIsDerived == true || string.IsNullOrWhiteSpace(Model.Metadata?.Audience)
+        : metadata!.Component!.Trim();
+    var audience = metadata?.AudienceIsDerived == true || string.IsNullOrWhiteSpace(metadata?.Audience)
         ? null
-        : Model.Metadata!.Audience!.Trim();
+        : metadata!.Audience!.Trim();
     var normalizedPath = Model.Path.Trim().Trim('/');
     var isNamespacePath = normalizedPath.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
                           || normalizedPath.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
-    var metadataBreadcrumbs = Model.Metadata?.Breadcrumbs?
+    var metadataBreadcrumbs = metadata?.Breadcrumbs?
         .Where(label => !string.IsNullOrWhiteSpace(label))
         .Select(label => label.Trim())
         .ToList();
@@ -54,9 +57,13 @@
     }
 
     var breadcrumbs = new List<(string Label, string? Href)>();
-    var canUseMetadataBreadcrumbs = metadataBreadcrumbs is { Count: > 0 }
-                                    && Model.Metadata?.BreadcrumbsMatchPathTargets == true
-                                    && metadataBreadcrumbs.Count == parsedBreadcrumbs.Count;
+    var metadataBreadcrumbCount = metadataBreadcrumbs?.Count ?? 0;
+    var hasMetadataBreadcrumbs = metadataBreadcrumbCount > 0;
+    var metadataBreadcrumbsMatchPathTargets = metadata?.BreadcrumbsMatchPathTargets == true;
+    var metadataBreadcrumbCountMatchesPath = metadataBreadcrumbCount == parsedBreadcrumbs.Count;
+    var canUseMetadataBreadcrumbs = hasMetadataBreadcrumbs
+                                    && metadataBreadcrumbsMatchPathTargets
+                                    && metadataBreadcrumbCountMatchesPath;
 
     if (canUseMetadataBreadcrumbs)
     {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
@@ -7,6 +7,13 @@
     var showSummary = !string.IsNullOrWhiteSpace(summary) && Model.Metadata?.SummaryIsDerived != true;
     ViewData["Title"] = resolvedTitle;
     var isCSharpApiDoc = Model.Path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
+    var pageTypeBadge = DocMetadataPresentation.ResolvePageTypeBadge(Model.Metadata?.PageType);
+    var component = Model.Metadata?.ComponentIsDerived == true || string.IsNullOrWhiteSpace(Model.Metadata?.Component)
+        ? null
+        : Model.Metadata!.Component!.Trim();
+    var audience = Model.Metadata?.AudienceIsDerived == true || string.IsNullOrWhiteSpace(Model.Metadata?.Audience)
+        ? null
+        : Model.Metadata!.Audience!.Trim();
     var normalizedPath = Model.Path.Trim().Trim('/');
     var isNamespacePath = normalizedPath.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
                           || normalizedPath.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
@@ -89,6 +96,23 @@
             }
         }
     </nav>
+    @if (pageTypeBadge is not null || component is not null || audience is not null)
+    {
+        <div class="docs-page-meta">
+            @if (pageTypeBadge is not null)
+            {
+                <span class="docs-page-badge docs-page-badge--@pageTypeBadge.Variant">@pageTypeBadge.Label</span>
+            }
+            @if (component is not null)
+            {
+                <span class="docs-metadata-chip">Component: @component</span>
+            }
+            @if (audience is not null)
+            {
+                <span class="docs-metadata-chip">Audience: @audience</span>
+            }
+        </div>
+    }
     @if (!isCSharpApiDoc)
     {
         <h1 class="text-3xl font-bold text-white tracking-tight">@resolvedTitle</h1>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Index.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Index.cshtml
@@ -3,23 +3,6 @@
 @{
     ViewData["Title"] = "Documentation Index";
     var visibleDocs = Model.VisibleDocs.ToList();
-
-    static string? FormatPageType(string? pageType)
-    {
-        if (string.IsNullOrWhiteSpace(pageType))
-        {
-            return null;
-        }
-
-        return pageType.Trim().ToLowerInvariant() switch
-        {
-            "api-reference" => "API Reference",
-            "how-to" => "How-To",
-            "start-here" => "Start Here",
-            _ => System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(
-                pageType.Replace('-', ' ').Replace('_', ' ').Trim().ToLowerInvariant())
-        };
-    }
 }
 
 <div class="flex flex-col items-center justify-center h-full p-6 sm:p-8 lg:p-12 text-center text-slate-500">
@@ -38,15 +21,15 @@
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 w-full max-w-6xl text-left">
             @foreach (var featuredPage in Model.FeaturedPages)
             {
-                var pageTypeLabel = FormatPageType(featuredPage.PageType);
+                var pageTypeBadge = featuredPage.PageTypeBadge ?? DocMetadataPresentation.ResolvePageTypeBadge(featuredPage.PageType);
                 <a href="@featuredPage.Href"
                    class="group h-full rounded-2xl border border-slate-800 bg-slate-900/60 p-6 transition-colors hover:border-cyan-500/50 hover:bg-slate-900">
                     <div class="mb-4 flex items-start justify-between gap-4">
                         <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400">@featuredPage.Question</p>
-                        @if (!string.IsNullOrWhiteSpace(pageTypeLabel))
+                        @if (pageTypeBadge is not null)
                         {
-                            <span class="rounded-full border border-cyan-500/30 bg-cyan-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-cyan-200">
-                                @pageTypeLabel
+                            <span class="docs-page-badge docs-page-badge--@pageTypeBadge.Variant">
+                                @pageTypeBadge.Label
                             </span>
                         }
                     </div>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search-client.js
@@ -231,6 +231,34 @@
       .replaceAll("'", '&#39;');
   }
 
+  function normalizeBadgeVariant(value) {
+    const normalized = String(value ?? '')
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9-]/g, '');
+
+    return normalized || 'neutral';
+  }
+
+  function renderPageTypeBadge(item) {
+    const label = String(item?.pageTypeLabel ?? '').trim();
+    if (!label) {
+      return '';
+    }
+
+    const variant = normalizeBadgeVariant(item?.pageTypeVariant);
+    return `<span class="docs-page-badge docs-page-badge--${escapeHtml(variant)}">${escapeHtml(label)}</span>`;
+  }
+
+  function renderMetadataChip(label, value) {
+    const normalizedValue = String(value ?? '').trim();
+    if (!normalizedValue) {
+      return '';
+    }
+
+    return `<span class="docs-metadata-chip">${escapeHtml(label)}: ${escapeHtml(normalizedValue)}</span>`;
+  }
+
   function getLocationLabel(item) {
     const context = item?.navGroup || item?.component || '';
     const path = item?.path || '';
@@ -335,7 +363,7 @@
     const MiniSearch = window.MiniSearch;
     searchIndex = new MiniSearch({
       fields: ['title', 'aliases', 'keywords', 'summary', 'headings', 'bodyText'],
-      storeFields: ['id', 'path', 'title', 'snippet', 'summary', 'pageType', 'component', 'audience', 'status', 'navGroup'],
+      storeFields: ['id', 'path', 'title', 'snippet', 'summary', 'pageType', 'pageTypeLabel', 'pageTypeVariant', 'component', 'audience', 'status', 'navGroup'],
       searchOptions: defaultSearchOptions
     });
 
@@ -350,6 +378,8 @@
       bodyText: d.bodyText ?? '',
       snippet: d.snippet ?? '',
       pageType: d.pageType ?? '',
+      pageTypeLabel: d.pageTypeLabel ?? '',
+      pageTypeVariant: d.pageTypeVariant ?? '',
       component: d.component ?? '',
       audience: d.audience ?? '',
       status: d.status ?? '',
@@ -500,9 +530,13 @@
     results.classList.remove('hidden');
     results.innerHTML = queryResults.map((item, index) => {
       const selected = index === activeIndex ? 'true' : 'false';
+      const pageTypeBadge = renderPageTypeBadge(item);
       return `<li id="docs-search-option-${index}" role="option" aria-selected="${selected}" tabindex="-1" class="docs-search-option" data-href="${escapeHtml(item.path)}">
         <a href="${escapeHtml(item.path)}" data-turbo-frame="doc-content" data-turbo-action="advance">
-          <span class="docs-search-option-title">${escapeHtml(item.title)}</span>
+          <span class="docs-search-option-title-row">
+            <span class="docs-search-option-title">${escapeHtml(item.title)}</span>
+            ${pageTypeBadge}
+          </span>
           <span class="docs-search-option-path">${escapeHtml(getLocationLabel(item))}</span>
         </a>
       </li>`;
@@ -547,13 +581,22 @@
       return;
     }
 
-    results.innerHTML = queryResults.map((item) => `
+    results.innerHTML = queryResults.map((item) => {
+      const metadata = [
+        renderPageTypeBadge(item),
+        renderMetadataChip('Component', item.component),
+        renderMetadataChip('Audience', item.audience)
+      ].filter(Boolean).join('');
+
+      return `
       <article class="docs-search-result">
+        ${metadata ? `<div class="docs-search-result-meta">${metadata}</div>` : ''}
         <h2><a href="${escapeHtml(item.path)}">${escapeHtml(item.title)}</a></h2>
         <p class="docs-search-result-path">${escapeHtml(getLocationLabel(item))}</p>
         <p class="docs-search-result-snippet">${escapeHtml(item.summary || item.snippet || '')}</p>
       </article>
-    `).join('');
+    `;
+    }).join('');
   }
 
   function setStatus(node, text) {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
@@ -67,7 +67,8 @@
 }
 
 .docs-page-badge--api-reference,
-.docs-page-badge--glossary {
+.docs-page-badge--glossary,
+.docs-page-badge--faq {
     border-color: rgba(99, 102, 241, 0.38);
     background: rgba(99, 102, 241, 0.12);
     color: #c7d2fe;

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
@@ -33,10 +33,83 @@
     display: none;
 }
 
+.docs-page-badge,
+.docs-metadata-chip {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    border: 1px solid #334155;
+    padding: 0.2rem 0.65rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.25;
+    background: rgba(15, 23, 42, 0.72);
+}
+
+.docs-page-badge {
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #cbd5e1;
+}
+
+.docs-page-badge--guide,
+.docs-page-badge--how-to,
+.docs-page-badge--start-here {
+    border-color: rgba(34, 211, 238, 0.35);
+    background: rgba(34, 211, 238, 0.12);
+    color: #a5f3fc;
+}
+
+.docs-page-badge--example {
+    border-color: rgba(16, 185, 129, 0.35);
+    background: rgba(16, 185, 129, 0.12);
+    color: #a7f3d0;
+}
+
+.docs-page-badge--api-reference,
+.docs-page-badge--glossary {
+    border-color: rgba(99, 102, 241, 0.38);
+    background: rgba(99, 102, 241, 0.12);
+    color: #c7d2fe;
+}
+
+.docs-page-badge--internals,
+.docs-page-badge--troubleshooting {
+    border-color: rgba(251, 191, 36, 0.4);
+    background: rgba(251, 191, 36, 0.12);
+    color: #fde68a;
+}
+
+.docs-page-badge--neutral {
+    color: #cbd5e1;
+}
+
+.docs-metadata-chip {
+    color: #cbd5e1;
+}
+
+.docs-page-meta,
+.docs-search-result-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.docs-page-meta {
+    margin-bottom: 1rem;
+}
+
 .docs-search-option a {
     display: block;
     padding: 0.55rem 0.65rem;
     text-decoration: none;
+}
+
+.docs-search-option-title-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
 }
 
 .docs-search-option-title {
@@ -85,8 +158,12 @@
     background: #020617;
 }
 
+.docs-search-result-meta {
+    margin-bottom: 0.65rem;
+}
+
 .docs-search-result h2 {
-    margin: 0;
+    margin: 0 0 0.15rem;
     font-size: 1.05rem;
 }
 


### PR DESCRIPTION
## What changed

This adds metadata-driven page type badges across the built-in RazorDocs experience.

- adds a shared `DocMetadataPresentation` helper to normalize page type labels and badge variants
- renders page type badges on the docs landing, detail pages, and search results
- extends the search index payload with `pageTypeLabel` and `pageTypeVariant` so the client renderer stays aligned with the server-side views
- adds shared badge and metadata-chip styling for RazorDocs search/detail surfaces
- updates RazorDocs package documentation for the new metadata-driven display contract

## Why it changed

Phase 2 of the RazorDocs roadmap calls for page type metadata to become visible and scannable across the evaluator experience. Before this change, page type handling was inconsistent and the search UI had no shared display contract.

## User and developer impact

- readers can distinguish guides, examples, API reference pages, and other typed docs more quickly
- custom clients consuming `/docs/search-index.json` now have normalized badge fields available without reimplementing the mapping logic
- authored metadata remains the source of truth, while missing values still degrade safely

## Root cause / follow-up fixes

The initial badge pass exposed two follow-up issues during review:

- derived `Audience` and `Component` metadata were too noisy to render as chips for markdown docs
- search results always rendered the meta wrapper, leaving an empty spacer for untyped results

This PR includes the follow-up fixes so only explicit audience/component values render, and the search result meta block appears only when it has content.

## Validation

- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --filter Search_RemainsFunctional_AfterTurboNavigationToAdvancedSearch`
- `dotnet format Web/ForgeTrust.Runnable.Web.RazorDocs/ForgeTrust.Runnable.Web.RazorDocs.csproj`
- `dotnet format Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
