### PR TITLE
refactor(razor-docs): [#152] prefer utilities for static chrome

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -710,7 +710,6 @@ public class RazorDocsViewsTests
         Assert.Contains("data-rw-search-suggestion=\"getting started\"", html);
         Assert.Contains("id=\"docs-search-page-failure\"", html);
         Assert.Contains("id=\"docs-search-page-retry\"", html);
-        Assert.Contains("docs-search-page-failure-link", html);
         Assert.Contains("href=\"/docs/search-index.json\"", html);
         Assert.Contains("data-rw-search-runtime=\"minisearch\"", html);
         Assert.Contains("data-turbo-frame=\"doc-content\"", html);
@@ -731,7 +730,7 @@ public class RazorDocsViewsTests
             c => c.Search());
 
         var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
-        var recoveryLink = document.QuerySelector("a.docs-search-page-failure-link[href='/docs']");
+        var recoveryLink = document.QuerySelector("a[href='/docs'][data-turbo-frame='_top']");
 
         Assert.NotNull(recoveryLink);
         Assert.Equal("_top", recoveryLink!.GetAttribute("data-turbo-frame"));

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsWebModuleRegressionTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsWebModuleRegressionTests.cs
@@ -64,7 +64,8 @@ public class RazorDocsWebModuleRegressionTests
             Assert.Equal("/docs/search.css", response.RequestMessage?.RequestUri?.AbsolutePath);
             Assert.Equal("text/css", response.Content.Headers.ContentType?.MediaType);
             Assert.False(string.IsNullOrWhiteSpace(body));
-            Assert.Contains("#docs-search-shell", body);
+            Assert.Contains("#docs-search-input", body);
+            Assert.Contains(".docs-search-page-results", body);
         }
         finally
         {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/DESIGN.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/DESIGN.md
@@ -68,6 +68,8 @@ Classes such as `docs-page-badge` and `docs-metadata-chip` are not a failure of 
 
 The search workspace renders semantic classes such as `docs-search-page`, `docs-search-page-filters-toggle`, and `docs-search-page-active-filters` directly in Razor, then extends those hooks in CSS and JavaScript. That is intentional. Shared hooks keep stateful UI readable and stable.
 
+That does not mean every heading, paragraph, or fallback-link wrapper inside `Search.cshtml` needs its own semantic class. Keep the stateful container and interactive hook semantic, then use local utilities for one-off typography and spacing inside that single view.
+
 #### Required `id` values
 
 Some search controls still need unique `id` values such as `docs-search-page-input` and `docs-search-page-filters-panel`. Those support uniqueness, accessibility relationships, and DOM targeting. They do not replace semantic classes as the reusable styling contract.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -37,6 +37,7 @@ This section is the normative source of truth for the boundary. `DESIGN.md` expl
 
 - New one-off page header spacing or typography in owned Razor markup: use Tailwind utilities in the view.
 - New reusable badge, metadata chip, or shared search workspace shell element: add or extend a semantic component class, then use utilities around it only when they are purely local.
+- For `Views/Docs/Search.cshtml`, keep the stateful search container or interactive hook semantic, but use local utilities for one-off header copy, helper layout, and fallback-link chrome inside that view.
 - Restyling paragraphs, headings, or code blocks inside `.docs-content`: update wrapper-scoped CSS instead of pushing utility classes into harvested HTML.
 - New search filter pill, active-filter surface, or other stateful search UI: use a semantic hook class because CSS and JavaScript both need to recognize it.
 
@@ -50,6 +51,7 @@ This section is the normative source of truth for the boundary. `DESIGN.md` expl
 
 - Do not refactor between utilities and semantic CSS for purity alone. Follow the surface contract unless a real usability or maintainability problem exists.
 - Do not treat required `id` values, such as `docs-search-page-input` or `docs-search-page-filters-panel`, as the reusable styling contract. They exist for uniqueness, targeting, and ARIA relationships.
+- Do not assume every child inside a semantic search container needs its own semantic class; local typography and spacing inside one view can still stay inline.
 - Do not add semantic classes to static package chrome when plain utilities are clearer and the styling is truly local.
 
 ## Configuration

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Search.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Search.cshtml
@@ -1,14 +1,17 @@
 @model ForgeTrust.Runnable.Web.RazorDocs.Models.SearchPageViewModel
+@{
+    const string FailureLinkClass = "grid gap-1 rounded-[0.85rem] border border-slate-800 bg-slate-900/55 px-[0.95rem] py-[0.85rem] no-underline transition-colors hover:border-cyan-400/35 hover:bg-cyan-950/20";
+}
 
 <div id="docs-search-page" class="docs-search-page">
-    <header class="docs-search-page-header">
-        <p class="docs-search-page-eyebrow">Docs Search</p>
-        <h1 class="docs-search-page-title">@Model.Title</h1>
-        <p class="docs-search-page-intro">@Model.Orientation</p>
+    <header class="grid gap-[0.55rem]">
+        <p class="m-0 text-[0.72rem] font-semibold uppercase tracking-[0.16em] text-cyan-300">Docs Search</p>
+        <h1 class="m-0 text-[clamp(2rem,4vw,3rem)] font-bold leading-[1.02] text-slate-50">@Model.Title</h1>
+        <p class="m-0 max-w-[52rem] text-base leading-[1.6] text-slate-400">@Model.Orientation</p>
     </header>
 
-    <div class="docs-search-page-query-row">
-        <div class="docs-search-page-input-wrap">
+    <div class="grid items-start gap-[0.85rem] md:grid-cols-[minmax(0,1fr)_auto]">
+        <div class="min-w-0">
             <label for="docs-search-page-input" class="sr-only">Search query</label>
             <input id="docs-search-page-input"
                    type="search"
@@ -45,7 +48,7 @@
              hidden
              aria-label="Search suggestions">
         <p class="docs-search-page-starter-copy">@Model.StarterHint</p>
-        <div class="docs-search-page-starter-chips">
+        <div class="flex flex-wrap gap-[0.6rem]">
             @foreach (var query in Model.SuggestedQueries)
             {
                 <button type="button"
@@ -62,37 +65,37 @@
              hidden
              aria-live="polite">
         <h2 class="docs-search-page-section-title">Search is temporarily unavailable</h2>
-        <p class="docs-search-page-failure-copy">
+        <p class="m-0 text-slate-300 leading-[1.55]">
             The search workspace loaded, but the index could not be fetched yet. You can retry or keep moving with one of these fallback paths.
         </p>
-        <div class="docs-search-page-failure-actions">
+        <div class="flex flex-wrap gap-3">
             <button id="docs-search-page-retry"
                     class="docs-search-page-retry"
                     type="button">
                 Retry
             </button>
         </div>
-        <div class="docs-search-page-failure-links">
+        <div class="grid gap-3 md:grid-cols-3">
             @foreach (var link in Model.FailureFallbackLinks)
             {
                 var usesDocsFrame = link.Href.StartsWith("/docs/", StringComparison.OrdinalIgnoreCase);
                 if (usesDocsFrame)
                 {
-                    <a class="docs-search-page-failure-link"
+                    <a class="@FailureLinkClass"
                        href="@link.Href"
                        data-turbo-frame="doc-content"
                        data-turbo-action="advance">
-                        <span class="docs-search-page-failure-link-title">@link.Title</span>
-                        <span class="docs-search-page-failure-link-description">@link.Description</span>
+                        <span class="text-[0.95rem] font-semibold text-cyan-300">@link.Title</span>
+                        <span class="text-[0.82rem] leading-[1.45] text-slate-400">@link.Description</span>
                     </a>
                 }
                 else
                 {
-                    <a class="docs-search-page-failure-link"
+                    <a class="@FailureLinkClass"
                        href="@link.Href"
                        data-turbo-frame="_top">
-                        <span class="docs-search-page-failure-link-title">@link.Title</span>
-                        <span class="docs-search-page-failure-link-description">@link.Description</span>
+                        <span class="text-[0.95rem] font-semibold text-cyan-300">@link.Title</span>
+                        <span class="text-[0.82rem] leading-[1.45] text-slate-400">@link.Description</span>
                     </a>
                 }
             }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Shared/Components/Sidebar/Default.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Shared/Components/Sidebar/Default.cshtml
@@ -7,6 +7,8 @@
         .Select(prefix => prefix.Trim())
         .OrderByDescending(prefix => prefix.Length)
         .ToArray();
+    const string PrimaryNavLinkClass = "block rounded-md px-2 py-1.5 text-sm font-medium text-slate-400 transition-all hover:bg-slate-900 hover:text-cyan-400";
+    const string SecondaryNavLinkClass = "block px-4 py-1 text-xs text-slate-500 transition-colors hover:text-cyan-400";
 }
 
 @foreach (var group in Model)
@@ -34,7 +36,7 @@
                 <a href="/docs/@(namespaceRoot.CanonicalPath ?? namespaceRoot.Path)"
                    data-turbo-frame="doc-content"
                    data-turbo-action="advance"
-                   class="block px-2 py-1.5 text-sm font-medium text-slate-400 hover:text-cyan-400 hover:bg-slate-900 rounded-md transition-all">
+                   class="@PrimaryNavLinkClass">
                     @namespaceRoot.Title
                 </a>
             }
@@ -57,7 +59,7 @@
                                     <a href="/docs/@(namespaceNode.CanonicalPath ?? namespaceNode.Path)"
                                        data-turbo-frame="doc-content"
                                        data-turbo-action="advance"
-                                       class="block px-2 py-1.5 text-sm font-medium text-slate-400 hover:text-cyan-400 hover:bg-slate-900 rounded-md transition-all">
+                                       class="@PrimaryNavLinkClass">
                                         @SidebarDisplayHelper.GetNamespaceDisplayName(SidebarDisplayHelper.GetFullNamespaceName(namespaceNode), namespacePrefixes)
                                     </a>
 
@@ -79,7 +81,7 @@
                                                            data-doc-anchor-link="true"
                                                            data-turbo-frame="doc-content"
                                                            data-turbo-action="advance"
-                                                           class="block px-4 py-1 text-xs text-slate-500 hover:text-cyan-400 transition-colors">
+                                                           class="@SecondaryNavLinkClass">
                                                             @typeItem.Title
                                                         </a>
                                                     </li>
@@ -103,7 +105,7 @@
                         <a href="/docs/@(docNode.CanonicalPath ?? docNode.Path)"
                            data-turbo-frame="doc-content"
                            data-turbo-action="advance"
-                           class="block px-2 py-1.5 text-sm font-medium text-slate-400 hover:text-cyan-400 hover:bg-slate-900 rounded-md transition-all">
+                           class="@PrimaryNavLinkClass">
                             @docNode.Title
                         </a>
 
@@ -125,7 +127,7 @@
                                                data-doc-anchor-link="true"
                                                data-turbo-frame="doc-content"
                                                data-turbo-action="advance"
-                                               class="block px-4 py-1 text-xs text-slate-500 hover:text-cyan-400 transition-colors">
+                                               class="@SecondaryNavLinkClass">
                                                 @sub.Title
                                             </a>
                                         </li>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Shared/_Layout.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Shared/_Layout.cshtml
@@ -55,7 +55,7 @@
                 RazorDocs
             </a>
         </div>
-        <div id="docs-search-shell" class="px-4 pb-2">
+        <div id="docs-search-shell" class="mb-3 px-4 pb-2">
             <label for="docs-search-input" class="sr-only">Search docs</label>
             <input id="docs-search-input"
                    type="search"
@@ -67,9 +67,10 @@
                    autocomplete="off" />
             <p id="docs-search-status" class="mt-1 text-xs text-slate-500" aria-live="polite"></p>
             <ul id="docs-search-results" class="hidden" role="listbox" aria-label="Search results"></ul>
-            <a href="/docs/search" class="docs-search-shell-cta">
+            <a href="/docs/search"
+               class="mt-[0.7rem] inline-flex w-full items-center justify-between gap-3 rounded-[0.8rem] border border-cyan-400/30 bg-gradient-to-b from-cyan-950/60 to-cyan-950/20 px-3.5 py-2.5 text-[0.82rem] font-semibold text-cyan-100 no-underline transition-colors hover:border-cyan-400/55 hover:from-cyan-950/70 hover:to-cyan-950/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400">
                 <span>Open Search Workspace</span>
-                <span class="docs-search-shell-cta-hint">Cmd/Ctrl+K</span>
+                <span class="text-[0.7rem] uppercase tracking-[0.08em] text-cyan-300">Cmd/Ctrl+K</span>
             </a>
         </div>
         <nav class="flex-grow overflow-y-auto px-4 pb-4 space-y-1 min-h-0" aria-label="Documentation navigation">

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
@@ -2,10 +2,6 @@
     display: none !important;
 }
 
-#docs-search-shell {
-    margin-bottom: 0.75rem;
-}
-
 #docs-search-input,
 #docs-search-page-input,
 .docs-search-page-select {
@@ -24,8 +20,7 @@
 .docs-search-page-chip:focus,
 .docs-search-page-starter-chip:focus,
 .docs-search-page-filters-toggle:focus,
-.docs-search-page-retry:focus,
-.docs-search-shell-cta:focus {
+.docs-search-page-retry:focus {
     border-color: #22d3ee;
     box-shadow: 0 0 0 1px #22d3ee inset;
 }
@@ -149,81 +144,11 @@
     padding: 0.8rem;
 }
 
-.docs-search-shell-cta {
-    margin-top: 0.7rem;
-    display: inline-flex;
-    width: 100%;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    border: 1px solid rgba(34, 211, 238, 0.28);
-    border-radius: 0.8rem;
-    background: linear-gradient(180deg, rgba(8, 47, 73, 0.6), rgba(8, 47, 73, 0.2));
-    color: #cffafe;
-    padding: 0.7rem 0.8rem;
-    text-decoration: none;
-    font-size: 0.82rem;
-    font-weight: 600;
-}
-
-.docs-search-shell-cta:hover {
-    border-color: rgba(34, 211, 238, 0.55);
-    background: linear-gradient(180deg, rgba(8, 47, 73, 0.72), rgba(8, 47, 73, 0.28));
-}
-
-.docs-search-shell-cta-hint {
-    font-size: 0.7rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: #67e8f9;
-}
-
 .docs-search-page {
     max-width: 60rem;
     margin: 0 auto;
     display: grid;
     gap: 1rem;
-}
-
-.docs-search-page-header {
-    display: grid;
-    gap: 0.55rem;
-}
-
-.docs-search-page-eyebrow {
-    margin: 0;
-    font-size: 0.72rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: #67e8f9;
-    font-weight: 600;
-}
-
-.docs-search-page-title {
-    margin: 0;
-    font-size: clamp(2rem, 4vw, 3rem);
-    line-height: 1.02;
-    color: #f8fafc;
-    font-weight: 700;
-}
-
-.docs-search-page-intro {
-    margin: 0;
-    max-width: 52rem;
-    color: #94a3b8;
-    font-size: 1rem;
-    line-height: 1.6;
-}
-
-.docs-search-page-query-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 0.85rem;
-    align-items: start;
-}
-
-.docs-search-page-input-wrap {
-    min-width: 0;
 }
 
 #docs-search-page-input {
@@ -359,17 +284,10 @@
     gap: 0.85rem;
 }
 
-.docs-search-page-starter-copy,
-.docs-search-page-failure-copy {
+.docs-search-page-starter-copy {
     margin: 0;
     color: #cbd5e1;
     line-height: 1.55;
-}
-
-.docs-search-page-starter-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.6rem;
 }
 
 .docs-search-page-starter-chip {
@@ -388,49 +306,11 @@
     gap: 1rem;
 }
 
-.docs-search-page-failure-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-}
-
 .docs-search-page-retry {
     border-radius: 0.8rem;
     padding-inline: 1rem;
     font-size: 0.84rem;
     font-weight: 600;
-}
-
-.docs-search-page-failure-links {
-    display: grid;
-    gap: 0.75rem;
-}
-
-.docs-search-page-failure-link {
-    display: grid;
-    gap: 0.25rem;
-    border: 1px solid #1e293b;
-    border-radius: 0.85rem;
-    padding: 0.85rem 0.95rem;
-    background: rgba(15, 23, 42, 0.55);
-    text-decoration: none;
-}
-
-.docs-search-page-failure-link:hover {
-    border-color: rgba(34, 211, 238, 0.35);
-    background: rgba(8, 47, 73, 0.2);
-}
-
-.docs-search-page-failure-link-title {
-    color: #67e8f9;
-    font-size: 0.95rem;
-    font-weight: 600;
-}
-
-.docs-search-page-failure-link-description {
-    color: #94a3b8;
-    font-size: 0.82rem;
-    line-height: 1.45;
 }
 
 .docs-search-page-results {
@@ -599,10 +479,6 @@
         gap: 0.9rem;
     }
 
-    .docs-search-page-query-row {
-        grid-template-columns: 1fr;
-    }
-
     .docs-search-page-filters-toggle {
         width: fit-content;
     }
@@ -619,9 +495,5 @@
 @media (min-width: 768px) {
     .docs-search-page-filters-toggle {
         display: none;
-    }
-
-    .docs-search-page-failure-links {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
@@ -37,7 +37,7 @@ public sealed class RazorDocsSearchPlaywrightTests
         await WaitForSidebarSearchReadyAsync(page);
         await RunSidebarSearchAndAssertResultsAsync(page, _fixture.SearchQuery);
 
-        await page.ClickAsync(".docs-search-shell-cta");
+        await page.ClickAsync("#docs-search-shell a[href='/docs/search']");
         await WaitForPathAsync(page, "/docs/search");
         await WaitForSearchPageSettledAsync(page);
         await RunAdvancedSearchAndAssertResultsAsync(page, _fixture.SearchQuery);
@@ -67,7 +67,7 @@ public sealed class RazorDocsSearchPlaywrightTests
             }
             """);
 
-        await page.ClickAsync(".docs-search-shell-cta");
+        await page.ClickAsync("#docs-search-shell a[href='/docs/search']");
         await page.WaitForFunctionAsync(
             """
             () => {
@@ -363,7 +363,7 @@ public sealed class RazorDocsSearchPlaywrightTests
         });
 
         Assert.True(await page.Locator("#docs-search-page-retry").IsVisibleAsync());
-        Assert.True(await page.Locator(".docs-search-page-failure-link").First.IsVisibleAsync());
+        Assert.True(await page.Locator("#docs-search-page-failure a[href]").First.IsVisibleAsync());
 
         await page.EvaluateAsync(
             """

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
@@ -82,8 +82,9 @@ public sealed class RazorDocsShellPlaywrightTests
                 && openButton?.getAttribute('aria-expanded') === 'false'
                 && Boolean(sidebarOverlay)
                 && window.getComputedStyle(sidebarOverlay).display === 'none'
-                && !main?.hasAttribute('inert')
-                && !main?.hasAttribute('aria-hidden')
+                && Boolean(main)
+                && !main.hasAttribute('inert')
+                && !main.hasAttribute('aria-hidden')
                 && document.activeElement === openButton;
             }
             """,

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
@@ -33,11 +33,15 @@ public sealed class RazorDocsShellPlaywrightTests
               const sidebar = document.getElementById('docs-sidebar');
               const sidebarOverlay = document.getElementById('docs-sidebar-overlay');
               const openButton = document.getElementById('docs-sidebar-open');
+              const main = document.getElementById('main-content');
               return Boolean(sidebar)
                 && sidebar.getAttribute('aria-hidden') === 'true'
                 && openButton?.getAttribute('aria-expanded') === 'false'
                 && Boolean(sidebarOverlay)
-                && window.getComputedStyle(sidebarOverlay).display === 'none';
+                && window.getComputedStyle(sidebarOverlay).display === 'none'
+                && Boolean(main)
+                && !main.hasAttribute('inert')
+                && !main.hasAttribute('aria-hidden');
             }
             """,
             null,
@@ -158,7 +162,10 @@ public sealed class RazorDocsShellPlaywrightTests
             },
             new PageWaitForFunctionOptions { Timeout = 30_000 });
 
-        Assert.Contains(targetUri.AbsolutePath, page.Url, StringComparison.Ordinal);
+        var navigatedUri = new Uri(page.Url);
+        Assert.Equal(
+            targetUri.AbsolutePath + targetUri.Fragment,
+            navigatedUri.AbsolutePath + navigatedUri.Fragment);
         Assert.True(await page.Locator("#docs-sidebar").IsVisibleAsync());
         Assert.True(await page.Locator("#docs-search-shell").IsVisibleAsync());
     }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
@@ -62,7 +62,8 @@ public sealed class RazorDocsShellPlaywrightTests
                 && openButton?.getAttribute('aria-expanded') === 'true'
                 && Boolean(sidebarOverlay)
                 && window.getComputedStyle(sidebarOverlay).display !== 'none'
-                && main?.hasAttribute('inert')
+                && Boolean(main)
+                && main.hasAttribute('inert')
                 && main.getAttribute('aria-hidden') === 'true'
                 && sidebar.contains(document.activeElement);
             }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.Playwright;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.IntegrationTests;
+
+[Collection(RazorDocsIntegrationCollection.Name)]
+[Trait("Category", "Integration")]
+public sealed class RazorDocsShellPlaywrightTests
+{
+    private readonly RazorDocsPlaywrightFixture _fixture;
+
+    public RazorDocsShellPlaywrightTests(RazorDocsPlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task MobileSidebarDrawer_OpensCloses_AndRestoresFocus()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 390,
+                Height = 844
+            }
+        });
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(_fixture.DocsUrl);
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const sidebar = document.getElementById('docs-sidebar');
+              return Boolean(sidebar)
+                && sidebar.classList.contains('-translate-x-full')
+                && sidebar.getAttribute('aria-hidden') === 'true';
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        await page.ClickAsync("#docs-sidebar-open");
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const sidebar = document.getElementById('docs-sidebar');
+              const main = document.getElementById('main-content');
+              return Boolean(sidebar)
+                && !sidebar.classList.contains('-translate-x-full')
+                && sidebar.getAttribute('role') === 'dialog'
+                && sidebar.getAttribute('aria-modal') === 'true'
+                && main?.hasAttribute('inert')
+                && main.getAttribute('aria-hidden') === 'true'
+                && sidebar.contains(document.activeElement);
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        Assert.Equal("true", await page.GetAttributeAsync("#docs-sidebar-open", "aria-expanded"));
+        Assert.True(await page.Locator("#docs-sidebar-overlay").IsVisibleAsync());
+
+        await page.ClickAsync("#docs-sidebar-close");
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const sidebar = document.getElementById('docs-sidebar');
+              const main = document.getElementById('main-content');
+              const openButton = document.getElementById('docs-sidebar-open');
+              return Boolean(sidebar)
+                && sidebar.classList.contains('-translate-x-full')
+                && sidebar.getAttribute('aria-hidden') === 'true'
+                && !main?.hasAttribute('inert')
+                && !main?.hasAttribute('aria-hidden')
+                && document.activeElement === openButton;
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        Assert.Equal("false", await page.GetAttributeAsync("#docs-sidebar-open", "aria-expanded"));
+        Assert.False(await page.Locator("#docs-sidebar-overlay").IsVisibleAsync());
+    }
+
+    [Fact]
+    public async Task SidebarLink_AdvancesDocContent_WithoutBreakingShellContext()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(_fixture.DocsUrl);
+
+        var link = page.Locator("nav[aria-label='Documentation navigation'] a[data-turbo-frame='doc-content']:not([data-doc-anchor-link='true'])").First;
+        await link.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = 30_000
+        });
+
+        var targetHref = await link.GetAttributeAsync("href");
+        Assert.False(string.IsNullOrWhiteSpace(targetHref));
+
+        var targetUri = new Uri(new Uri(_fixture.DocsUrl), targetHref!);
+        var initialContent = await page.Locator("#doc-content").InnerHTMLAsync();
+
+        await link.ClickAsync();
+        await page.WaitForFunctionAsync(
+            """
+            (args) => {
+              const island = document.getElementById('doc-content');
+              return window.location.pathname + window.location.hash === args.target
+                && Boolean(island)
+                && island.innerHTML !== args.initial;
+            }
+            """,
+            new
+            {
+                target = targetUri.AbsolutePath + targetUri.Fragment,
+                initial = initialContent
+            },
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+
+        Assert.Contains(targetUri.AbsolutePath, page.Url, StringComparison.Ordinal);
+        Assert.True(await page.Locator("#docs-sidebar").IsVisibleAsync());
+        Assert.True(await page.Locator("#docs-search-shell").IsVisibleAsync());
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsShellPlaywrightTests.cs
@@ -31,9 +31,13 @@ public sealed class RazorDocsShellPlaywrightTests
             """
             () => {
               const sidebar = document.getElementById('docs-sidebar');
+              const sidebarOverlay = document.getElementById('docs-sidebar-overlay');
+              const openButton = document.getElementById('docs-sidebar-open');
               return Boolean(sidebar)
-                && sidebar.classList.contains('-translate-x-full')
-                && sidebar.getAttribute('aria-hidden') === 'true';
+                && sidebar.getAttribute('aria-hidden') === 'true'
+                && openButton?.getAttribute('aria-expanded') === 'false'
+                && Boolean(sidebarOverlay)
+                && window.getComputedStyle(sidebarOverlay).display === 'none';
             }
             """,
             null,
@@ -44,11 +48,16 @@ public sealed class RazorDocsShellPlaywrightTests
             """
             () => {
               const sidebar = document.getElementById('docs-sidebar');
+              const sidebarOverlay = document.getElementById('docs-sidebar-overlay');
+              const openButton = document.getElementById('docs-sidebar-open');
               const main = document.getElementById('main-content');
               return Boolean(sidebar)
-                && !sidebar.classList.contains('-translate-x-full')
+                && sidebar.getAttribute('aria-hidden') === 'false'
                 && sidebar.getAttribute('role') === 'dialog'
                 && sidebar.getAttribute('aria-modal') === 'true'
+                && openButton?.getAttribute('aria-expanded') === 'true'
+                && Boolean(sidebarOverlay)
+                && window.getComputedStyle(sidebarOverlay).display !== 'none'
                 && main?.hasAttribute('inert')
                 && main.getAttribute('aria-hidden') === 'true'
                 && sidebar.contains(document.activeElement);
@@ -65,11 +74,14 @@ public sealed class RazorDocsShellPlaywrightTests
             """
             () => {
               const sidebar = document.getElementById('docs-sidebar');
+              const sidebarOverlay = document.getElementById('docs-sidebar-overlay');
               const main = document.getElementById('main-content');
               const openButton = document.getElementById('docs-sidebar-open');
               return Boolean(sidebar)
-                && sidebar.classList.contains('-translate-x-full')
                 && sidebar.getAttribute('aria-hidden') === 'true'
+                && openButton?.getAttribute('aria-expanded') === 'false'
+                && Boolean(sidebarOverlay)
+                && window.getComputedStyle(sidebarOverlay).display === 'none'
                 && !main?.hasAttribute('inert')
                 && !main?.hasAttribute('aria-hidden')
                 && document.activeElement === openButton;
@@ -90,20 +102,45 @@ public sealed class RazorDocsShellPlaywrightTests
 
         await page.GotoAsync(_fixture.DocsUrl);
 
-        var link = page.Locator("nav[aria-label='Documentation navigation'] a[data-turbo-frame='doc-content']:not([data-doc-anchor-link='true'])").First;
-        await link.WaitForAsync(new LocatorWaitForOptions
+        var links = page.Locator("nav[aria-label='Documentation navigation'] a[data-turbo-frame='doc-content']:not([data-doc-anchor-link='true'])");
+        await links.First.WaitForAsync(new LocatorWaitForOptions
         {
             State = WaitForSelectorState.Visible,
             Timeout = 30_000
         });
 
-        var targetHref = await link.GetAttributeAsync("href");
-        Assert.False(string.IsNullOrWhiteSpace(targetHref));
+        var currentUri = new Uri(page.Url);
+        var currentTarget = currentUri.AbsolutePath + currentUri.Fragment;
+        var linkCount = await links.CountAsync();
+        ILocator? selectedLink = null;
+        Uri? targetUri = null;
 
-        var targetUri = new Uri(new Uri(_fixture.DocsUrl), targetHref!);
+        for (var index = 0; index < linkCount; index++)
+        {
+            var candidate = links.Nth(index);
+            var candidateHref = await candidate.GetAttributeAsync("href");
+            if (string.IsNullOrWhiteSpace(candidateHref))
+            {
+                continue;
+            }
+
+            var resolvedTarget = new Uri(new Uri(_fixture.DocsUrl), candidateHref);
+            var resolvedPathAndFragment = resolvedTarget.AbsolutePath + resolvedTarget.Fragment;
+            if (string.Equals(resolvedPathAndFragment, currentTarget, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            selectedLink = candidate;
+            targetUri = resolvedTarget;
+            break;
+        }
+
+        Assert.NotNull(selectedLink);
+        Assert.NotNull(targetUri);
         var initialContent = await page.Locator("#doc-content").InnerHTMLAsync();
 
-        await link.ClickAsync();
+        await selectedLink!.ClickAsync();
         await page.WaitForFunctionAsync(
             """
             (args) => {


### PR DESCRIPTION
## Summary
- move RazorDocs-owned static shell and search chrome toward inline Tailwind utilities while preserving search runtime hooks
- dedupe repeated sidebar link utility bundles with view-local class constants and update the styling-boundary docs
- add Playwright shell regressions for mobile sidebar focus/restore and in-shell sidebar navigation

## Testing
- dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj
- dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj
- coderabbit review --plain -t committed --base main -c AGENTS.md --no-color

Fixes #152