### PR TITLE
feat: add RazorDocs markdown sidecar metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,3 @@
----
-title: Runnable
-summary: Runnable gives .NET teams a modular startup pipeline for web, console, and distributed apps. Start with the pillar you need, then drill into concrete examples and API reference.
-featured_pages:
-  - question: How do I ship a web app with Runnable?
-    path: Web/README.md
-    supporting_copy: See the web surface that composes middleware, endpoints, and host startup without a monolithic Program.cs.
-    order: 10
-  - question: Show me a working app, not just abstractions
-    path: examples/web-app/README.md
-    supporting_copy: Walk through a minimal ASP.NET Core app that uses Runnable modules end to end.
-    order: 20
-  - question: How does this fit distributed systems?
-    path: Aspire/README.md
-    supporting_copy: See how the same modular approach extends into .NET Aspire and service-default composition.
-    order: 30
-  - question: What about CLI and worker flows?
-    path: Console/README.md
-    supporting_copy: Follow the console tooling for commands, critical services, and shared startup patterns.
-    order: 40
----
-
 # Runnable
 
 > ⚠️ **Under Construction:** This library is actively being developed and is not intended for production use yet.

--- a/README.md.yml
+++ b/README.md.yml
@@ -1,0 +1,19 @@
+title: Runnable
+summary: Runnable gives .NET teams a modular startup pipeline for web, console, and distributed apps. Start with the pillar you need, then drill into concrete examples and API reference.
+featured_pages:
+  - question: How do I ship a web app with Runnable?
+    path: Web/README.md
+    supporting_copy: See the web surface that composes middleware, endpoints, and host startup without a monolithic Program.cs.
+    order: 10
+  - question: Show me a working app, not just abstractions
+    path: examples/web-app/README.md
+    supporting_copy: Walk through a minimal ASP.NET Core app that uses Runnable modules end to end.
+    order: 20
+  - question: How does this fit distributed systems?
+    path: Aspire/README.md
+    supporting_copy: See how the same modular approach extends into .NET Aspire and service-default composition.
+    order: 30
+  - question: What about CLI and worker flows?
+    path: Console/README.md
+    supporting_copy: Follow the console tooling for commands, critical services, and shared startup patterns.
+    order: 40

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -734,6 +734,45 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDocsAsync_ShouldAllowNamespaceReadmeSidecarClassificationOverrides()
+    {
+        var namespaceContent = "<section class='doc-namespace-groups'><h4>Namespaces</h4></section><section class='doc-type'>Type body</section>";
+        var sidecarMetadata = new DocMetadata
+        {
+            PageType = "concept",
+            Audience = "implementer",
+            Component = "Docs",
+            NavGroup = "Concepts"
+        };
+        var harvestedDocs = new List<DocNode>
+        {
+            new(
+                "Web",
+                "Namespaces/ForgeTrust.Runnable.Web",
+                namespaceContent,
+                Metadata: DocMetadataFactory.CreateApiReferenceMetadata("Web", "ForgeTrust.Runnable.Web")),
+            new(
+                "README",
+                "docs/ForgeTrust.Runnable.Web/README.md",
+                "<p>Namespace intro</p>",
+                Metadata: DocMetadataFactory.CreateMarkdownMetadata(
+                    "docs/ForgeTrust.Runnable.Web/README.md",
+                    "ForgeTrust.Runnable.Web",
+                    DocMetadata.Merge(null, sidecarMetadata),
+                    "Namespace intro."))
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        var docs = (await _aggregator.GetDocsAsync()).ToList();
+        var namespaceDoc = docs.Single(d => d.Path == "Namespaces/ForgeTrust.Runnable.Web");
+
+        Assert.Equal("concept", namespaceDoc.Metadata?.PageType);
+        Assert.Equal("implementer", namespaceDoc.Metadata?.Audience);
+        Assert.Equal("Docs", namespaceDoc.Metadata?.Component);
+        Assert.Equal("Concepts", namespaceDoc.Metadata?.NavGroup);
+    }
+
+    [Fact]
     public void MergeNamespaceIntroIntoContent_ShouldHandleMalformedNamespaceSections()
     {
         // Act

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/FeaturedLandingNavigation.regression-001.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/FeaturedLandingNavigation.regression-001.test.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+using AngleSharp.Html.Parser;
+using ForgeTrust.Runnable.Caching;
+using ForgeTrust.Runnable.Web.RazorDocs.Controllers;
+using ForgeTrust.Runnable.Web.RazorDocs.Models;
+using ForgeTrust.Runnable.Web.RazorDocs.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
+
+public class FeaturedLandingNavigationRegressionTests
+{
+    [Fact]
+    public async Task IndexView_ShouldAdvanceHistory_WhenFeaturedCardTargetsDocumentFrame()
+    {
+        // Regression: ISSUE-001 — featured landing cards replaced doc content without advancing browser history
+        // Found by /qa on 2026-04-19
+        // Report: .gstack/qa-reports/qa-report-localhost-5189-2026-04-19.md
+        var docs = new List<DocNode>
+        {
+            new(
+                "Home",
+                "README.md",
+                "<p>Home</p>",
+                Metadata: new DocMetadata
+                {
+                    FeaturedPages =
+                    [
+                        new DocFeaturedPageDefinition
+                        {
+                            Question = "Open Web docs",
+                            Path = "Web/README.md"
+                        }
+                    ]
+                }),
+            new(
+                "Web",
+                "Web/README.md",
+                "<p>Web docs</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "Web summary."
+                })
+        };
+
+        using var services = CreateServiceProvider(docs);
+        var html = await RenderIndexViewAsync(services);
+        var document = new HtmlParser().ParseDocument(html);
+
+        var featuredLink = document.QuerySelector("a.group[href='/docs/Web/README.md.html']");
+
+        Assert.NotNull(featuredLink);
+        Assert.Equal("doc-content", featuredLink!.GetAttribute("data-turbo-frame"));
+        Assert.Equal("advance", featuredLink.GetAttribute("data-turbo-action"));
+    }
+
+    private static ServiceProvider CreateServiceProvider(IReadOnlyList<DocNode> docs)
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var webRoot = Path.Combine(repoRoot, "Web", "ForgeTrust.Runnable.Web.RazorDocs");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["RepositoryRoot"] = repoRoot
+                })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var diagnosticListener = new DiagnosticListener(nameof(FeaturedLandingNavigationRegressionTests));
+        services.AddSingleton<DiagnosticSource>(diagnosticListener);
+        services.AddSingleton(diagnosticListener);
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment(webRoot));
+        services.AddSingleton<IConfiguration>(_ => configuration);
+        services.AddMemoryCache();
+        services.AddSingleton<IMemo, Memo>();
+        services.AddRazorDocs();
+        services.RemoveAll<IDocHarvester>();
+        services.AddSingleton<IDocHarvester>(_ => new StaticDocHarvester(docs));
+        services.AddControllersWithViews()
+            .AddApplicationPart(typeof(DocsController).Assembly);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<string> RenderIndexViewAsync(ServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var scopedServices = scope.ServiceProvider;
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = scopedServices
+        };
+        httpContext.Response.Body = new MemoryStream();
+
+        var controller = ActivatorUtilities.CreateInstance<DocsController>(scopedServices);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext,
+            RouteData = new RouteData(),
+            ActionDescriptor = new ControllerActionDescriptor
+            {
+                ControllerName = "Docs",
+                ActionName = "Index"
+            }
+        };
+
+        var result = await controller.Index();
+        var viewResult = Assert.IsType<ViewResult>(result);
+        viewResult.ViewName ??= "/Views/Docs/Index.cshtml";
+
+        var executor = scopedServices.GetRequiredService<IActionResultExecutor<ViewResult>>();
+        var actionContext = new ActionContext(
+            controller.HttpContext,
+            controller.RouteData,
+            controller.ControllerContext.ActionDescriptor);
+
+        await executor.ExecuteAsync(actionContext, viewResult);
+
+        httpContext.Response.Body.Position = 0;
+        using var reader = new StreamReader(httpContext.Response.Body);
+        return await reader.ReadToEndAsync();
+    }
+
+    private sealed class StaticDocHarvester : IDocHarvester
+    {
+        private readonly IReadOnlyList<DocNode> _docs;
+
+        public StaticDocHarvester(IReadOnlyList<DocNode> docs)
+        {
+            _docs = docs;
+        }
+
+        public Task<IReadOnlyList<DocNode>> HarvestAsync(string rootPath, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_docs);
+        }
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment, IDisposable
+    {
+        public TestWebHostEnvironment(string contentRootPath)
+        {
+            ApplicationName = typeof(DocsController).Assembly.GetName().Name ?? "RazorDocsRegressionTests";
+            EnvironmentName = Environments.Development;
+            ContentRootPath = contentRootPath;
+            ContentRootFileProvider = new PhysicalFileProvider(contentRootPath);
+            WebRootPath = contentRootPath;
+            WebRootFileProvider = new PhysicalFileProvider(contentRootPath);
+        }
+
+        public string ApplicationName { get; set; }
+
+        public IFileProvider ContentRootFileProvider { get; set; }
+
+        public string ContentRootPath { get; set; }
+
+        public string EnvironmentName { get; set; }
+
+        public IFileProvider WebRootFileProvider { get; set; }
+
+        public string WebRootPath { get; set; }
+
+        public void Dispose()
+        {
+            (ContentRootFileProvider as IDisposable)?.Dispose();
+            (WebRootFileProvider as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/FeaturedLandingNavigation.regression-001.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/FeaturedLandingNavigation.regression-001.test.cs
@@ -57,7 +57,7 @@ public class FeaturedLandingNavigationRegressionTests
         var html = await RenderIndexViewAsync(services);
         var document = new HtmlParser().ParseDocument(html);
 
-        var featuredLink = document.QuerySelector("a.group[href='/docs/Web/README.md.html']");
+        var featuredLink = document.QuerySelector("a[href='/docs/Web/README.md.html']");
 
         Assert.NotNull(featuredLink);
         Assert.Equal("doc-content", featuredLink!.GetAttribute("data-turbo-frame"));

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/FeaturedLandingNavigation.regression-001.test.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/FeaturedLandingNavigation.regression-001.test.cs
@@ -82,7 +82,7 @@ public class FeaturedLandingNavigationRegressionTests
         var diagnosticListener = new DiagnosticListener(nameof(FeaturedLandingNavigationRegressionTests));
         services.AddSingleton<DiagnosticSource>(diagnosticListener);
         services.AddSingleton(diagnosticListener);
-        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment(webRoot));
+        services.AddSingleton<IWebHostEnvironment>(_ => new TestWebHostEnvironment(webRoot));
         services.AddSingleton<IConfiguration>(_ => configuration);
         services.AddMemoryCache();
         services.AddSingleton<IMemo, Memo>();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/HarvestPathExclusionsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/HarvestPathExclusionsTests.cs
@@ -42,6 +42,25 @@ public class HarvestPathExclusionsTests
     }
 
     [Fact]
+    public void ShouldExcludeFilePath_WhenCustomExcludedDirectoriesAreProvided_UsesSharedHiddenDirectoryRules()
+    {
+        IReadOnlySet<string> excludedDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "TestResults"
+        };
+
+        Assert.True(HarvestPathExclusions.ShouldExcludeFilePath("artifacts/TestResults/README.md", excludedDirectories));
+        Assert.False(HarvestPathExclusions.ShouldExcludeFilePath("src/Tests/README.md", excludedDirectories));
+        Assert.True(HarvestPathExclusions.ShouldExcludeFilePath(".github/README.md", excludedDirectories));
+    }
+
+    [Fact]
+    public void ShouldExcludeFilePath_WhenCustomExcludedDirectoriesAreNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => HarvestPathExclusions.ShouldExcludeFilePath("README.md", null!));
+    }
+
+    [Fact]
     public void ShouldExcludeFilePath_WhenPathIsNull_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => HarvestPathExclusions.ShouldExcludeFilePath(null!));

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
@@ -199,6 +199,12 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void ParseMetadataYaml_ShouldThrowArgumentNullException_WhenYamlIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => MarkdownFrontMatterParser.ParseMetadataYaml(null!));
+    }
+
+    [Fact]
     public void ParseMetadataYaml_ShouldNormalizeSameSchema_AsInlineFrontMatter()
     {
         var yaml = """

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
@@ -1,4 +1,5 @@
 using ForgeTrust.Runnable.Web.RazorDocs.Services;
+using YamlDotNet.Core;
 
 namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
 
@@ -195,5 +196,46 @@ public sealed class MarkdownFrontMatterParserTests
         Assert.Empty(metadata.Breadcrumbs!);
         Assert.Empty(metadata.FeaturedPages!);
         Assert.Empty(metadata.RelatedPages!);
+    }
+
+    [Fact]
+    public void ParseMetadataYaml_ShouldNormalizeSameSchema_AsInlineFrontMatter()
+    {
+        var yaml = """
+            title: Quickstart
+            summary: >
+              Build forms, streams,
+              and handlers together.
+            featured_pages:
+              - question: Where do I start?
+                path: guides/intro.md
+                supporting_copy: Start with the intro guide.
+                order: 10
+            """;
+
+        var metadata = MarkdownFrontMatterParser.ParseMetadataYaml(yaml);
+
+        Assert.NotNull(metadata);
+        Assert.Equal("Quickstart", metadata!.Title);
+        Assert.Equal("Build forms, streams, and handlers together.", metadata.Summary);
+        var featuredPage = Assert.Single(metadata.FeaturedPages!);
+        Assert.Equal("Where do I start?", featuredPage.Question);
+        Assert.Equal("guides/intro.md", featuredPage.Path);
+        Assert.Equal("Start with the intro guide.", featuredPage.SupportingCopy);
+        Assert.Equal(10, featuredPage.Order);
+    }
+
+    [Fact]
+    public void ParseMetadataYaml_ShouldReturnNull_WhenDocumentIsYamlNull()
+    {
+        var metadata = MarkdownFrontMatterParser.ParseMetadataYaml("null");
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public void ParseMetadataYaml_ShouldThrow_WhenYamlIsInvalid()
+    {
+        Assert.Throws<YamlException>(() => MarkdownFrontMatterParser.ParseMetadataYaml("title: ["));
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownHarvesterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownHarvesterTests.cs
@@ -194,6 +194,24 @@ public class MarkdownHarvesterTests : IDisposable
     }
 
     [Fact]
+    public async Task HarvestAsync_ShouldReadSingleMdYamlSidecar()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md"), "# Guide");
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md.yaml"), "title: YAML Sidecar Title");
+
+        var results = (await _harvester.HarvestAsync(_testRoot)).ToList();
+        var doc = Assert.Single(results);
+
+        Assert.Equal("YAML Sidecar Title", doc.Title);
+        Assert.Equal("YAML Sidecar Title", doc.Metadata?.Title);
+        A.CallTo(_loggerFake)
+            .Where(
+                call => call.Method.Name == nameof(ILogger.Log)
+                        && call.GetArgument<LogLevel>(0) == LogLevel.Warning)
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
     public async Task HarvestAsync_ShouldPreferInlineFrontMatterOverSidecarMetadata()
     {
         await File.WriteAllTextAsync(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownHarvesterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownHarvesterTests.cs
@@ -163,6 +163,145 @@ public class MarkdownHarvesterTests : IDisposable
     }
 
     [Fact]
+    public async Task HarvestAsync_ShouldReadRootReadmeMetadataFromPairedSidecar()
+    {
+        var guidesDir = Path.Combine(_testRoot, "guides");
+        Directory.CreateDirectory(guidesDir);
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "README.md"), "# Runnable");
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "README.md.yml"),
+            """
+            title: Runnable
+            summary: Start with the proof paths that matter most.
+            featured_pages:
+              - question: Where do I start?
+                path: guides/intro.md
+                supporting_copy: Follow the intro guide first.
+                order: 10
+            """);
+        await File.WriteAllTextAsync(Path.Combine(guidesDir, "intro.md"), "# Intro");
+
+        var results = (await _harvester.HarvestAsync(_testRoot)).ToList();
+        var doc = results.Single(n => n.Path == "README.md");
+
+        Assert.Equal("Runnable", doc.Title);
+        Assert.Equal("Start with the proof paths that matter most.", doc.Metadata?.Summary);
+        Assert.False(doc.Metadata?.SummaryIsDerived);
+        var featuredPage = Assert.Single(doc.Metadata?.FeaturedPages!);
+        Assert.Equal("Where do I start?", featuredPage.Question);
+        Assert.Equal("guides/intro.md", featuredPage.Path);
+        Assert.Equal("Follow the intro guide first.", featuredPage.SupportingCopy);
+        Assert.Equal(10, featuredPage.Order);
+    }
+
+    [Fact]
+    public async Task HarvestAsync_ShouldPreferInlineFrontMatterOverSidecarMetadata()
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(_testRoot, "Guide.md"),
+            """
+            ---
+            title: Inline Quickstart
+            summary: Inline summary wins.
+            ---
+            # Hello
+
+            Inline body.
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(_testRoot, "Guide.md.yml"),
+            """
+            title: Sidecar Quickstart
+            summary: Sidecar summary should lose.
+            keywords:
+              - paired
+              - fallback
+            """);
+
+        var results = (await _harvester.HarvestAsync(_testRoot)).ToList();
+        var doc = Assert.Single(results);
+
+        Assert.Equal("Inline Quickstart", doc.Title);
+        Assert.Equal("Inline summary wins.", doc.Metadata?.Summary);
+        Assert.False(doc.Metadata?.SummaryIsDerived);
+        Assert.Equal(["paired", "fallback"], doc.Metadata?.Keywords);
+    }
+
+    [Fact]
+    public async Task HarvestAsync_ShouldTreatExplicitEmptyInlineListsAsAuthoritativeOverSidecarMetadata()
+    {
+        var guidesDir = Path.Combine(_testRoot, "guides");
+        Directory.CreateDirectory(guidesDir);
+        await File.WriteAllTextAsync(
+            Path.Combine(_testRoot, "README.md"),
+            """
+            ---
+            featured_pages: []
+            ---
+            # Runnable
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(_testRoot, "README.md.yml"),
+            """
+            featured_pages:
+              - path: guides/intro.md
+            """);
+        await File.WriteAllTextAsync(Path.Combine(guidesDir, "intro.md"), "# Intro");
+
+        var results = (await _harvester.HarvestAsync(_testRoot)).ToList();
+        var doc = results.Single(n => n.Path == "README.md");
+
+        Assert.Empty(doc.Metadata?.FeaturedPages!);
+    }
+
+    [Fact]
+    public async Task HarvestAsync_ShouldIgnoreMetadataSidecars_WhenBothYamlExtensionsExist()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md"), "# Guide");
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md.yml"), "title: First");
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md.yaml"), "title: Second");
+
+        var results = (await _harvester.HarvestAsync(_testRoot)).ToList();
+        var doc = Assert.Single(results);
+
+        Assert.Equal("Guide", doc.Title);
+        Assert.Equal("Guide", doc.Metadata?.Title);
+        AssertWarningLogged("both");
+    }
+
+    [Fact]
+    public async Task HarvestAsync_ShouldIgnoreInvalidMetadataSidecar_AndLogWarning()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md"), "# Guide");
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md.yml"), "title: [");
+
+        var results = (await _harvester.HarvestAsync(_testRoot)).ToList();
+        var doc = Assert.Single(results);
+
+        Assert.Equal("Guide", doc.Title);
+        Assert.Equal("Guide", doc.Metadata?.Title);
+        AssertWarningLogged("could not be parsed");
+    }
+
+    [Fact]
+    public async Task HarvestAsync_ShouldIgnoreUnreadableMetadataSidecar_AndLogWarning()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md"), "# Guide");
+        await File.WriteAllTextAsync(Path.Combine(_testRoot, "Guide.md.yml"), "title: Hidden");
+        var harvester = new MarkdownHarvester(
+            _loggerFake,
+            (path, cancellationToken) => path.EndsWith(".md.yml", StringComparison.OrdinalIgnoreCase)
+                ? Task.FromException<string>(new IOException("boom"))
+                : File.ReadAllTextAsync(path, cancellationToken));
+
+        var results = (await harvester.HarvestAsync(_testRoot)).ToList();
+        var doc = Assert.Single(results);
+
+        Assert.Equal("Guide", doc.Title);
+        Assert.Equal("Guide", doc.Metadata?.Title);
+        AssertWarningLogged("could not be read");
+    }
+
+    [Fact]
     public async Task HarvestAsync_ShouldDeriveSummary_WhenFrontMatterSummaryIsMissing()
     {
         await File.WriteAllTextAsync(
@@ -330,6 +469,22 @@ public class MarkdownHarvesterTests : IDisposable
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => harvester.HarvestAsync(_testRoot));
         A.CallTo(_loggerFake).Where(call => call.Method.Name == "Log").MustNotHaveHappened();
+    }
+
+    private void AssertWarningLogged(string expectedMessageFragment)
+    {
+        A.CallTo(_loggerFake)
+            .Where(
+                call => call.Method.Name == nameof(ILogger.Log)
+                        && call.GetArgument<LogLevel>(0) == LogLevel.Warning
+                        && LoggedMessageContains(call, expectedMessageFragment))
+            .MustHaveHappened();
+    }
+
+    private static bool LoggedMessageContains(FakeItEasy.Core.IFakeObjectCall call, string expectedMessageFragment)
+    {
+        var message = call.GetArgument<object>(2)?.ToString();
+        return message?.Contains(expectedMessageFragment, StringComparison.OrdinalIgnoreCase) == true;
     }
 
     public void Dispose()

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownHarvesterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownHarvesterTests.cs
@@ -302,6 +302,39 @@ public class MarkdownHarvesterTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadMetadataSidecarAsync_ShouldThrow_WhenMarkdownPathIsBlank()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _harvester.ReadMetadataSidecarAsync(" ", "Guide.md", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadMetadataSidecarAsync_ShouldThrow_WhenRelativeMarkdownPathIsBlank()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _harvester.ReadMetadataSidecarAsync(Path.Combine(_testRoot, "Guide.md"), " ", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadMetadataSidecarAsync_ShouldPropagateOperationCanceled_WhenSidecarReadIsCanceled()
+    {
+        var markdownPath = Path.Combine(_testRoot, "Guide.md");
+        await File.WriteAllTextAsync(markdownPath, "# Guide");
+        await File.WriteAllTextAsync(markdownPath + ".yml", "title: Hidden");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var harvester = new MarkdownHarvester(
+            _loggerFake,
+            (path, cancellationToken) => path.EndsWith(".md.yml", StringComparison.OrdinalIgnoreCase)
+                ? Task.FromCanceled<string>(cts.Token)
+                : File.ReadAllTextAsync(path, cancellationToken));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => harvester.ReadMetadataSidecarAsync(markdownPath, "Guide.md", cts.Token));
+        A.CallTo(_loggerFake).Where(call => call.Method.Name == "Log").MustNotHaveHappened();
+    }
+
+    [Fact]
     public async Task HarvestAsync_ShouldDeriveSummary_WhenFrontMatterSummaryIsMissing()
     {
         await File.WriteAllTextAsync(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
+
+public sealed class RepositoryReadmePolicyTests
+{
+    [Fact]
+    public void TrackedReadmes_ShouldNotStartWithYamlFrontMatter()
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var violatingReadmes = GetTrackedReadmePaths(repoRoot)
+            .Where(path => path.EndsWith("README.md", StringComparison.OrdinalIgnoreCase))
+            .Where(
+                path => File.ReadAllText(Path.Combine(repoRoot, path))
+                    .Replace("\r\n", "\n", StringComparison.Ordinal)
+                    .StartsWith("---\n", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(
+            violatingReadmes.Length == 0,
+            $"Tracked README.md files must stay portable and avoid inline YAML front matter. Violations: {string.Join(", ", violatingReadmes)}");
+    }
+
+    private static IReadOnlyList<string> GetTrackedReadmePaths(string repoRoot)
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            WorkingDirectory = repoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("ls-files");
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start git ls-files.");
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"git ls-files failed while collecting tracked README paths: {standardError}");
+        }
+
+        return standardOutput
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToArray();
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
@@ -40,6 +40,13 @@ public sealed class RepositoryReadmePolicyTests
     }
 
     [Fact]
+    public void StartsWithYamlFrontMatter_ShouldReturnTrue_WhenContentStartsWithYamlMarkerUsingCrLf()
+    {
+        Assert.True(
+            StartsWithYamlFrontMatter("---\r\ntitle: Portable Docs\r\n---\r\n# Heading\r\n"));
+    }
+
+    [Fact]
     public void StartsWithYamlFrontMatter_ShouldReturnFalse_WhenContentDoesNotStartWithYamlMarker()
     {
         Assert.False(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
@@ -18,14 +18,37 @@ public sealed class RepositoryReadmePolicyTests
         var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
         var violatingReadmes = EnumerateAuthoredReadmePaths(repoRoot)
             .Where(
-                path => File.ReadAllText(Path.Combine(repoRoot, path))
-                    .Replace("\r\n", "\n", StringComparison.Ordinal)
-                    .StartsWith("---\n", StringComparison.Ordinal))
+                path => StartsWithYamlFrontMatter(File.ReadAllText(Path.Combine(repoRoot, path))))
             .ToArray();
 
         Assert.True(
             violatingReadmes.Length == 0,
             $"Authored README.md files must stay portable and avoid inline YAML front matter. Violations: {string.Join(", ", violatingReadmes)}");
+    }
+
+    [Fact]
+    public void StartsWithYamlFrontMatter_ShouldReturnTrue_WhenContentStartsWithBomPrefixedYamlMarker()
+    {
+        Assert.True(
+            StartsWithYamlFrontMatter(
+                """
+                ﻿---
+                title: Portable Docs
+                ---
+                # Heading
+                """));
+    }
+
+    [Fact]
+    public void StartsWithYamlFrontMatter_ShouldReturnFalse_WhenContentDoesNotStartWithYamlMarker()
+    {
+        Assert.False(
+            StartsWithYamlFrontMatter(
+                """
+                ﻿# Heading
+                ---
+                not front matter
+                """));
     }
 
     private static IReadOnlyList<string> EnumerateAuthoredReadmePaths(string repoRoot)
@@ -35,5 +58,13 @@ public sealed class RepositoryReadmePolicyTests
             .Select(path => Path.GetRelativePath(repoRoot, path).Replace('\\', '/'))
             .Where(path => !HarvestPathExclusions.ShouldExcludeFilePath(path, AuthoredReadmeExcludedDirectories))
             .ToArray();
+    }
+
+    private static bool StartsWithYamlFrontMatter(string content)
+    {
+        return content
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .TrimStart('\uFEFF')
+            .StartsWith("---\n", StringComparison.Ordinal);
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
@@ -1,15 +1,20 @@
-using System.Diagnostics;
-
 namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
 
 public sealed class RepositoryReadmePolicyTests
 {
+    private static readonly HashSet<string> ExcludedDirectorySegments = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bin",
+        "obj",
+        "node_modules",
+        "TestResults"
+    };
+
     [Fact]
     public void TrackedReadmes_ShouldNotStartWithYamlFrontMatter()
     {
         var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
-        var violatingReadmes = GetTrackedReadmePaths(repoRoot)
-            .Where(path => path.EndsWith("README.md", StringComparison.OrdinalIgnoreCase))
+        var violatingReadmes = EnumerateAuthoredReadmePaths(repoRoot)
             .Where(
                 path => File.ReadAllText(Path.Combine(repoRoot, path))
                     .Replace("\r\n", "\n", StringComparison.Ordinal)
@@ -21,30 +26,36 @@ public sealed class RepositoryReadmePolicyTests
             $"Tracked README.md files must stay portable and avoid inline YAML front matter. Violations: {string.Join(", ", violatingReadmes)}");
     }
 
-    private static IReadOnlyList<string> GetTrackedReadmePaths(string repoRoot)
+    private static IReadOnlyList<string> EnumerateAuthoredReadmePaths(string repoRoot)
     {
-        var startInfo = new ProcessStartInfo("git")
-        {
-            WorkingDirectory = repoRoot,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false
-        };
-        startInfo.ArgumentList.Add("ls-files");
+        return Directory
+            .EnumerateFiles(repoRoot, "README.md", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(repoRoot, path).Replace('\\', '/'))
+            .Where(path => !ShouldExcludePath(path))
+            .ToArray();
+    }
 
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start git ls-files.");
-        var standardOutput = process.StandardOutput.ReadToEnd();
-        var standardError = process.StandardError.ReadToEnd();
-        process.WaitForExit();
-
-        if (process.ExitCode != 0)
+    private static bool ShouldExcludePath(string relativePath)
+    {
+        var segments = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length <= 1)
         {
-            throw new InvalidOperationException($"git ls-files failed while collecting tracked README paths: {standardError}");
+            return false;
         }
 
-        return standardOutput
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .ToArray();
+        foreach (var directorySegment in segments[..^1])
+        {
+            if (directorySegment.StartsWith(".", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (ExcludedDirectorySegments.Contains(directorySegment))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryReadmePolicyTests.cs
@@ -1,8 +1,10 @@
+using ForgeTrust.Runnable.Web.RazorDocs.Services;
+
 namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
 
 public sealed class RepositoryReadmePolicyTests
 {
-    private static readonly HashSet<string> ExcludedDirectorySegments = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> AuthoredReadmeExcludedDirectories = new(StringComparer.OrdinalIgnoreCase)
     {
         "bin",
         "obj",
@@ -31,31 +33,7 @@ public sealed class RepositoryReadmePolicyTests
         return Directory
             .EnumerateFiles(repoRoot, "README.md", SearchOption.AllDirectories)
             .Select(path => Path.GetRelativePath(repoRoot, path).Replace('\\', '/'))
-            .Where(path => !ShouldExcludePath(path))
+            .Where(path => !HarvestPathExclusions.ShouldExcludeFilePath(path, AuthoredReadmeExcludedDirectories))
             .ToArray();
-    }
-
-    private static bool ShouldExcludePath(string relativePath)
-    {
-        var segments = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (segments.Length <= 1)
-        {
-            return false;
-        }
-
-        foreach (var directorySegment in segments[..^1])
-        {
-            if (directorySegment.StartsWith(".", StringComparison.Ordinal))
-            {
-                return true;
-            }
-
-            if (ExcludedDirectorySegments.Contains(directorySegment))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -32,11 +32,12 @@ public class DocsController : Controller
     }
 
     /// <summary>
-    /// Displays the documentation index view containing either curated proof paths from the repository-root landing doc or the neutral docs landing fallback.
+    /// Displays the documentation index view containing either curated proof paths from the repository-root landing doc metadata or the neutral docs landing fallback.
     /// </summary>
     /// <returns>
     /// A view result whose model is a <see cref="DocLandingViewModel"/>. The model includes curated featured cards when the
-    /// repository-root <c>README.md</c> authors <c>featured_pages</c>; otherwise it includes the neutral fallback landing data.
+    /// repository-root <c>README.md</c> metadata authors <c>featured_pages</c> through inline front matter or a paired
+    /// sidecar such as <c>README.md.yml</c>; otherwise it includes the neutral fallback landing data.
     /// </returns>
     public async Task<IActionResult> Index()
     {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -94,8 +94,9 @@ public sealed record DocMetadata
     /// Gets optional landing-page curation entries authored with the documentation page.
     /// </summary>
     /// <remarks>
-    /// RazorDocs parses this metadata on any page so the contract stays page-agnostic. The built-in docs landing
-    /// consumes these entries only from the repository-root <c>README.md</c>.
+    /// RazorDocs parses this metadata on any page so the contract stays page-agnostic. Authors can supply these entries
+    /// either inline in Markdown front matter or through a paired sidecar such as <c>README.md.yml</c>. The built-in docs
+    /// landing consumes these entries only from the repository-root <c>README.md</c> metadata.
     /// </remarks>
     public IReadOnlyList<DocFeaturedPageDefinition>? FeaturedPages { get; init; }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -28,14 +28,19 @@ If `RazorDocs:Source:RepositoryRoot` is omitted, the package falls back to repos
 
 ## Landing Curation
 
-RazorDocs can turn the root docs landing into a curated proof-path surface by reading `featured_pages` from the repository-root `README.md` front matter.
+RazorDocs can turn the root docs landing into a curated proof-path surface by reading `featured_pages` from the repository-root `README.md` metadata.
 
 ### Authoring contract
 
-`featured_pages` is parsed as part of `DocMetadata`, so the metadata contract stays page-agnostic. The built-in `/docs` landing consumes those entries only from the root `README.md`.
+`featured_pages` is parsed as part of `DocMetadata`, so the metadata contract stays page-agnostic. The built-in `/docs` landing consumes those entries only from the root `README.md` metadata, but authors can now supply that metadata in either of two places:
+
+- Inline Markdown front matter at the top of the `.md` file
+- A paired sidecar YAML file such as `README.md.yml` or `README.md.yaml`
+
+Inline front matter remains the default authoring path for ordinary docs pages. Paired sidecars are the recommended escape hatch for portability-sensitive files such as `README.md`, where raw front matter renders poorly on GitHub and other plain Markdown surfaces.
 
 ```yaml
----
+# README.md.yml
 title: Runnable
 summary: Follow the proof paths that explain what this framework is for and how it composes.
 featured_pages:
@@ -43,11 +48,9 @@ featured_pages:
     path: guides/composition.md
     supporting_copy: Start with the composition guide before drilling into APIs.
     order: 10
-
   - question: Show me an end-to-end example
     path: examples/hello-world/README.md
     order: 20
----
 ```
 
 ### Field behavior
@@ -61,8 +64,17 @@ featured_pages:
 
 - If the root `README.md` is missing, the landing stays on the neutral docs index.
 - If `featured_pages` is missing or empty, the landing stays on the neutral docs index.
+- If both `README.md.yml` and `README.md.yaml` exist for the same Markdown file, RazorDocs logs a warning and ignores both sidecars until the conflict is removed.
+- If both sidecar metadata and inline front matter define the same field, inline front matter wins and the sidecar acts as fallback metadata only.
+- Invalid sidecar YAML logs a warning and falls back to the inline/default metadata path instead of breaking the page harvest.
 - If a featured path is missing, hidden from public navigation, or duplicated, RazorDocs skips it and logs a warning.
 - If all featured entries are skipped, RazorDocs falls back to the neutral docs index instead of rendering broken cards.
+
+### Pitfalls
+
+- Do not create both `.yml` and `.yaml` sidecars for the same Markdown file. RazorDocs treats that as an authoring error and ignores both.
+- Do not use a sidecar as a second secret metadata system. It supports the same `DocMetadata` schema as inline front matter, and it is best reserved for files whose Markdown needs to stay portable on other surfaces.
+- README portability matters most at the repository and package level. In this repo, authored tracked `README.md` files should stay free of inline front matter so GitHub renders them cleanly.
 
 ## Related Projects
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/HarvestPathExclusions.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/HarvestPathExclusions.cs
@@ -23,8 +23,21 @@ internal static class HarvestPathExclusions
     /// <param name="filePath">The relative file path to check.</param>
     /// <returns><c>true</c> if the file should be excluded; otherwise, <c>false</c>.</returns>
     public static bool ShouldExcludeFilePath(string filePath)
+        => ShouldExcludeFilePath(filePath, ExcludedDirectories);
+
+    /// <summary>
+    /// Determines whether a file should be excluded based on shared hidden-directory rules and a caller-supplied
+    /// set of explicitly excluded directory names.
+    /// </summary>
+    /// <param name="filePath">The relative file path to check.</param>
+    /// <param name="excludedDirectories">
+    /// Directory names that should always be excluded in addition to the shared hidden-directory behavior.
+    /// </param>
+    /// <returns><c>true</c> if the file should be excluded; otherwise, <c>false</c>.</returns>
+    internal static bool ShouldExcludeFilePath(string filePath, IReadOnlySet<string> excludedDirectories)
     {
         ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(excludedDirectories);
 
         var segments = filePath.Split(
             [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/', '\\'],
@@ -37,7 +50,7 @@ internal static class HarvestPathExclusions
 
         foreach (var directorySegment in segments[..^1])
         {
-            if (ExcludedDirectories.Contains(directorySegment))
+            if (excludedDirectories.Contains(directorySegment))
             {
                 return true;
             }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
@@ -26,7 +26,7 @@ internal static class MarkdownFrontMatterParser
 
         try
         {
-            return (body, Parse(frontMatter));
+            return (body, ParseMetadataYaml(frontMatter));
         }
         catch (YamlException)
         {
@@ -36,9 +36,21 @@ internal static class MarkdownFrontMatterParser
         }
     }
 
-    private static DocMetadata? Parse(string frontMatter)
+    /// <summary>
+    /// Parses a YAML metadata document into normalized documentation metadata.
+    /// </summary>
+    /// <param name="yaml">The raw YAML content to deserialize.</param>
+    /// <returns>The normalized metadata model, or <c>null</c> when the YAML document is explicitly empty or null.</returns>
+    /// <remarks>
+    /// This entry point is shared by inline Markdown front matter and paired sidecar metadata files so both authoring styles
+    /// normalize through the same schema, defaults, and empty-list handling.
+    /// </remarks>
+    /// <exception cref="YamlException">Thrown when <paramref name="yaml"/> cannot be parsed as YAML.</exception>
+    internal static DocMetadata? ParseMetadataYaml(string yaml)
     {
-        var document = Deserializer.Deserialize<FrontMatterDocument>(frontMatter);
+        ArgumentNullException.ThrowIfNull(yaml);
+
+        var document = Deserializer.Deserialize<FrontMatterDocument>(yaml);
         if (document is null)
         {
             return null;

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownHarvester.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownHarvester.cs
@@ -1,5 +1,6 @@
 using ForgeTrust.Runnable.Web.RazorDocs.Models;
 using Markdig;
+using YamlDotNet.Core;
 
 namespace ForgeTrust.Runnable.Web.RazorDocs.Services;
 
@@ -8,6 +9,7 @@ namespace ForgeTrust.Runnable.Web.RazorDocs.Services;
 /// </summary>
 public class MarkdownHarvester : IDocHarvester
 {
+    private static readonly string[] SidecarExtensions = [".yml", ".yaml"];
     private readonly MarkdownPipeline _pipeline;
     private readonly ILogger<MarkdownHarvester> _logger;
     private readonly Func<string, CancellationToken, Task<string>> _readAllTextAsync;
@@ -67,6 +69,8 @@ public class MarkdownHarvester : IDocHarvester
 
                 var content = await _readAllTextAsync(file, cancellationToken);
                 var (markdownBody, frontMatterMetadata) = MarkdownFrontMatterParser.Extract(content);
+                var sidecarMetadata = await ReadMetadataSidecarAsync(file, relativePath, cancellationToken);
+                var explicitMetadata = DocMetadata.Merge(frontMatterMetadata, sidecarMetadata);
                 var html = Markdown.ToHtml(markdownBody, _pipeline);
                 var title = Path.GetFileNameWithoutExtension(file);
 
@@ -76,11 +80,11 @@ public class MarkdownHarvester : IDocHarvester
                     title = string.IsNullOrEmpty(parentDir) ? "Home" : Path.GetFileName(parentDir);
                 }
 
-                var resolvedTitle = frontMatterMetadata?.Title ?? title;
+                var resolvedTitle = explicitMetadata?.Title ?? title;
                 var metadata = DocMetadataFactory.CreateMarkdownMetadata(
                     relativePath,
                     resolvedTitle,
-                    frontMatterMetadata,
+                    explicitMetadata,
                     ExtractSummary(markdownBody));
 
                 nodes.Add(new DocNode(resolvedTitle, relativePath, html, Metadata: metadata));
@@ -96,6 +100,78 @@ public class MarkdownHarvester : IDocHarvester
         }
 
         return nodes;
+    }
+
+    /// <summary>
+    /// Reads an optional paired sidecar metadata file for a Markdown source document.
+    /// </summary>
+    /// <param name="markdownFilePath">The absolute Markdown file path.</param>
+    /// <param name="relativeMarkdownPath">The Markdown file path relative to the harvest root.</param>
+    /// <param name="cancellationToken">A token that can cancel sidecar discovery or file reads.</param>
+    /// <returns>The parsed sidecar metadata, or <c>null</c> when no valid sidecar applies.</returns>
+    /// <remarks>
+    /// RazorDocs supports paired metadata files named <c>{file}.yml</c> and <c>{file}.yaml</c> such as
+    /// <c>README.md.yml</c>. When both extensions exist for the same Markdown file, RazorDocs logs a warning and ignores
+    /// both sidecars until the ambiguity is removed. Inline front matter remains the primary metadata source and overrides
+    /// any overlapping sidecar fields.
+    /// </remarks>
+    internal async Task<DocMetadata?> ReadMetadataSidecarAsync(
+        string markdownFilePath,
+        string relativeMarkdownPath,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdownFilePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativeMarkdownPath);
+
+        var existingSidecars = SidecarExtensions
+            .Select(extension => markdownFilePath + extension)
+            .Where(File.Exists)
+            .ToArray();
+
+        if (existingSidecars.Length == 0)
+        {
+            return null;
+        }
+
+        if (existingSidecars.Length > 1)
+        {
+            _logger.LogWarning(
+                "Ignoring metadata sidecars for {MarkdownPath} because both {FirstSidecar} and {SecondSidecar} exist. Keep only one sidecar extension per Markdown file.",
+                relativeMarkdownPath,
+                Path.GetFileName(existingSidecars[0]),
+                Path.GetFileName(existingSidecars[1]));
+            return null;
+        }
+
+        var sidecarPath = existingSidecars[0];
+
+        try
+        {
+            var yaml = await _readAllTextAsync(sidecarPath, cancellationToken);
+            return MarkdownFrontMatterParser.ParseMetadataYaml(yaml);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (YamlException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Ignoring metadata sidecar {SidecarPath} for {MarkdownPath} because the YAML could not be parsed.",
+                Path.GetFileName(sidecarPath),
+                relativeMarkdownPath);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Ignoring metadata sidecar {SidecarPath} for {MarkdownPath} because it could not be read.",
+                Path.GetFileName(sidecarPath),
+                relativeMarkdownPath);
+            return null;
+        }
     }
 
     internal static string? ExtractSummary(string markdown)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Index.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Index.cshtml
@@ -40,6 +40,8 @@
             {
                 var pageTypeLabel = FormatPageType(featuredPage.PageType);
                 <a href="@featuredPage.Href"
+                   data-turbo-frame="doc-content"
+                   data-turbo-action="advance"
                    class="group h-full rounded-2xl border border-slate-800 bg-slate-900/60 p-6 transition-colors hover:border-cyan-500/50 hover:bg-slate-900">
                     <div class="mb-4 flex items-start justify-between gap-4">
                         <p class="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400">@featuredPage.Question</p>


### PR DESCRIPTION
## Summary
- add paired Markdown sidecar metadata support for RazorDocs, merging `*.md.yml` and `*.md.yaml` beneath inline front matter with warnings for invalid or conflicting sidecars
- move root landing curation out of the public repo `README.md` into `README.md.yml`, document the sidecar contract, and enforce the authored `README.md` portability policy without depending on Git at test time
- fix featured landing cards so Turbo frame navigation advances browser history and cover the new behavior with regression tests

## Testing
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --filter RepositoryReadmePolicyTests`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --filter FeaturedLandingNavigationRegressionTests`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
- `git diff --check`