### PR TITLE
fix(web): preserve RazorDocs stylesheet export

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsWebModuleRegressionTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsWebModuleRegressionTests.cs
@@ -19,6 +19,7 @@ namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
 public class RazorDocsWebModuleRegressionTests
 {
     private const string PackagedAssetBasePath = "/_content/ForgeTrust.Runnable.Web.RazorDocs/docs";
+    private const string PackagedStylesheetPath = "/_content/ForgeTrust.Runnable.Web.RazorDocs/css/site.gen.css";
     private const string RootStylesheetPath = "/css/site.gen.css";
 
     [Fact]
@@ -281,6 +282,120 @@ public class RazorDocsWebModuleRegressionTests
         }
     }
 
+    [Fact]
+    public async Task ConfigureEndpoints_Issue001_RedirectsRootStylesheetToPackagedContent_WhenRazorDocsIsRootModule()
+    {
+        var module = new RazorDocsWebModule();
+        var context = new StartupContext([], module);
+        var builder = WebApplication.CreateBuilder();
+
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddControllersWithViews().AddApplicationPart(typeof(DocsController).Assembly);
+
+        using var app = builder.Build();
+        module.ConfigureEndpoints(context, app);
+
+        await app.StartAsync();
+
+        try
+        {
+            var server = app.Services.GetRequiredService<IServer>();
+            var addresses = server.Features.Get<IServerAddressesFeature>();
+            var baseAddress = Assert.Single(addresses!.Addresses);
+
+            using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+            {
+                BaseAddress = new Uri(baseAddress)
+            };
+
+            await AssertRedirectAsync(client, RootStylesheetPath, PackagedStylesheetPath);
+            await AssertRedirectAsync(client, $"{RootStylesheetPath}?v=42", $"{PackagedStylesheetPath}?v=42");
+            await AssertRedirectAsync(client, HttpMethod.Head, RootStylesheetPath, PackagedStylesheetPath);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_Issue001_DoesNotRedirectRootStylesheet_WhenRazorDocsIsEmbedded()
+    {
+        var module = new RazorDocsWebModule();
+        var context = CreateStartupContext();
+        var builder = WebApplication.CreateBuilder();
+
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddControllersWithViews().AddApplicationPart(typeof(DocsController).Assembly);
+
+        using var app = builder.Build();
+        module.ConfigureEndpoints(context, app);
+
+        await app.StartAsync();
+
+        try
+        {
+            var server = app.Services.GetRequiredService<IServer>();
+            var addresses = server.Features.Get<IServerAddressesFeature>();
+            var baseAddress = Assert.Single(addresses!.Addresses);
+
+            using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+            {
+                BaseAddress = new Uri(baseAddress)
+            };
+
+            await AssertDoesNotRedirectAsync(client, RootStylesheetPath);
+            await AssertDoesNotRedirectAsync(client, HttpMethod.Head, $"{RootStylesheetPath}?v=42");
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_Issue001_PreservesPathBaseInRootStylesheetRedirect_WhenRazorDocsIsRootModule()
+    {
+        var module = new RazorDocsWebModule();
+        var context = new StartupContext([], module);
+        var builder = WebApplication.CreateBuilder();
+
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddControllersWithViews().AddApplicationPart(typeof(DocsController).Assembly);
+
+        using var app = builder.Build();
+        app.UsePathBase("/some-base");
+        module.ConfigureEndpoints(context, app);
+
+        await app.StartAsync();
+
+        try
+        {
+            var server = app.Services.GetRequiredService<IServer>();
+            var addresses = server.Features.Get<IServerAddressesFeature>();
+            var baseAddress = Assert.Single(addresses!.Addresses);
+
+            using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+            {
+                BaseAddress = new Uri(baseAddress)
+            };
+
+            await AssertRedirectAsync(
+                client,
+                $"/some-base{RootStylesheetPath}?v=42",
+                $"/some-base{PackagedStylesheetPath}?v=42");
+            await AssertRedirectAsync(
+                client,
+                HttpMethod.Head,
+                $"/some-base{RootStylesheetPath}?cache=abc",
+                $"/some-base{PackagedStylesheetPath}?cache=abc");
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
     private static async Task AssertRedirectAsync(HttpClient client, string requestPath, string expectedLocation)
     {
         await AssertRedirectAsync(client, HttpMethod.Get, requestPath, expectedLocation);
@@ -293,6 +408,20 @@ public class RazorDocsWebModuleRegressionTests
 
         Assert.Equal(HttpStatusCode.Found, response.StatusCode);
         Assert.Equal(expectedLocation, response.Headers.Location?.OriginalString);
+    }
+
+    private static async Task AssertDoesNotRedirectAsync(HttpClient client, string requestPath)
+    {
+        await AssertDoesNotRedirectAsync(client, HttpMethod.Get, requestPath);
+    }
+
+    private static async Task AssertDoesNotRedirectAsync(HttpClient client, HttpMethod method, string requestPath)
+    {
+        using var request = new HttpRequestMessage(method, requestPath);
+        using var response = await client.SendAsync(request);
+
+        Assert.NotEqual(HttpStatusCode.Found, response.StatusCode);
+        Assert.Null(response.Headers.Location);
     }
 
     private static async Task AssertRuntimeManifestContainsSubPathAsync(string manifestPath, string expectedSubPath)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsAssetPathResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsAssetPathResolver.cs
@@ -46,8 +46,18 @@ internal sealed class RazorDocsAssetPathResolver
     internal static RazorDocsAssetPathResolver CreateForRootModule(Assembly rootModuleAssembly)
     {
         return new RazorDocsAssetPathResolver(
-            rootModuleAssembly == RazorDocsAssembly
+            IsRootModuleAssembly(rootModuleAssembly)
                 ? RootStylesheetPath
                 : PackagedStylesheetPath);
+    }
+
+    /// <summary>
+    /// Determines whether the supplied root module assembly belongs to the RazorDocs standalone host.
+    /// </summary>
+    /// <param name="rootModuleAssembly">The assembly that owns the current host's root module.</param>
+    /// <returns><see langword="true"/> when RazorDocs is the root module; otherwise, <see langword="false"/>.</returns>
+    internal static bool IsRootModuleAssembly(Assembly rootModuleAssembly)
+    {
+        return rootModuleAssembly == RazorDocsAssembly;
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsAssetPathResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsAssetPathResolver.cs
@@ -6,10 +6,11 @@ namespace ForgeTrust.Runnable.Web.RazorDocs;
 /// Resolves stylesheet paths for RazorDocs hosts.
 /// </summary>
 /// <remarks>
-/// When the current application's root module lives in the RazorDocs assembly, RazorDocs static web assets are
-/// rooted at the application base path, so the generated stylesheet is served from <c>~/css/site.gen.css</c>.
-/// When RazorDocs is consumed from another host assembly, the same stylesheet is served from the Razor Class
-/// Library asset path under <c>~/_content/ForgeTrust.Runnable.Web.RazorDocs/css/site.gen.css</c>.
+/// When the current application's root module lives in the RazorDocs assembly, RazorDocs layouts preserve the
+/// historical root stylesheet URL at <c>~/css/site.gen.css</c>. Published and exported hosts may only materialize
+/// the packaged Razor Class Library asset path, so <see cref="RazorDocsWebModule"/> also preserves the root URL via
+/// a compatibility redirect to <c>~/_content/ForgeTrust.Runnable.Web.RazorDocs/css/site.gen.css</c>.
+/// When RazorDocs is consumed from another host assembly, layouts link directly to that packaged asset path.
 /// </remarks>
 internal sealed class RazorDocsAssetPathResolver
 {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsWebModule.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsWebModule.cs
@@ -11,6 +11,8 @@ namespace ForgeTrust.Runnable.Web.RazorDocs;
 public class RazorDocsWebModule : IRunnableWebModule
 {
     private const string RazorDocsStaticAssetBasePath = "/_content/ForgeTrust.Runnable.Web.RazorDocs/docs";
+    private const string RazorDocsPackagedStylesheetPath = "/_content/ForgeTrust.Runnable.Web.RazorDocs/css/site.gen.css";
+    private const string RazorDocsRootStylesheetPath = "/css/site.gen.css";
 
     /// <inheritdoc />
     public bool IncludeAsApplicationPart => true;
@@ -80,6 +82,13 @@ public class RazorDocsWebModule : IRunnableWebModule
     /// <param name="endpoints">Endpoint route builder used to map the module's routes.</param>
     public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
     {
+        if (ShouldPreserveRootStylesheetPath(context))
+        {
+            // Published/exported standalone hosts can resolve the packaged stylesheet only under /_content.
+            // Preserve the historical root stylesheet URL so docs HTML and static exports stay portable.
+            MapLegacyAssetRedirect(endpoints, RazorDocsRootStylesheetPath, RazorDocsPackagedStylesheetPath);
+        }
+
         // Preserve the historical /docs asset URLs even though the assets now live in the RazorDocs RCL package.
         MapLegacyAssetRedirect(endpoints, "/docs/search.css", $"{RazorDocsStaticAssetBasePath}/search.css");
         MapLegacyAssetRedirect(endpoints, "/docs/minisearch.min.js", $"{RazorDocsStaticAssetBasePath}/minisearch.min.js");
@@ -140,5 +149,10 @@ public class RazorDocsWebModule : IRunnableWebModule
                 context.Response.Redirect(redirectPath, permanent: false);
                 return Task.CompletedTask;
             });
+    }
+
+    private static bool ShouldPreserveRootStylesheetPath(StartupContext context)
+    {
+        return context.RootModuleAssembly == typeof(RazorDocsWebModule).Assembly;
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsWebModule.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsWebModule.cs
@@ -160,6 +160,6 @@ public class RazorDocsWebModule : IRunnableWebModule
 
     private static bool ShouldPreserveRootStylesheetPath(StartupContext context)
     {
-        return context.RootModuleAssembly == typeof(RazorDocsWebModule).Assembly;
+        return RazorDocsAssetPathResolver.IsRootModuleAssembly(context.RootModuleAssembly);
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsWebModule.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsWebModule.cs
@@ -78,6 +78,13 @@ public class RazorDocsWebModule : IRunnableWebModule
     /// <summary>
     /// Adds the module's default catch-all controller route for documentation endpoints.
     /// </summary>
+    /// <remarks>
+    /// When RazorDocs is the root module assembly, standalone and static-export hosts preserve the historical
+    /// <c>/css/site.gen.css</c> URL by redirecting it to the packaged Razor Class Library stylesheet at
+    /// <c>/_content/ForgeTrust.Runnable.Web.RazorDocs/css/site.gen.css</c>. Embedded hosts do not register that
+    /// redirect because they already link to the packaged asset directly. Redirects preserve the request
+    /// <see cref="HttpRequest.PathBase"/> and query string so legacy links continue to work behind a virtual path.
+    /// </remarks>
     /// <param name="context">Startup context for the application and environment.</param>
     /// <param name="endpoints">Endpoint route builder used to map the module's routes.</param>
     public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportEngineTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportEngineTests.cs
@@ -518,6 +518,22 @@ public class ExportEngineTests
     }
 
     [Fact]
+    public async Task RedirectFollowingHandler_Should_StopAfterConfiguredRedirectLimit()
+    {
+        var loopHandler = new RedirectLoopHandler();
+        using var client = new HttpClient(new RedirectFollowingHandler(loopHandler, maxRedirects: 3))
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        using var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal("/loop", response.Headers.Location?.OriginalString);
+        Assert.Equal(4, loopHandler.CallCount);
+    }
+
+    [Fact]
     public void MapHtmlFilePathToPartialPath_Should_Append_Partial_Suffix()
     {
         var htmlPath = Path.Combine("dist", "docs", "topic.html");
@@ -925,36 +941,73 @@ public class ExportEngineTests
         }
     }
 
+    private sealed class RedirectLoopHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Found)
+            {
+                Headers =
+                {
+                    Location = new Uri("/loop", UriKind.Relative)
+                }
+            });
+        }
+    }
+
     private sealed class RedirectFollowingHandler : DelegatingHandler
     {
-        public RedirectFollowingHandler(HttpMessageHandler innerHandler)
+        private readonly int _maxRedirects;
+
+        public RedirectFollowingHandler(HttpMessageHandler innerHandler, int maxRedirects = 10)
             : base(innerHandler)
         {
+            _maxRedirects = maxRedirects;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            const int maxRedirects = 10;
             var currentRequest = request;
+            HttpRequestMessage? ownedRedirectRequest = null;
             var response = await base.SendAsync(currentRequest, cancellationToken);
 
-            for (var redirectCount = 0; redirectCount < maxRedirects; redirectCount++)
+            try
             {
-                if (!IsRedirect(response.StatusCode) || response.Headers.Location is null)
+                for (var redirectCount = 0; redirectCount < _maxRedirects; redirectCount++)
                 {
-                    return response;
+                    if (!IsRedirect(response.StatusCode) || response.Headers.Location is null)
+                    {
+                        return response;
+                    }
+
+                    var currentRequestUri = currentRequest.RequestUri;
+                    if (currentRequestUri is null || !currentRequestUri.IsAbsoluteUri)
+                    {
+                        return response;
+                    }
+
+                    var redirectUri = response.Headers.Location.IsAbsoluteUri
+                        ? response.Headers.Location
+                        : new Uri(currentRequestUri, response.Headers.Location);
+
+                    response.Dispose();
+                    ownedRedirectRequest?.Dispose();
+
+                    ownedRedirectRequest = new HttpRequestMessage(currentRequest.Method, redirectUri);
+                    currentRequest = ownedRedirectRequest;
+                    response = await base.SendAsync(currentRequest, cancellationToken);
                 }
 
-                var redirectUri = response.Headers.Location.IsAbsoluteUri
-                    ? response.Headers.Location
-                    : new Uri(currentRequest.RequestUri!, response.Headers.Location);
-
-                response.Dispose();
-                currentRequest = new HttpRequestMessage(currentRequest.Method, redirectUri);
-                response = await base.SendAsync(currentRequest, cancellationToken);
+                return response;
             }
-
-            return response;
+            finally
+            {
+                ownedRedirectRequest?.Dispose();
+            }
         }
 
         private static bool IsRedirect(HttpStatusCode statusCode)

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportEngineTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportEngineTests.cs
@@ -485,6 +485,39 @@ public class ExportEngineTests
     }
 
     [Fact]
+    public async Task RunAsync_Should_Export_Redirected_Stylesheet_To_Original_Route_Path()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var client = new HttpClient(
+                new RedirectFollowingHandler(new RedirectedStylesheetHandler()))
+            {
+                BaseAddress = new Uri("http://localhost:5000")
+            };
+            A.CallTo(() => _httpClientFactory.CreateClient("ExportEngine")).Returns(client);
+
+            var context = new ExportContext(tempDir, null, "http://localhost:5000");
+            await _sut.RunAsync(context);
+
+            var rootStylesheetPath = Path.Combine(tempDir, "css", "site.gen.css");
+            Assert.True(File.Exists(rootStylesheetPath), "Expected redirected root stylesheet to be exported.");
+
+            var stylesheet = await File.ReadAllTextAsync(rootStylesheetPath);
+            Assert.Contains(".docs-content { color: cyan; }", stylesheet);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
     public void MapHtmlFilePathToPartialPath_Should_Append_Partial_Suffix()
     {
         var htmlPath = Path.Combine("dist", "docs", "topic.html");
@@ -738,6 +771,49 @@ public class ExportEngineTests
         }
     }
 
+    private sealed class RedirectedStylesheetHandler : HttpMessageHandler
+    {
+        private const string RootStylesheetPath = "/css/site.gen.css";
+        private const string PackagedStylesheetPath = "/_content/ForgeTrust.Runnable.Web.RazorDocs/css/site.gen.css";
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.AbsolutePath ?? "/";
+
+            if (path == "/" || path == "/index")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        $"""<html><body><link rel="stylesheet" href="{RootStylesheetPath}"></body></html>""",
+                        Encoding.UTF8,
+                        "text/html")
+                });
+            }
+
+            if (path == RootStylesheetPath)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Found)
+                {
+                    Headers =
+                    {
+                        Location = new Uri(PackagedStylesheetPath, UriKind.Relative)
+                    }
+                });
+            }
+
+            if (path == PackagedStylesheetPath)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(".docs-content { color: cyan; }", Encoding.UTF8, "text/css")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
     private sealed class DocsPartialHandler : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -846,6 +922,48 @@ public class ExportEngineTests
             }
 
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class RedirectFollowingHandler : DelegatingHandler
+    {
+        public RedirectFollowingHandler(HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            const int maxRedirects = 10;
+            var currentRequest = request;
+            var response = await base.SendAsync(currentRequest, cancellationToken);
+
+            for (var redirectCount = 0; redirectCount < maxRedirects; redirectCount++)
+            {
+                if (!IsRedirect(response.StatusCode) || response.Headers.Location is null)
+                {
+                    return response;
+                }
+
+                var redirectUri = response.Headers.Location.IsAbsoluteUri
+                    ? response.Headers.Location
+                    : new Uri(currentRequest.RequestUri!, response.Headers.Location);
+
+                response.Dispose();
+                currentRequest = new HttpRequestMessage(currentRequest.Method, redirectUri);
+                response = await base.SendAsync(currentRequest, cancellationToken);
+            }
+
+            return response;
+        }
+
+        private static bool IsRedirect(HttpStatusCode statusCode)
+        {
+            return statusCode is HttpStatusCode.Moved
+                or HttpStatusCode.Redirect
+                or HttpStatusCode.RedirectMethod
+                or HttpStatusCode.TemporaryRedirect
+                or HttpStatusCode.PermanentRedirect;
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve the RazorDocs root stylesheet compatibility redirect only for standalone/root-module hosts
- keep the manifest regression portable across Debug and Release test runs
- add export-layer coverage proving redirected `/css/site.gen.css` is written to the original Pages output path

## Verification
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj -c Release`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests.csproj -c Release`