### PR TITLE
fix: preserve generated docs css in static web assets

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ForgeTrust.Runnable.Web.RazorDocs\ForgeTrust.Runnable.Web.RazorDocs.csproj" />
+    <ProjectReference Include="..\ForgeTrust.Runnable.Web.RazorDocs.Standalone\ForgeTrust.Runnable.Web.RazorDocs.Standalone.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsWebModuleRegressionTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsWebModuleRegressionTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using FakeItEasy;
 using ForgeTrust.Runnable.Core;
 using ForgeTrust.Runnable.Web;
@@ -147,6 +148,52 @@ public class RazorDocsWebModuleRegressionTests
     }
 
     [Fact]
+    public async Task StandaloneBuild_Issue001_IncludesGeneratedStylesheetInRuntimeAndPackManifests()
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var buildCoordinates = GetCurrentBuildCoordinates();
+
+        var standaloneRuntimeManifestPath = Path.Combine(
+            repoRoot,
+            "Web",
+            "ForgeTrust.Runnable.Web.RazorDocs.Standalone",
+            "bin",
+            buildCoordinates.Configuration,
+            buildCoordinates.TargetFramework,
+            "ForgeTrust.Runnable.Web.RazorDocs.Standalone.staticwebassets.runtime.json");
+        var razorDocsRuntimeManifestPath = Path.Combine(
+            repoRoot,
+            "Web",
+            "ForgeTrust.Runnable.Web.RazorDocs.Standalone",
+            "bin",
+            buildCoordinates.Configuration,
+            buildCoordinates.TargetFramework,
+            "ForgeTrust.Runnable.Web.RazorDocs.staticwebassets.runtime.json");
+        var razorDocsPackManifestPath = Path.Combine(
+            repoRoot,
+            "Web",
+            "ForgeTrust.Runnable.Web.RazorDocs",
+            "obj",
+            buildCoordinates.Configuration,
+            buildCoordinates.TargetFramework,
+            "staticwebassets.pack.json");
+
+        Assert.True(
+            File.Exists(standaloneRuntimeManifestPath),
+            $"Expected the standalone host build to emit '{standaloneRuntimeManifestPath}'.");
+        Assert.True(
+            File.Exists(razorDocsRuntimeManifestPath),
+            $"Expected the standalone host build to emit '{razorDocsRuntimeManifestPath}'.");
+        Assert.True(
+            File.Exists(razorDocsPackManifestPath),
+            $"Expected the RazorDocs package build to emit '{razorDocsPackManifestPath}'.");
+
+        await AssertRuntimeManifestContainsSubPathAsync(standaloneRuntimeManifestPath, "css/site.gen.css");
+        await AssertRuntimeManifestContainsSubPathAsync(razorDocsRuntimeManifestPath, "css/site.gen.css");
+        await AssertPackManifestContainsPathAsync(razorDocsPackManifestPath, "staticwebassets/css/site.gen.css");
+    }
+
+    [Fact]
     public async Task ConfigureEndpoints_Issue001_RedirectsLegacySearchAssetsToPackagedContent()
     {
         var module = new RazorDocsWebModule();
@@ -248,11 +295,91 @@ public class RazorDocsWebModuleRegressionTests
         Assert.Equal(expectedLocation, response.Headers.Location?.OriginalString);
     }
 
+    private static async Task AssertRuntimeManifestContainsSubPathAsync(string manifestPath, string expectedSubPath)
+    {
+        await using var stream = File.OpenRead(manifestPath);
+        using var document = await JsonDocument.ParseAsync(stream);
+
+        Assert.True(
+            JsonContainsPropertyValue(document.RootElement, "SubPath", expectedSubPath),
+            $"Expected '{manifestPath}' to contain a SubPath of '{expectedSubPath}'.");
+    }
+
+    private static async Task AssertPackManifestContainsPathAsync(string manifestPath, string expectedPackagePath)
+    {
+        await using var stream = File.OpenRead(manifestPath);
+        using var document = await JsonDocument.ParseAsync(stream);
+
+        var files = document.RootElement.GetProperty("Files");
+        Assert.Contains(
+            files.EnumerateArray(),
+            file => file.TryGetProperty("PackagePath", out var packagePath)
+                && string.Equals(packagePath.GetString(), expectedPackagePath, StringComparison.Ordinal));
+    }
+
+    private static bool JsonContainsPropertyValue(JsonElement element, string propertyName, string expectedValue)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, propertyName, StringComparison.Ordinal)
+                        && string.Equals(property.Value.GetString(), expectedValue, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+
+                    if (JsonContainsPropertyValue(property.Value, propertyName, expectedValue))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    if (JsonContainsPropertyValue(item, propertyName, expectedValue))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            default:
+                return false;
+        }
+    }
+
     private static StartupContext CreateStartupContext()
     {
         var rootModule = A.Fake<IRunnableHostModule>();
         var environmentProvider = A.Fake<IEnvironmentProvider>();
         return new StartupContext(Array.Empty<string>(), rootModule, "TestApp", environmentProvider);
+    }
+
+    private static BuildCoordinates GetCurrentBuildCoordinates()
+    {
+        var trimmedBaseDirectory = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var current = new DirectoryInfo(trimmedBaseDirectory);
+        var segmentsBelowBin = new List<string>();
+
+        while (current is not null && !string.Equals(current.Name, "bin", StringComparison.OrdinalIgnoreCase))
+        {
+            segmentsBelowBin.Add(current.Name);
+            current = current.Parent;
+        }
+
+        if (current is null || segmentsBelowBin.Count < 2)
+        {
+            throw new InvalidOperationException(
+                $"Could not determine build configuration and target framework from '{AppContext.BaseDirectory}'.");
+        }
+
+        return new BuildCoordinates(
+            segmentsBelowBin[^1],
+            segmentsBelowBin[^2]);
     }
 
     private sealed class TestRazorDocsStartup : WebStartup<RazorDocsWebModule>
@@ -266,4 +393,6 @@ public class RazorDocsWebModuleRegressionTests
 
         protected override RazorDocsWebModule CreateRootModule() => _module;
     }
+
+    private sealed record BuildCoordinates(string Configuration, string TargetFramework);
 }

--- a/Web/ForgeTrust.Runnable.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace ForgeTrust.Runnable.Web.Tailwind.Tests;
 
@@ -66,6 +67,119 @@ public sealed class TailwindBuildTargetsTests : IDisposable
         Assert.False(File.Exists(markerPath));
     }
 
+    [Fact]
+    public async Task RunTailwindBuild_IncludesGeneratedCssInStaticWebAssetsManifest_OnCleanBuild()
+    {
+        var projectDirectory = Path.Combine(_tempRoot, "sample-rcl");
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "wwwroot", "css"));
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "tools"));
+
+        await File.WriteAllTextAsync(
+            Path.Combine(projectDirectory, "wwwroot", "css", "app.css"),
+            "@import \"tailwindcss\";" + Environment.NewLine);
+
+        var markerPath = Path.Combine(projectDirectory, "tailwind-cli-executed.marker");
+        var cliRelativePath = await CreateTailwindCliStubAsync(projectDirectory, markerPath);
+        var projectPath = Path.Combine(projectDirectory, "Sample.csproj");
+        var targetsPath = GetTailwindTargetsPath();
+
+        await File.WriteAllTextAsync(
+            projectPath,
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <StaticWebAssetBasePath>_content/Sample</StaticWebAssetBasePath>
+                <TailwindInputPath>wwwroot/css/app.css</TailwindInputPath>
+                <TailwindOutputPath>wwwroot/css/site.gen.css</TailwindOutputPath>
+                <TailwindCliPath>{{cliRelativePath}}</TailwindCliPath>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <FrameworkReference Include="Microsoft.AspNetCore.App" />
+              </ItemGroup>
+
+              <Import Project="{{EscapeForXml(targetsPath)}}" />
+            </Project>
+            """);
+
+        var result = await RunDotNetBuildAsync(projectPath, projectDirectory);
+        var combinedOutput = result.Stdout + Environment.NewLine + result.Stderr;
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(File.Exists(markerPath), combinedOutput);
+
+        var generatedCssPath = Path.Combine(projectDirectory, "wwwroot", "css", "site.gen.css");
+        Assert.True(File.Exists(generatedCssPath), "Expected the Tailwind stub to emit the generated stylesheet.");
+
+        var manifestPath = Path.Combine(projectDirectory, "obj", "Debug", "net10.0", "staticwebassets.build.json");
+        Assert.True(File.Exists(manifestPath), "Expected a static web assets build manifest.");
+
+        await AssertBuildManifestContainsGeneratedCssAsync(manifestPath);
+    }
+
+    [Fact]
+    public async Task RunTailwindBuild_PreservesGeneratedCssInStaticWebAssetsManifest_WhenDefaultContentItemsAreDisabled()
+    {
+        var projectDirectory = Path.Combine(_tempRoot, "sample-rcl-no-default-content");
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "wwwroot", "css"));
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "tools"));
+
+        await File.WriteAllTextAsync(
+            Path.Combine(projectDirectory, "wwwroot", "css", "app.css"),
+            "@import \"tailwindcss\";" + Environment.NewLine);
+
+        var markerPath = Path.Combine(projectDirectory, "tailwind-cli-executed.marker");
+        var cliRelativePath = await CreateTailwindCliStubAsync(projectDirectory, markerPath);
+        var projectPath = Path.Combine(projectDirectory, "Sample.csproj");
+        var targetsPath = GetTailwindTargetsPath();
+
+        await File.WriteAllTextAsync(
+            projectPath,
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <EnableDefaultContentItems>false</EnableDefaultContentItems>
+                <StaticWebAssetBasePath>_content/Sample</StaticWebAssetBasePath>
+                <TailwindInputPath>wwwroot/css/app.css</TailwindInputPath>
+                <TailwindOutputPath>wwwroot/css/site.gen.css</TailwindOutputPath>
+                <TailwindCliPath>{{cliRelativePath}}</TailwindCliPath>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <FrameworkReference Include="Microsoft.AspNetCore.App" />
+              </ItemGroup>
+
+              <Import Project="{{EscapeForXml(targetsPath)}}" />
+            </Project>
+            """);
+
+        var firstBuildResult = await RunDotNetBuildAsync(projectPath, projectDirectory);
+        var firstBuildOutput = firstBuildResult.Stdout + Environment.NewLine + firstBuildResult.Stderr;
+
+        Assert.Equal(0, firstBuildResult.ExitCode);
+        Assert.True(File.Exists(markerPath), firstBuildOutput);
+
+        var manifestPath = Path.Combine(projectDirectory, "obj", "Debug", "net10.0", "staticwebassets.build.json");
+        Assert.True(File.Exists(manifestPath), "Expected a static web assets build manifest after the first build.");
+        await AssertBuildManifestContainsGeneratedCssAsync(manifestPath);
+
+        var secondBuildResult = await RunDotNetBuildAsync(projectPath, projectDirectory);
+        var secondBuildOutput = secondBuildResult.Stdout + Environment.NewLine + secondBuildResult.Stderr;
+
+        Assert.Equal(0, secondBuildResult.ExitCode);
+        Assert.True(File.Exists(manifestPath), "Expected a static web assets build manifest after the second build.");
+        await AssertBuildManifestContainsGeneratedCssAsync(manifestPath);
+
+        Assert.DoesNotContain(
+            "Duplicate 'Content' items were included.",
+            secondBuildOutput,
+            StringComparison.Ordinal);
+    }
+
     private static string GetTailwindTargetsPath()
     {
         return Path.GetFullPath(
@@ -91,9 +205,13 @@ public sealed class TailwindBuildTargetsTests : IDisposable
             .Replace(">", "&gt;", StringComparison.Ordinal);
     }
 
-    private static async Task<string> CreateTailwindCliStubAsync(string projectDirectory, string markerPath)
+    private static async Task<string> CreateTailwindCliStubAsync(
+        string projectDirectory,
+        string markerPath,
+        string outputRelativePath = "wwwroot/css/site.gen.css")
     {
         var toolsDirectory = Path.Combine(projectDirectory, "tools");
+        var outputPath = Path.Combine(projectDirectory, outputRelativePath.Replace('/', Path.DirectorySeparatorChar));
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -101,11 +219,12 @@ public sealed class TailwindBuildTargetsTests : IDisposable
             var fullPath = Path.Combine(projectDirectory, relativePath);
             await File.WriteAllTextAsync(
                 fullPath,
-                $"""
-                @echo off
-                echo invoked>"{markerPath}"
-                exit /b 0
-                """);
+                $@"@echo off
+if not exist ""{Path.GetDirectoryName(outputPath)}"" mkdir ""{Path.GetDirectoryName(outputPath)}""
+>""{outputPath}"" echo .generated{{color:red;}}
+echo invoked>""{markerPath}""
+exit /b 0
+");
 
             return relativePath;
         }
@@ -119,11 +238,14 @@ public sealed class TailwindBuildTargetsTests : IDisposable
         var unixFullPath = Path.Combine(projectDirectory, unixRelativePath);
         await File.WriteAllTextAsync(
             unixFullPath,
-            $"""
-            #!/bin/sh
-            printf 'invoked\n' > "{markerPath}"
-            exit 0
-            """);
+            $@"#!/bin/sh
+mkdir -p ""{Path.GetDirectoryName(outputPath)}""
+cat <<'EOF' > ""{outputPath}""
+.generated{{color:red;}}
+EOF
+printf 'invoked\n' > ""{markerPath}""
+exit 0
+");
         File.SetUnixFileMode(unixFullPath, executableMode);
         return unixRelativePath;
     }
@@ -158,6 +280,20 @@ public sealed class TailwindBuildTargetsTests : IDisposable
             process.ExitCode,
             await stdoutTask,
             await stderrTask);
+    }
+
+    private static async Task AssertBuildManifestContainsGeneratedCssAsync(string manifestPath)
+    {
+        await using var manifestStream = File.OpenRead(manifestPath);
+        using var document = await JsonDocument.ParseAsync(manifestStream);
+
+        var assets = document.RootElement.GetProperty("Assets");
+        Assert.Contains(
+            assets.EnumerateArray(),
+            asset => asset.TryGetProperty("RelativePath", out var relativePath)
+                && relativePath.GetString() is string value
+                && value.StartsWith("css/site.gen", StringComparison.Ordinal)
+                && value.EndsWith(".css", StringComparison.Ordinal));
     }
 
     private sealed record DotNetCommandResult(int ExitCode, string Stdout, string Stderr);

--- a/Web/ForgeTrust.Runnable.Web.Tailwind/README.md
+++ b/Web/ForgeTrust.Runnable.Web.Tailwind/README.md
@@ -31,6 +31,12 @@ Reference the generated stylesheet from your layout:
 <link rel="stylesheet" href="~/css/site.gen.css" asp-append-version="true" />
 ```
 
+When `OutputPath` stays under `wwwroot/`, the generated file is registered as an ASP.NET Core static web
+asset on clean builds and publish runs. That means Razor Class Libraries and other package-style consumers can
+serve the generated CSS without checking `site.gen.css` into source control first.
+That registration also stays in place for projects that disable the SDK's default content items and rely on the
+package to declare the generated web-root asset explicitly.
+
 Keep `InputPath` and `OutputPath` pointed at different files. The build target and the development watch service both reject configurations where the two paths resolve to the same file, even if one path uses a normalized relative form such as `./wwwroot/css/../css/app.css`.
 
 ## CI
@@ -60,6 +66,7 @@ If your custom setup still uses the standalone CLI but stores it outside the pac
 ## Notes
 
 - The generated CSS file is intended to be build output and is commonly ignored in source control.
+- Generated CSS outside `wwwroot/` still builds locally, but it is not exposed automatically through the static web asset pipeline.
 - The platform-specific `ForgeTrust.Runnable.Web.Tailwind.Runtime.*` packages are support packages consumed transitively by this package and are not usually installed directly.
 - Tailwind CLI selection follows the current build host, not `RuntimeIdentifier`, because the standalone CLI runs during the build. Cross-targeted builds still execute the host-compatible binary.
 - Windows Arm64 hosts intentionally use the `win-x64` runtime under emulation. There is no `ForgeTrust.Runnable.Web.Tailwind.Runtime.win-arm64` package because Tailwind `v4.1.18` does not ship a native Windows Arm64 standalone CLI.

--- a/Web/ForgeTrust.Runnable.Web.Tailwind/TailwindOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web.Tailwind/TailwindOptions.cs
@@ -40,7 +40,9 @@ public class TailwindOptions
     /// </summary>
     /// <remarks>
     /// Defaults to <c>wwwroot/css/site.gen.css</c>. The value should be a non-empty relative path whose parent
-    /// directory exists and is writable. Avoid pointing this at the same file as <see cref="InputPath"/>.
+    /// directory exists and is writable. Keep the output under <c>wwwroot/</c> when the generated stylesheet
+    /// needs to participate in ASP.NET Core static web asset discovery for build and publish output. Avoid
+    /// pointing this at the same file as <see cref="InputPath"/>.
     /// </remarks>
     public string OutputPath { get; set; } = "wwwroot/css/site.gen.css";
 }

--- a/Web/ForgeTrust.Runnable.Web.Tailwind/build/ForgeTrust.Runnable.Web.Tailwind.targets
+++ b/Web/ForgeTrust.Runnable.Web.Tailwind/build/ForgeTrust.Runnable.Web.Tailwind.targets
@@ -8,12 +8,33 @@
     <_TailwindVersionFileSource>$(MSBuildThisFileDirectory)..\tailwind.version</_TailwindVersionFileSource>
     <_TailwindVersionFile Condition="Exists('$(_TailwindVersionFilePackage)')">$(_TailwindVersionFilePackage)</_TailwindVersionFile>
     <_TailwindVersionFile Condition="'$(_TailwindVersionFile)' == '' and Exists('$(_TailwindVersionFileSource)')">$(_TailwindVersionFileSource)</_TailwindVersionFile>
+    <_TailwindOutputPathNormalized>$([System.String]::Copy('$(TailwindOutputPath)').Replace('\', '/'))</_TailwindOutputPathNormalized>
+    <_TailwindOutputPathNormalized Condition="$([System.String]::Copy('$(_TailwindOutputPathNormalized)').StartsWith('./'))">$([System.String]::Copy('$(_TailwindOutputPathNormalized)').Substring(2))</_TailwindOutputPathNormalized>
+    <_TailwindOutputIsWebRootAsset>false</_TailwindOutputIsWebRootAsset>
+    <_TailwindOutputIsWebRootAsset Condition="'$(_TailwindOutputPathNormalized)' == 'wwwroot' or $([System.String]::Copy('$(_TailwindOutputPathNormalized)').StartsWith('wwwroot/'))">true</_TailwindOutputIsWebRootAsset>
+    <_TailwindUsesSdkDefaultContentItems>true</_TailwindUsesSdkDefaultContentItems>
+    <_TailwindUsesSdkDefaultContentItems Condition="'$(EnableDefaultItems)' == 'false' or '$(EnableDefaultContentItems)' == 'false'">false</_TailwindUsesSdkDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>
     <_TailwindTemplates Include="**/*.cshtml;**/*.html;**/*.razor" Exclude="bin/**;obj/**" />
     <_TailwindConfigs Include="tailwind.config.js" Condition="Exists('tailwind.config.js')" />
     <_TailwindConfigs Include="postcss.config.js" Condition="Exists('postcss.config.js')" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TailwindEnabled)' == 'true' and '$(_TailwindOutputIsWebRootAsset)' == 'true' and ('$(_TailwindUsesSdkDefaultContentItems)' == 'false' or !Exists('$(TailwindOutputPath)'))">
+    <!--
+      Declare the generated output as project content up front so a clean build can include it in the
+      static web asset manifest once RunTailwindBuild materializes the file under wwwroot/. Keep the
+      explicit item for consumers that disable the SDK's default content globs because they do not pick
+      up existing wwwroot files on subsequent incremental builds.
+    -->
+    <Content Include="$(TailwindOutputPath)">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <Pack>false</Pack>
+      <Visible>false</Visible>
+    </Content>
   </ItemGroup>
 
   <Target Name="ValidateTailwindBuildPaths"


### PR DESCRIPTION
## What changed

- updated the Tailwind MSBuild targets so generated `wwwroot/css/site.gen.css` is registered in static web assets on clean builds
- kept explicit registration for consumers that disable SDK default content items, so incremental builds do not lose the generated stylesheet
- added Tailwind regression coverage for clean builds and for the `EnableDefaultContentItems=false` case
- updated the RazorDocs manifest regression to derive the active configuration and target framework instead of assuming `Debug/net10.0`
- documented the generated output and static web asset behavior in the Tailwind package docs

## Why

Public RazorDocs pages could request `/css/site.gen.css` while the generated asset was missing from the clean-build static web asset manifests. That meant the docs could look fine in a warmed local tree but ship broken styling from fresh build and publish output.

## Impact

RazorDocs hosts and package-style consumers now serve the generated docs stylesheet reliably from clean builds, publish output, and configurations that disable default content item globs.

## Validation

- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --filter "FullyQualifiedName~StandaloneBuild_Issue001_IncludesGeneratedStylesheetInRuntimeAndPackManifests"`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj -c Release --filter "FullyQualifiedName~StandaloneBuild_Issue001_IncludesGeneratedStylesheetInRuntimeAndPackManifests"`
- `dotnet test Web/ForgeTrust.Runnable.Web.Tailwind.Tests/ForgeTrust.Runnable.Web.Tailwind.Tests.csproj`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
- browser QA against the local RazorDocs standalone host, covering `/docs`, `/docs/search`, and `/docs/Web/README.md.html`, with `GET /css/site.gen.css` returning `200` and no page console errors