### PR TITLE
feat(releases): add release contract and RazorDocs release hub

### DIFF
--- a/.github/release-ops.md
+++ b/.github/release-ops.md
@@ -1,0 +1,23 @@
+# Release contract maintainer notes
+
+This file lives under `.github/` on purpose so RazorDocs does not publish it as public documentation.
+
+## `no-unreleased-entry` label
+
+Use `no-unreleased-entry` only when a pull request does not belong in the public release story, such as:
+
+- repository administration
+- workflow-only cleanup
+- maintainer ergonomics that do not affect adopters
+
+Do not use it for package behavior, CLI behavior, examples, docs-facing behavior, or release policy changes.
+
+## Deferred automation
+
+The current workflow establishes the contracts that future release automation will consume:
+
+- Conventional Commits PR titles
+- one public unreleased proof artifact
+- tagged release notes plus a compact changelog
+
+Tracked follow-up: #161, "Automate coordinated monorepo releases from the public release contract".

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     paths-ignore:
       - '**/*.gitattributes'
       - '**/*.gitignore'
-      - '**/*.md'
   pull_request:
     branches:
       - main

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -1,0 +1,77 @@
+name: Release Contract
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title and unreleased entry
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.setFailed("This workflow only supports pull_request events.");
+              return;
+            }
+
+            const title = (pr.title || "").trim();
+            const conventionalCommitTitle = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+/;
+            const labels = (pr.labels || [])
+              .map(label => label && typeof label.name === "string" ? label.name : "")
+              .filter(Boolean);
+            const skipUnreleasedEntry = labels.includes("no-unreleased-entry");
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100
+              });
+            const changedFiles = files.map(file => file.filename);
+            const touchesUnreleased = changedFiles.includes("releases/unreleased.md")
+              || changedFiles.includes("releases/unreleased.md.yml");
+
+            const failures = [];
+
+            if (!conventionalCommitTitle.test(title)) {
+              failures.push(
+                "PR titles must follow Conventional Commits, for example `feat(web): add streamed sidebar`.");
+            }
+
+            if (!skipUnreleasedEntry && !touchesUnreleased) {
+              failures.push(
+                "PRs must update `releases/unreleased.md` unless a maintainer applies the `no-unreleased-entry` label.");
+            }
+
+            await core.summary
+              .addHeading("Release contract check")
+              .addTable([
+                [{data: "PR title", header: true}, title || "(empty)"],
+                [{data: "Conventional title", header: true}, conventionalCommitTitle.test(title) ? "yes" : "no"],
+                [{data: "Touched unreleased note", header: true}, touchesUnreleased ? "yes" : "no"],
+                [{data: "Skip label present", header: true}, skipUnreleasedEntry ? "yes" : "no"]
+              ])
+              .write();
+
+            if (failures.length > 0) {
+              core.setFailed(failures.join("\n"));
+            }

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -47,8 +47,7 @@ jobs:
                 per_page: 100
               });
             const changedFiles = files.map(file => file.filename);
-            const touchesUnreleased = changedFiles.includes("releases/unreleased.md")
-              || changedFiles.includes("releases/unreleased.md.yml");
+            const touchesUnreleased = changedFiles.includes("releases/unreleased.md");
 
             const failures = [];
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+!/releases/
+!/releases/**
 x64/
 x86/
 [Ww][Ii][Nn]32/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+This changelog is the compact release ledger for Runnable. The monorepo ships in unison, so each tagged version covers packages, CLI tooling, examples, and docs-facing behavior from this repository together.
+
+## Reading guide
+
+- `Unreleased` tracks the next coordinated version and points to the living release note.
+- Future tagged sections will use the shape `## x.y.z - YYYY-MM-DD`.
+- Every tagged section will link to a matching narrative release note in [`releases/`](./releases/README.md).
+- Breaking or behavior-changing updates must record migration guidance here and in the matching release note.
+
+## Unreleased
+
+Narrative release note: [Upcoming release note](./releases/unreleased.md)  
+Upgrade policy: [Pre-1.0 upgrade policy](./releases/upgrade-policy.md)  
+Authoring workflow: [Release authoring checklist](./releases/release-authoring-checklist.md)
+
+### Added
+
+- Runnable now has a repo-level release contract: a public release hub, an unreleased proof artifact, a pre-1.0 upgrade policy, and a tagged-release template for future versioned notes.
+- RazorDocs pages can now render a top-of-page trust bar from structured metadata so release notes and upgrade guidance can show status, safety context, and provenance without custom page code.
+
+### Changed
+
+- Runnable now treats the whole monorepo as one coordinated release surface. Packages, CLI tools, examples, and docs-facing behavior all roll into the same upcoming version.
+- Pull requests are expected to use Conventional Commits titles and to update `releases/unreleased.md` unless maintainers explicitly opt out.
+- Markdown-only changes on `main` now trigger the build-and-export workflow so release-note and policy updates publish with the docs surface.
+
+### Migration
+
+- Runnable has not cut `v0.1.0` yet, so there is no tagged migration guide today.
+- Before `v0.1.0`, any breaking or behavior-changing update should record provisional guidance in [`releases/unreleased.md`](./releases/unreleased.md) and move finalized steps into the tagged release note once the version ships.
+
+## No tagged releases yet
+
+Runnable is still defining its first release boundary. The first tagged section will be added when the project is ready to cut `v0.1.0`.

--- a/CHANGELOG.md.yml
+++ b/CHANGELOG.md.yml
@@ -4,7 +4,6 @@ page_type: release-log
 nav_group: Releases
 order: 20
 breadcrumbs:
-  - Releases
   - Changelog
 trust:
   status: Changelog contract

--- a/CHANGELOG.md.yml
+++ b/CHANGELOG.md.yml
@@ -4,6 +4,7 @@ page_type: release-log
 nav_group: Releases
 order: 20
 breadcrumbs:
+  - Releases
   - Changelog
 trust:
   status: Changelog contract

--- a/CHANGELOG.md.yml
+++ b/CHANGELOG.md.yml
@@ -1,0 +1,20 @@
+title: Changelog
+summary: Compact ledger for coordinated Runnable releases across packages, CLI tooling, examples, and docs-facing behavior.
+page_type: release-log
+nav_group: Releases
+order: 20
+breadcrumbs:
+  - Releases
+  - Changelog
+trust:
+  status: Changelog contract
+  summary: This ledger is the compact record for what is next and what shipped. Narrative detail and full migration walkthroughs live in the matching release pages.
+  freshness: Updated whenever unreleased work is regrouped or a tagged release is cut.
+  change_scope: Repository-wide. Every package and runnable surface in this monorepo shares the same release version.
+  migration:
+    label: Read the pre-1.0 upgrade policy
+    href: /docs/releases/upgrade-policy.md.html
+  archive: Tagged sections will link to long-form release notes under /docs/releases/ once versions start shipping.
+  sources:
+    - releases/unreleased.md
+    - releases/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Runnable
+
+Runnable is putting its release contract in place before the first tagged version. This file explains the contribution rules that feed the public release surface.
+
+## Release contract
+
+- Runnable releases the monorepo in unison. Packages, CLI tooling, examples, and docs-facing behavior all roll into the same next version.
+- Pull request titles that land on `main` must follow Conventional Commits. The squash-merge title is the durable signal for future automation and changelog grouping.
+- Update [`releases/unreleased.md`](./releases/unreleased.md) whenever a pull request changes behavior, usage guidance, release policy, examples, or docs consumers would care about in release notes.
+- Maintainers may apply the `no-unreleased-entry` label only for changes that do not belong in the public release story, such as repo administration or workflow-only cleanup.
+
+## Writing release notes
+
+- Start from the public [release hub](./releases/README.md).
+- Keep [`CHANGELOG.md`](./CHANGELOG.md) compact. It is the ledger, not the full story.
+- Put detailed adoption notes in the current unreleased page or a tagged release page under [`releases/`](./releases/README.md).
+- Record breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
+
+## Maintainer workflow
+
+- Use the [release authoring checklist](./releases/release-authoring-checklist.md) when preparing a release.
+- Use the [tagged release template](./releases/templates/tagged-release-template.md) when cutting the first versioned release note.
+- Keep private maintainer-only recovery notes outside harvested public docs. In this repository, `.github/` is the safe home for that material.
+
+## Local verification
+
+Build and test the full solution before pushing substantive changes:
+
+```bash
+dotnet build
+dotnet test --no-build
+./scripts/coverage-solution.sh
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Runnable is putting its release contract in place before the first tagged versio
 - Start from the public [release hub](./releases/README.md).
 - Keep [`CHANGELOG.md`](./CHANGELOG.md) compact. It is the ledger, not the full story.
 - Put detailed adoption notes in the current unreleased page or a tagged release page under [`releases/`](./releases/README.md).
-- Breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
+- Capture breaking changes or other behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
 
 ## Maintainer workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Runnable is putting its release contract in place before the first tagged versio
 - Start from the public [release hub](./releases/README.md).
 - Keep [`CHANGELOG.md`](./CHANGELOG.md) compact. It is the ledger, not the full story.
 - Put detailed adoption notes in the current unreleased page or a tagged release page under [`releases/`](./releases/README.md).
-- Record breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
+- Record-breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
 
 ## Maintainer workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Runnable is putting its release contract in place before the first tagged versio
 - Start from the public [release hub](./releases/README.md).
 - Keep [`CHANGELOG.md`](./CHANGELOG.md) compact. It is the ledger, not the full story.
 - Put detailed adoption notes in the current unreleased page or a tagged release page under [`releases/`](./releases/README.md).
-- Record-breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
+- Breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
 
 ## Maintainer workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Runnable is putting its release contract in place before the first tagged versio
 ## Release contract
 
 - Runnable releases the monorepo in unison. Packages, CLI tooling, examples, and docs-facing behavior all roll into the same next version.
-- Pull request titles that land on `main` must follow Conventional Commits. The squash-merge title is the durable signal for future automation and changelog grouping.
+- Pull request titles that land on `main` must follow [Conventional Commits](https://www.conventionalcommits.org/) using release-note-friendly types such as `feat`, `fix`, `docs`, `perf`, `refactor`, `test`, `build`, `ci`, `chore`, or `revert`. The squash-merge title is the durable signal for future automation and changelog grouping.
 - Update [`releases/unreleased.md`](./releases/unreleased.md) whenever a pull request changes behavior, usage guidance, release policy, examples, or docs consumers would care about in release notes.
 - Maintainers may apply the `no-unreleased-entry` label only for changes that do not belong in the public release story, such as repo administration or workflow-only cleanup.
 
@@ -14,7 +14,7 @@ Runnable is putting its release contract in place before the first tagged versio
 - Start from the public [release hub](./releases/README.md).
 - Keep [`CHANGELOG.md`](./CHANGELOG.md) compact. It is the ledger, not the full story.
 - Put detailed adoption notes in the current unreleased page or a tagged release page under [`releases/`](./releases/README.md).
-- Capture breaking changes or other behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
+- Capture breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
 
 ## Maintainer workflow
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ dotnet run --project examples/console-app
 dotnet run --project examples/web-app
 ```
 
+## Release notes and upgrade policy
+
+Runnable is preparing to release the entire monorepo in unison. The public release contract now lives in the repository so teams can see what is queued for the next version, how pre-1.0 changes are handled, and where future migration notes will live.
+
+- [Release hub](./releases/README.md) - start here for the narrative release surface.
+- [Unreleased proof artifact](./releases/unreleased.md) - the living notes for the next coordinated version.
+- [Changelog](./CHANGELOG.md) - the compact ledger for tagged and in-flight changes.
+- [Pre-1.0 upgrade policy](./releases/upgrade-policy.md) - the stability and migration contract before `v1.0.0`.
+- [Contribution and release entry rules](./CONTRIBUTING.md) - how PR titles and unreleased entries feed the release surface.
+
 ## Examples
 
 The [examples](examples) directory contains sample applications that demonstrate

--- a/README.md.yml
+++ b/README.md.yml
@@ -1,6 +1,10 @@
 title: Runnable
 summary: Runnable gives .NET teams a modular startup pipeline for web, console, and distributed apps. Start with the pillar you need, then drill into concrete examples and API reference.
 featured_pages:
+  - question: What is shipping next, and how risky is the upgrade?
+    path: releases/README.md
+    supporting_copy: Start with the public release hub, then drill into the unreleased proof artifact, changelog, and pre-1.0 upgrade policy.
+    order: 5
   - question: How do I ship a web app with Runnable?
     path: Web/README.md
     supporting_copy: See the web surface that composes middleware, endpoints, and host startup without a monolithic Program.cs.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -154,6 +154,23 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDocsAsync_ShouldFallbackToEmptyContent_WhenSanitizerReturnsNull()
+    {
+        var harvestedDocs = new List<DocNode>
+        {
+            new("Title", "path", "<p>content</p>")
+        };
+
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+        A.CallTo(() => _sanitizerFake.Sanitize("<p>content</p>"))
+            .ReturnsLazily(static (string _) => (string)null!);
+
+        var result = Assert.Single((await _aggregator.GetDocsAsync()).ToList());
+
+        Assert.Equal(string.Empty, result.Content);
+    }
+
+    [Fact]
     public async Task GetDocsAsync_ShouldHandleDuplicatePaths_ByKeepingFirst()
     {
         // Arrange

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -133,6 +133,27 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDocsAsync_ShouldRewriteInternalDocLinks_AfterSanitizing()
+    {
+        var harvestedDocs = new List<DocNode>
+        {
+            new(
+                "Releases",
+                "releases/README.md",
+                "<p><a href=\"./unreleased.md\">Unreleased</a> <a href=\"https://example.com/releases\">External</a></p>")
+        };
+
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        var result = Assert.Single((await _aggregator.GetDocsAsync()).ToList());
+
+        Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", result.Content);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", result.Content);
+        Assert.Contains("data-turbo-action=\"advance\"", result.Content);
+        Assert.Contains("href=\"https://example.com/releases\"", result.Content);
+    }
+
+    [Fact]
     public async Task GetDocsAsync_ShouldHandleDuplicatePaths_ByKeepingFirst()
     {
         // Arrange

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -1,4 +1,5 @@
 using AngleSharp;
+using AngleSharp.Html.Parser;
 using FakeItEasy;
 using ForgeTrust.Runnable.Caching;
 using ForgeTrust.Runnable.Web.RazorDocs.Models;
@@ -151,6 +152,28 @@ public class DocAggregatorTests : IDisposable
         Assert.Contains("data-turbo-frame=\"doc-content\"", result.Content);
         Assert.Contains("data-turbo-action=\"advance\"", result.Content);
         Assert.Contains("href=\"https://example.com/releases\"", result.Content);
+    }
+
+    [Fact]
+    public async Task GetDocsAsync_ShouldRewriteTitledMarkdownLinks_WithQuotedGreaterThanInTitle()
+    {
+        var harvestedDocs = new List<DocNode>
+        {
+            new(
+                "Guide",
+                "README.md",
+                "<p><a href=\"guide.md\" title=\"1 > 0\">guide</a></p>")
+        };
+
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        var result = Assert.Single((await _aggregator.GetDocsAsync()).ToList());
+        var document = new HtmlParser().ParseDocument(result.Content);
+        var anchor = Assert.Single(document.QuerySelectorAll("a"));
+
+        Assert.Equal("/docs/guide.md.html", anchor.GetAttribute("href"));
+        Assert.Equal("1 > 0", anchor.GetAttribute("title"));
+        Assert.Equal("guide", anchor.TextContent);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -47,6 +47,30 @@ public sealed class DocContentLinkRewriterTests
     }
 
     [Fact]
+    public void RewriteInternalDocLinks_ShouldCanonicalizeSourceDocsLinks_UnderDocsRoot()
+    {
+        var html = "<p><a href=\"/docs/releases/upgrade-policy.md\">Policy</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+
+        Assert.Contains("href=\"/docs/releases/upgrade-policy.md.html\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldLeaveNonPageDocsAssets_Unchanged()
+    {
+        var html = "<p><a href=\"/docs/search-index.json\">Search index</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+
+        Assert.Contains("href=\"/docs/search-index.json\"", rewritten);
+        Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.DoesNotContain("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
     public void RewriteInternalDocLinks_ShouldDecorateDocsLandingLinks_WithoutChangingTheirRoutes()
     {
         var html = "<p><a href=\"/docs\">Docs home</a></p>";
@@ -139,7 +163,7 @@ public sealed class DocContentLinkRewriterTests
     }
 
     [Fact]
-    public void RewriteInternalDocLinks_ShouldAppendAttributes_ToSelfClosingAnchors()
+    public void RewriteInternalDocLinks_ShouldRewriteSelfClosingAnchors_AsValidHtmlAnchors()
     {
         var html = "<a href=\"./unreleased.md\" />";
 
@@ -148,7 +172,7 @@ public sealed class DocContentLinkRewriterTests
         Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
         Assert.Contains("data-turbo-action=\"advance\"", rewritten);
-        Assert.EndsWith("/>", rewritten, StringComparison.Ordinal);
+        Assert.Contains("</a>", rewritten);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -71,6 +71,28 @@ public sealed class DocContentLinkRewriterTests
     }
 
     [Fact]
+    public void RewriteInternalDocLinks_ShouldLeaveAnchorsWithoutNavigableDocTargetsUnchanged()
+    {
+        var html = """
+            <p>
+              <a href="   ">Empty</a>
+              <a href="//example.com/releases">Scheme relative</a>
+              <a href="?view=compact">Query only</a>
+              <a href="/">Site root</a>
+            </p>
+            """;
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+
+        Assert.Contains("href=\"   \"", rewritten);
+        Assert.Contains("href=\"//example.com/releases\"", rewritten);
+        Assert.Contains("href=\"?view=compact\"", rewritten);
+        Assert.Contains("href=\"/\"", rewritten);
+        Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.DoesNotContain("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
     public void RewriteInternalDocLinks_ShouldLeaveExternalAndNewTabLinksUnchanged()
     {
         var html = """

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -47,6 +47,30 @@ public sealed class DocContentLinkRewriterTests
     }
 
     [Fact]
+    public void RewriteInternalDocLinks_ShouldRewriteRootedMarkdownLinks_ToCanonicalDocsRoutes()
+    {
+        var html = "<p><a href=\"/releases/unreleased.md\">Unreleased</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+
+        Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldLeaveRootedNonDocHtmlLinksUnchanged()
+    {
+        var html = "<p><a href=\"/privacy.html\">Privacy</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+
+        Assert.Contains("href=\"/privacy.html\"", rewritten);
+        Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.DoesNotContain("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
     public void RewriteInternalDocLinks_ShouldLeaveExternalAndNewTabLinksUnchanged()
     {
         var html = """

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -112,6 +112,33 @@ public sealed class DocContentLinkRewriterTests
     }
 
     [Fact]
+    public void RewriteInternalDocLinks_ShouldRewriteRelativeCanonicalMarkdownLinks_ToDocsRoutes()
+    {
+        var html = "<p><a href=\"../CHANGELOG.md.html\">Changelog</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+
+        Assert.Contains("href=\"/docs/CHANGELOG.md.html\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldLeaveRelativeNonDocHtmlLinksUnchanged()
+    {
+        var html = "<p><a href=\"../privacy.html\">Privacy</a> <a href=\"../../status.html\">Status</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks(
+            "releases/templates/tagged-release-template.md",
+            html);
+
+        Assert.Contains("href=\"../privacy.html\"", rewritten);
+        Assert.Contains("href=\"../../status.html\"", rewritten);
+        Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.DoesNotContain("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
     public void RewriteInternalDocLinks_ShouldAppendAttributes_ToSelfClosingAnchors()
     {
         var html = "<a href=\"./unreleased.md\" />";

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -1,0 +1,65 @@
+using ForgeTrust.Runnable.Web.RazorDocs.Services;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
+
+public sealed class DocContentLinkRewriterTests
+{
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldRewriteRelativeMarkdownLinks_ToCanonicalDocsRoutes()
+    {
+        var html = """
+            <p>
+              <a class="proof-link" href="./unreleased.md">Unreleased</a>
+              <a href="../CHANGELOG.md">Changelog</a>
+            </p>
+            """;
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+
+        Assert.Contains("class=\"proof-link\"", rewritten);
+        Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
+        Assert.Contains("href=\"/docs/CHANGELOG.md.html\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldRewriteFragmentOnlyLinks_AndMarkAnchorNavigation()
+    {
+        var html = "<p><a href=\"#migration\">Migration</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+
+        Assert.Contains("href=\"/docs/releases/unreleased.md.html#migration\"", rewritten);
+        Assert.Contains("data-doc-anchor-link=\"true\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldDecorateCanonicalDocsLinks_WithoutChangingTheirRoutes()
+    {
+        var html = "<p><a href=\"/docs/releases/upgrade-policy.md.html\">Policy</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+
+        Assert.Contains("href=\"/docs/releases/upgrade-policy.md.html\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldLeaveExternalAndNewTabLinksUnchanged()
+    {
+        var html = """
+            <p>
+              <a href="https://example.com/releases">External</a>
+              <a href="./unreleased.md" target="_blank">Open in new tab</a>
+            </p>
+            """;
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+
+        Assert.Contains("href=\"https://example.com/releases\"", rewritten);
+        Assert.DoesNotContain("href=\"https://example.com/releases\" data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("href=\"./unreleased.md\" target=\"_blank\"", rewritten);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -47,6 +47,18 @@ public sealed class DocContentLinkRewriterTests
     }
 
     [Fact]
+    public void RewriteInternalDocLinks_ShouldDecorateDocsLandingLinks_WithoutChangingTheirRoutes()
+    {
+        var html = "<p><a href=\"/docs\">Docs home</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+
+        Assert.Contains("href=\"/docs\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
     public void RewriteInternalDocLinks_ShouldRewriteRootedMarkdownLinks_ToCanonicalDocsRoutes()
     {
         var html = "<p><a href=\"/releases/unreleased.md\">Unreleased</a></p>";
@@ -54,6 +66,35 @@ public sealed class DocContentLinkRewriterTests
         var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
 
         Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldRewriteRootLevelRelativeLinks_AndUseSourcePathWithoutFragments()
+    {
+        var html = """
+            <p>
+              <a href="./README.md">Start here</a>
+              <a href="#summary">Summary</a>
+            </p>
+            """;
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("CHANGELOG.md#history", html);
+
+        Assert.Contains("href=\"/docs/README.md.html\"", rewritten);
+        Assert.Contains("href=\"/docs/CHANGELOG.md.html#summary\"", rewritten);
+        Assert.Contains("data-doc-anchor-link=\"true\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldRewriteRelativeLinks_WhenSourcePathIsEmpty()
+    {
+        var html = "<p><a href=\"./README.md\">Start here</a></p>";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks(string.Empty, html);
+
+        Assert.Contains("href=\"/docs/README.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
         Assert.Contains("data-turbo-action=\"advance\"", rewritten);
     }
@@ -68,6 +109,19 @@ public sealed class DocContentLinkRewriterTests
         Assert.Contains("href=\"/privacy.html\"", rewritten);
         Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
         Assert.DoesNotContain("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldAppendAttributes_ToSelfClosingAnchors()
+    {
+        var html = "<a href=\"./unreleased.md\" />";
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+
+        Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
+        Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.Contains("data-turbo-action=\"advance\"", rewritten);
+        Assert.EndsWith("/>", rewritten, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
@@ -22,6 +22,51 @@ public sealed class DocMetadataFactoryTests
         Assert.Equal(["Concepts", "Quickstart"], metadata.Breadcrumbs);
     }
 
+    [Fact]
+    public void CreateMarkdownMetadata_ShouldMarkExplicitBreadcrumbs_WhenTheyAlignWithPathTargets()
+    {
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(
+            "releases/unreleased.md",
+            "Unreleased",
+            new DocMetadata
+            {
+                Breadcrumbs = ["Releases", "Unreleased"]
+            },
+            null);
+
+        Assert.True(metadata.BreadcrumbsMatchPathTargets);
+    }
+
+    [Fact]
+    public void CreateMarkdownMetadata_ShouldTreatNestedReadmeAsDirectoryLanding_ForBreadcrumbAlignment()
+    {
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(
+            "releases/README.md",
+            "Releases",
+            new DocMetadata
+            {
+                Breadcrumbs = ["Releases"]
+            },
+            null);
+
+        Assert.True(metadata.BreadcrumbsMatchPathTargets);
+    }
+
+    [Fact]
+    public void CreateMarkdownMetadata_ShouldNotMarkExplicitBreadcrumbs_WhenTargetCountDoesNotMatch()
+    {
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(
+            "CHANGELOG.md",
+            "Changelog",
+            new DocMetadata
+            {
+                Breadcrumbs = ["Releases", "Changelog"]
+            },
+            null);
+
+        Assert.Null(metadata.BreadcrumbsMatchPathTargets);
+    }
+
     [Theory]
     [InlineData("Tests/guide.md")]
     [InlineData("test/guide.md")]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
@@ -67,6 +67,21 @@ public sealed class DocMetadataFactoryTests
         Assert.Null(metadata.BreadcrumbsMatchPathTargets);
     }
 
+    [Fact]
+    public void CreateMarkdownMetadata_ShouldTreatExtensionlessInternalPathsAsInternal()
+    {
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(
+            "docs/benchmarks",
+            "Benchmarks",
+            null,
+            null);
+
+        Assert.Equal("internals", metadata.PageType);
+        Assert.Equal("contributor", metadata.Audience);
+        Assert.True(metadata.HideFromPublicNav);
+        Assert.True(metadata.HideFromSearch);
+    }
+
     [Theory]
     [InlineData("Tests/guide.md")]
     [InlineData("test/guide.md")]
@@ -134,6 +149,16 @@ public sealed class DocMetadataFactoryTests
     }
 
     [Theory]
+    [InlineData("guides/quickstart.md", null)]
+    [InlineData("docs/Runnable/overview.md", "Runnable")]
+    public void DeriveComponentFromPath_ShouldReturnExpectedComponent(string path, string? expectedComponent)
+    {
+        var component = DocMetadataFactory.DeriveComponentFromPath(path);
+
+        Assert.Equal(expectedComponent, component);
+    }
+
+    [Theory]
     [InlineData("ForgeTrust.Runnable.Web.Tests", true)]
     [InlineData("ForgeTrust.Runnable.Web.RazorWire.Cli.Tests", true)]
     [InlineData("RunnableBenchmarks.Web", true)]
@@ -153,6 +178,14 @@ public sealed class DocMetadataFactoryTests
 
         Assert.Equal(["Namespaces", "Web"], metadata.Breadcrumbs);
         Assert.True(metadata.BreadcrumbsMatchPathTargets);
+    }
+
+    [Fact]
+    public void DeriveComponentFromNamespace_ShouldReturnOriginalValue_WhenFallbackNamespaceHasNoSegments()
+    {
+        var component = DocMetadataFactory.DeriveComponentFromNamespace(".");
+
+        Assert.Equal(".", component);
     }
 
     [Theory]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
@@ -53,6 +53,22 @@ public sealed class DocMetadataFactoryTests
     }
 
     [Fact]
+    public void CreateMarkdownMetadata_ShouldMarkExplicitBreadcrumbs_WhenTheyIncludeAuthoredNavGroupParent()
+    {
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(
+            "CHANGELOG.md",
+            "Changelog",
+            new DocMetadata
+            {
+                NavGroup = "Releases",
+                Breadcrumbs = ["Releases", "Changelog"]
+            },
+            null);
+
+        Assert.True(metadata.BreadcrumbsMatchPathTargets);
+    }
+
+    [Fact]
     public void CreateMarkdownMetadata_ShouldNotMarkExplicitBreadcrumbs_WhenTargetCountDoesNotMatch()
     {
         var metadata = DocMetadataFactory.CreateMarkdownMetadata(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocModelsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocModelsTests.cs
@@ -14,6 +14,15 @@ public class DocModelsTests
             Summary = "Summary",
             SummaryIsDerived = true,
             PageType = "guide",
+            Trust = new DocTrustMetadata
+            {
+                Status = "Unreleased",
+                Migration = new DocTrustLink
+                {
+                    Label = "Read the upgrade policy",
+                    Href = "/docs/releases/upgrade-policy.md.html"
+                }
+            },
             FeaturedPages =
             [
                 new DocFeaturedPageDefinition
@@ -40,6 +49,8 @@ public class DocModelsTests
         Assert.Equal("Summary", node.Metadata?.Summary);
         Assert.True(node.Metadata?.SummaryIsDerived);
         Assert.Equal("guide", node.Metadata?.PageType);
+        Assert.Equal("Unreleased", node.Metadata?.Trust?.Status);
+        Assert.Equal("/docs/releases/upgrade-policy.md.html", node.Metadata?.Trust?.Migration?.Href);
         Assert.Single(node.Metadata?.FeaturedPages!);
         Assert.Equal(["alias-one"], node.Metadata?.Aliases);
         Assert.Equal(["legacy/alias"], node.Metadata?.RedirectAliases);
@@ -105,6 +116,51 @@ public class DocModelsTests
 
         Assert.NotNull(merged);
         Assert.Equal("Fallback Title", merged!.Title);
+    }
+
+    [Fact]
+    public void Merge_ShouldMergeTrustMetadata_FieldByField_AndPreserveExplicitEmptySources()
+    {
+        var merged = DocMetadata.Merge(
+            new DocMetadata
+            {
+                Trust = new DocTrustMetadata
+                {
+                    Status = "Unreleased",
+                    Sources = Array.Empty<string>(),
+                    Migration = new DocTrustLink
+                    {
+                        Label = "Upgrade guide"
+                    }
+                }
+            },
+            new DocMetadata
+            {
+                Trust = new DocTrustMetadata
+                {
+                    Summary = "This page is provisional until the tag is cut.",
+                    Freshness = "Updated on main.",
+                    ChangeScope = "Repository-wide.",
+                    Archive = "Tagged release notes keep the durable record.",
+                    Sources = ["CHANGELOG.md"],
+                    Migration = new DocTrustLink
+                    {
+                        Label = "Read the upgrade policy",
+                        Href = "/docs/releases/upgrade-policy.md.html"
+                    }
+                }
+            });
+
+        Assert.NotNull(merged);
+        Assert.NotNull(merged!.Trust);
+        Assert.Equal("Unreleased", merged.Trust!.Status);
+        Assert.Equal("This page is provisional until the tag is cut.", merged.Trust.Summary);
+        Assert.Equal("Updated on main.", merged.Trust.Freshness);
+        Assert.Equal("Repository-wide.", merged.Trust.ChangeScope);
+        Assert.Equal("Upgrade guide", merged.Trust.Migration?.Label);
+        Assert.Equal("/docs/releases/upgrade-policy.md.html", merged.Trust.Migration?.Href);
+        Assert.Equal("Tagged release notes keep the durable record.", merged.Trust.Archive);
+        Assert.Empty(merged.Trust.Sources!);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocModelsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocModelsTests.cs
@@ -231,4 +231,93 @@ public class DocModelsTests
 
         Assert.Same(primary, merged);
     }
+
+    [Fact]
+    public void DocTrustMetadataMerge_ShouldReturnFallback_WhenPrimaryIsNull()
+    {
+        var fallback = new DocTrustMetadata
+        {
+            Status = "Published"
+        };
+
+        var merged = DocTrustMetadata.Merge(null, fallback);
+
+        Assert.Same(fallback, merged);
+    }
+
+    [Fact]
+    public void DocTrustMetadataMerge_ShouldReturnPrimary_WhenFallbackIsNull()
+    {
+        var primary = new DocTrustMetadata
+        {
+            Status = "Published"
+        };
+
+        var merged = DocTrustMetadata.Merge(primary, null);
+
+        Assert.Same(primary, merged);
+    }
+
+    [Fact]
+    public void DocTrustMetadataMerge_ShouldTreatBlankFallbackValuesAsMissing()
+    {
+        var merged = DocTrustMetadata.Merge(
+            new DocTrustMetadata
+            {
+                Summary = "   "
+            },
+            new DocTrustMetadata
+            {
+                Summary = "\t"
+            });
+
+        Assert.NotNull(merged);
+        Assert.Null(merged!.Summary);
+    }
+
+    [Fact]
+    public void DocTrustLinkMerge_ShouldReturnFallback_WhenPrimaryIsNull()
+    {
+        var fallback = new DocTrustLink
+        {
+            Label = "Upgrade guide"
+        };
+
+        var merged = DocTrustLink.Merge(null, fallback);
+
+        Assert.Same(fallback, merged);
+    }
+
+    [Fact]
+    public void DocTrustLinkMerge_ShouldReturnPrimary_WhenFallbackIsNull()
+    {
+        var primary = new DocTrustLink
+        {
+            Label = "Upgrade guide"
+        };
+
+        var merged = DocTrustLink.Merge(primary, null);
+
+        Assert.Same(primary, merged);
+    }
+
+    [Fact]
+    public void DocTrustLinkMerge_ShouldTreatBlankFallbackValuesAsMissing()
+    {
+        var merged = DocTrustLink.Merge(
+            new DocTrustLink
+            {
+                Label = "   ",
+                Href = " "
+            },
+            new DocTrustLink
+            {
+                Label = "\t",
+                Href = "\n"
+            });
+
+        Assert.NotNull(merged);
+        Assert.Null(merged!.Label);
+        Assert.Null(merged.Href);
+    }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
@@ -138,6 +138,28 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void Extract_ShouldTreatBlankMigrationLinkFieldsAsMissing()
+    {
+        var markdown = """
+            ---
+            trust:
+              status: Unreleased
+              migration:
+                label: "   "
+                href: "   "
+            ---
+            # Hello
+            """;
+
+        var (body, metadata) = MarkdownFrontMatterParser.Extract(markdown);
+
+        Assert.Equal("# Hello", body);
+        Assert.NotNull(metadata?.Trust);
+        Assert.Equal("Unreleased", metadata!.Trust!.Status);
+        Assert.Null(metadata.Trust.Migration);
+    }
+
+    [Fact]
     public void Extract_ShouldReturnOriginalMarkdown_WhenFrontMatterIsInvalid()
     {
         var markdown = """

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/MarkdownFrontMatterParserTests.cs
@@ -103,6 +103,41 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void Extract_ShouldParseTrustMetadata_AndPreserveExplicitEmptySourceLists()
+    {
+        var markdown = """
+            ---
+            trust:
+              status: Unreleased
+              summary: >
+                This page is provisional until the tag is cut.
+              freshness: Updated on main.
+              change_scope: Repository-wide.
+              migration:
+                label: Read the upgrade policy
+                href: /docs/releases/upgrade-policy.md.html
+              archive: Tagged release notes keep the durable record.
+              sources: []
+            ---
+            # Hello
+            """;
+
+        var (body, metadata) = MarkdownFrontMatterParser.Extract(markdown);
+
+        Assert.Equal("# Hello", body);
+        Assert.NotNull(metadata);
+        Assert.NotNull(metadata!.Trust);
+        Assert.Equal("Unreleased", metadata.Trust!.Status);
+        Assert.Equal("This page is provisional until the tag is cut.", metadata.Trust.Summary);
+        Assert.Equal("Updated on main.", metadata.Trust.Freshness);
+        Assert.Equal("Repository-wide.", metadata.Trust.ChangeScope);
+        Assert.Equal("Read the upgrade policy", metadata.Trust.Migration?.Label);
+        Assert.Equal("/docs/releases/upgrade-policy.md.html", metadata.Trust.Migration?.Href);
+        Assert.Equal("Tagged release notes keep the durable record.", metadata.Trust.Archive);
+        Assert.Empty(metadata.Trust.Sources!);
+    }
+
+    [Fact]
     public void Extract_ShouldReturnOriginalMarkdown_WhenFrontMatterIsInvalid()
     {
         var markdown = """
@@ -229,6 +264,18 @@ public sealed class MarkdownFrontMatterParserTests
         Assert.Equal("guides/intro.md", featuredPage.Path);
         Assert.Equal("Start with the intro guide.", featuredPage.SupportingCopy);
         Assert.Equal(10, featuredPage.Order);
+    }
+
+    [Fact]
+    public void ParseMetadataYaml_ShouldIgnoreEmptyTrustBlocks()
+    {
+        var metadata = MarkdownFrontMatterParser.ParseMetadataYaml(
+            """
+            trust: {}
+            """);
+
+        Assert.NotNull(metadata);
+        Assert.Null(metadata!.Trust);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -575,6 +575,31 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task DetailsView_ShouldUseMetadataBreadcrumbLabels_WhenRootDocHasNavGroupParent()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Changelog",
+            "CHANGELOG.md",
+            "<p>Release ledger</p>",
+            Metadata: new DocMetadata
+            {
+                NavGroup = "Releases",
+                Breadcrumbs = ["Releases", "Changelog"],
+                BreadcrumbsMatchPathTargets = true
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">Releases</span>", html);
+        Assert.Contains(">Changelog</span>", html);
+        Assert.DoesNotContain(">CHANGELOG.md</span>", html);
+    }
+
+    [Fact]
     public async Task DetailsView_ShouldRenderSingleSegmentBreadcrumbWithoutParentLinks()
     {
         using var services = CreateServiceProvider(CreateDocs());

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -682,6 +682,75 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task DetailsView_ShouldRenderTrustBar_WhenTrustMetadataIsPresent()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Unreleased",
+            "releases/unreleased.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Trust = new DocTrustMetadata
+                {
+                    Status = "Unreleased",
+                    Summary = "This page is provisional until the tag is cut.",
+                    Freshness = "Updated on main.",
+                    ChangeScope = "Repository-wide.",
+                    Archive = "Tagged release notes keep the durable record.",
+                    Sources = ["CHANGELOG.md", "releases/unreleased.md"],
+                    Migration = new DocTrustLink
+                    {
+                        Label = "Read the upgrade policy",
+                        Href = "/docs/releases/upgrade-policy.md.html"
+                    }
+                }
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        var trustBar = document.QuerySelector(".docs-trust-bar");
+        Assert.NotNull(trustBar);
+        Assert.Equal("Unreleased", trustBar!.QuerySelector(".docs-trust-bar-status-badge")?.TextContent.Trim());
+        Assert.Contains("Repository-wide.", trustBar.TextContent);
+        Assert.Contains("CHANGELOG.md", trustBar.TextContent);
+
+        var migrationLink = trustBar.QuerySelector("a.docs-trust-bar-link[href='/docs/releases/upgrade-policy.md.html']");
+        Assert.NotNull(migrationLink);
+        Assert.Equal("doc-content", migrationLink!.GetAttribute("data-turbo-frame"));
+        Assert.Equal("advance", migrationLink.GetAttribute("data-turbo-action"));
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldNotRenderTrustBar_WhenTrustMetadataHasNoDisplayableValues()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Unreleased",
+            "releases/unreleased.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Trust = new DocTrustMetadata
+                {
+                    Sources = Array.Empty<string>()
+                }
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        Assert.Null(document.QuerySelector(".docs-trust-bar"));
+    }
+
+    [Fact]
     public async Task SearchView_ShouldRenderSearchPageShell()
     {
         var docs = CreateDocs();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -575,6 +575,24 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task DetailsView_ShouldRenderSingleSegmentBreadcrumbWithoutParentLinks()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Quickstart",
+            "quickstart.md",
+            "<p>Guide body</p>");
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">quickstart.md</span>", html);
+        Assert.DoesNotContain("href=\"/docs/quickstart.md.html\"", html);
+    }
+
+    [Fact]
     public async Task DetailsView_ShouldNotRenderDerivedSummaryBlurb()
     {
         using var services = CreateServiceProvider(CreateDocs());
@@ -765,6 +783,79 @@ public class RazorDocsViewsTests
         Assert.NotNull(migrationLink);
         Assert.Equal("doc-content", migrationLink!.GetAttribute("data-turbo-frame"));
         Assert.Equal("advance", migrationLink.GetAttribute("data-turbo-action"));
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldRenderExternalMigrationAndFilteredSources()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Unreleased",
+            "releases/unreleased.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Trust = new DocTrustMetadata
+                {
+                    Summary = "This page is still settling.",
+                    Sources = ["  ", "CHANGELOG.md", "\t"],
+                    Migration = new DocTrustLink
+                    {
+                        Label = "   ",
+                        Href = "https://example.com/upgrade"
+                    }
+                }
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        var trustBar = document.QuerySelector(".docs-trust-bar");
+        Assert.NotNull(trustBar);
+        Assert.Contains("This page is still settling.", trustBar!.TextContent);
+        Assert.Null(trustBar.QuerySelector(".docs-trust-bar-status-badge"));
+
+        var migrationLink = trustBar.QuerySelector("a.docs-trust-bar-link[href='https://example.com/upgrade']");
+        Assert.NotNull(migrationLink);
+        Assert.Equal("Migration guidance", migrationLink!.TextContent.Trim());
+        Assert.Null(migrationLink.GetAttribute("data-turbo-frame"));
+        Assert.Null(migrationLink.GetAttribute("data-turbo-action"));
+
+        var trustSources = trustBar.QuerySelectorAll(".docs-trust-bar-list li")
+            .Select(item => item.TextContent.Trim())
+            .ToArray();
+        Assert.Equal(["CHANGELOG.md"], trustSources);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldRenderArchiveWithoutSourcesList_WhenSourcesAreMissing()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Unreleased",
+            "releases/unreleased.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Trust = new DocTrustMetadata
+                {
+                    Archive = "Tagged release notes keep the durable record."
+                }
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        var trustBar = document.QuerySelector(".docs-trust-bar");
+        Assert.NotNull(trustBar);
+        Assert.Contains("Tagged release notes keep the durable record.", trustBar!.TextContent);
+        Assert.Null(trustBar.QuerySelector(".docs-trust-bar-list"));
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -533,6 +533,48 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task DetailsView_ShouldCollapseNestedReadmePathBreadcrumbs()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Releases",
+            "releases/README.md",
+            "<p>Guide body</p>");
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">releases</span>", html);
+        Assert.DoesNotContain(">README.md</span>", html);
+    }
+
+    [Fact]
+    public async Task DetailsView_ShouldUseMetadataBreadcrumbLabels_ForNestedReadmeLandings()
+    {
+        using var services = CreateServiceProvider(CreateDocs());
+        var doc = new DocNode(
+            "Releases",
+            "releases/README.md",
+            "<p>Guide body</p>",
+            Metadata: new DocMetadata
+            {
+                Breadcrumbs = ["Releases"],
+                BreadcrumbsMatchPathTargets = true
+            });
+
+        var html = await RenderViewAsync(
+            services,
+            "/Views/Docs/Details.cshtml",
+            doc);
+
+        Assert.Contains(">Releases</span>", html);
+        Assert.DoesNotContain(">releases</span>", html);
+        Assert.DoesNotContain(">README.md</span>", html);
+    }
+
+    [Fact]
     public async Task DetailsView_ShouldNotRenderDerivedSummaryBlurb()
     {
         using var services = CreateServiceProvider(CreateDocs());

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -117,6 +117,10 @@ public sealed record DocMetadata
 
     internal bool? NavGroupIsDerived { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether authored breadcrumb labels align with the path-derived breadcrumb targets that
+    /// RazorDocs can safely reuse for rendering.
+    /// </summary>
     internal bool? BreadcrumbsMatchPathTargets { get; init; }
 
     internal static DocMetadata? Merge(DocMetadata? primary, DocMetadata? fallback)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -100,6 +100,15 @@ public sealed record DocMetadata
     /// </remarks>
     public IReadOnlyList<DocFeaturedPageDefinition>? FeaturedPages { get; init; }
 
+    /// <summary>
+    /// Gets optional trust and provenance metadata rendered near the top of the page.
+    /// </summary>
+    /// <remarks>
+    /// This nested object is designed for release notes, upgrade policies, changelogs, and similar pages that need to
+    /// communicate current status, adoption safety, and archival provenance without custom view logic.
+    /// </remarks>
+    public DocTrustMetadata? Trust { get; init; }
+
     internal bool? PageTypeIsDerived { get; init; }
 
     internal bool? AudienceIsDerived { get; init; }
@@ -187,7 +196,8 @@ public sealed record DocMetadata
             CanonicalSlug = PreferNonBlank(primary.CanonicalSlug, fallback.CanonicalSlug),
             Breadcrumbs = breadcrumbs,
             BreadcrumbsMatchPathTargets = breadcrumbsMatchPathTargets,
-            FeaturedPages = MergeLists(primary.FeaturedPages, fallback.FeaturedPages)
+            FeaturedPages = MergeLists(primary.FeaturedPages, fallback.FeaturedPages),
+            Trust = DocTrustMetadata.Merge(primary.Trust, fallback.Trust)
         };
     }
 
@@ -233,6 +243,126 @@ public sealed record DocMetadata
         return fallbackValue is not null
             ? (fallbackValue, fallbackFlag)
             : (null, null);
+    }
+}
+
+/// <summary>
+/// Structured trust and provenance metadata for a documentation page.
+/// </summary>
+public sealed record DocTrustMetadata
+{
+    /// <summary>
+    /// Gets the compact top-level state shown in the trust bar, such as <c>Unreleased</c> or <c>Pre-1.0 policy</c>.
+    /// </summary>
+    public string? Status { get; init; }
+
+    /// <summary>
+    /// Gets the short trust statement that explains what the current status means for readers.
+    /// </summary>
+    public string? Summary { get; init; }
+
+    /// <summary>
+    /// Gets the freshness statement that explains how current or provisional the page is.
+    /// </summary>
+    public string? Freshness { get; init; }
+
+    /// <summary>
+    /// Gets the statement describing which product surfaces or artifacts this page covers.
+    /// </summary>
+    public string? ChangeScope { get; init; }
+
+    /// <summary>
+    /// Gets an optional link to migration or upgrade guidance.
+    /// </summary>
+    public DocTrustLink? Migration { get; init; }
+
+    /// <summary>
+    /// Gets the archival or long-term home statement for the page contents.
+    /// </summary>
+    public string? Archive { get; init; }
+
+    /// <summary>
+    /// Gets optional provenance notes or upstream sources that support the page.
+    /// </summary>
+    public IReadOnlyList<string>? Sources { get; init; }
+
+    internal static DocTrustMetadata? Merge(DocTrustMetadata? primary, DocTrustMetadata? fallback)
+    {
+        if (primary is null)
+        {
+            return fallback;
+        }
+
+        if (fallback is null)
+        {
+            return primary;
+        }
+
+        static string? PreferNonBlank(string? preferred, string? fallbackValue)
+        {
+            if (!string.IsNullOrWhiteSpace(preferred))
+            {
+                return preferred.Trim();
+            }
+
+            return string.IsNullOrWhiteSpace(fallbackValue) ? null : fallbackValue.Trim();
+        }
+
+        return new DocTrustMetadata
+        {
+            Status = PreferNonBlank(primary.Status, fallback.Status),
+            Summary = PreferNonBlank(primary.Summary, fallback.Summary),
+            Freshness = PreferNonBlank(primary.Freshness, fallback.Freshness),
+            ChangeScope = PreferNonBlank(primary.ChangeScope, fallback.ChangeScope),
+            Migration = DocTrustLink.Merge(primary.Migration, fallback.Migration),
+            Archive = PreferNonBlank(primary.Archive, fallback.Archive),
+            Sources = DocMetadata.MergeLists(primary.Sources, fallback.Sources)
+        };
+    }
+}
+
+/// <summary>
+/// Link metadata used by trust-bar actions such as migration guidance.
+/// </summary>
+public sealed record DocTrustLink
+{
+    /// <summary>
+    /// Gets the reader-facing link label.
+    /// </summary>
+    public string? Label { get; init; }
+
+    /// <summary>
+    /// Gets the browser-facing destination URL.
+    /// </summary>
+    public string? Href { get; init; }
+
+    internal static DocTrustLink? Merge(DocTrustLink? primary, DocTrustLink? fallback)
+    {
+        if (primary is null)
+        {
+            return fallback;
+        }
+
+        if (fallback is null)
+        {
+            return primary;
+        }
+
+        static string? PreferNonBlank(string? preferred, string? fallbackValue)
+        {
+            if (!string.IsNullOrWhiteSpace(preferred))
+            {
+                return preferred.Trim();
+            }
+
+            return string.IsNullOrWhiteSpace(fallbackValue) ? null : fallbackValue.Trim();
+        }
+
+        return new DocTrustLink
+        {
+            Label = PreferNonBlank(primary.Label, fallback.Label),
+            Href = PreferNonBlank(primary.Href, fallback.Href)
+        };
     }
 }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -302,24 +302,14 @@ public sealed record DocTrustMetadata
             return primary;
         }
 
-        static string? PreferNonBlank(string? preferred, string? fallbackValue)
-        {
-            if (!string.IsNullOrWhiteSpace(preferred))
-            {
-                return preferred.Trim();
-            }
-
-            return string.IsNullOrWhiteSpace(fallbackValue) ? null : fallbackValue.Trim();
-        }
-
         return new DocTrustMetadata
         {
-            Status = PreferNonBlank(primary.Status, fallback.Status),
-            Summary = PreferNonBlank(primary.Summary, fallback.Summary),
-            Freshness = PreferNonBlank(primary.Freshness, fallback.Freshness),
-            ChangeScope = PreferNonBlank(primary.ChangeScope, fallback.ChangeScope),
+            Status = DocTrustMergeHelpers.PreferNonBlank(primary.Status, fallback.Status),
+            Summary = DocTrustMergeHelpers.PreferNonBlank(primary.Summary, fallback.Summary),
+            Freshness = DocTrustMergeHelpers.PreferNonBlank(primary.Freshness, fallback.Freshness),
+            ChangeScope = DocTrustMergeHelpers.PreferNonBlank(primary.ChangeScope, fallback.ChangeScope),
             Migration = DocTrustLink.Merge(primary.Migration, fallback.Migration),
-            Archive = PreferNonBlank(primary.Archive, fallback.Archive),
+            Archive = DocTrustMergeHelpers.PreferNonBlank(primary.Archive, fallback.Archive),
             Sources = DocMetadata.MergeLists(primary.Sources, fallback.Sources)
         };
     }
@@ -352,21 +342,24 @@ public sealed record DocTrustLink
             return primary;
         }
 
-        static string? PreferNonBlank(string? preferred, string? fallbackValue)
-        {
-            if (!string.IsNullOrWhiteSpace(preferred))
-            {
-                return preferred.Trim();
-            }
-
-            return string.IsNullOrWhiteSpace(fallbackValue) ? null : fallbackValue.Trim();
-        }
-
         return new DocTrustLink
         {
-            Label = PreferNonBlank(primary.Label, fallback.Label),
-            Href = PreferNonBlank(primary.Href, fallback.Href)
+            Label = DocTrustMergeHelpers.PreferNonBlank(primary.Label, fallback.Label),
+            Href = DocTrustMergeHelpers.PreferNonBlank(primary.Href, fallback.Href)
         };
+    }
+}
+
+file static class DocTrustMergeHelpers
+{
+    internal static string? PreferNonBlank(string? preferred, string? fallbackValue)
+    {
+        if (!string.IsNullOrWhiteSpace(preferred))
+        {
+            return preferred.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(fallbackValue) ? null : fallbackValue.Trim();
     }
 }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -166,19 +166,9 @@ public sealed record DocMetadata
             fallback.Breadcrumbs,
             fallback.BreadcrumbsMatchPathTargets);
 
-        static string? PreferNonBlank(string? preferred, string? fallbackValue)
-        {
-            if (!string.IsNullOrWhiteSpace(preferred))
-            {
-                return preferred.Trim();
-            }
-
-            return string.IsNullOrWhiteSpace(fallbackValue) ? null : fallbackValue.Trim();
-        }
-
         return new DocMetadata
         {
-            Title = PreferNonBlank(primary.Title, fallback.Title),
+            Title = DocTrustMergeHelpers.PreferNonBlank(primary.Title, fallback.Title),
             Summary = summary,
             SummaryIsDerived = summaryIsDerived,
             PageType = pageType,
@@ -190,14 +180,14 @@ public sealed record DocMetadata
             Aliases = MergeLists(primary.Aliases, fallback.Aliases),
             RedirectAliases = MergeLists(primary.RedirectAliases, fallback.RedirectAliases),
             Keywords = MergeLists(primary.Keywords, fallback.Keywords),
-            Status = PreferNonBlank(primary.Status, fallback.Status),
+            Status = DocTrustMergeHelpers.PreferNonBlank(primary.Status, fallback.Status),
             NavGroup = navGroup,
             NavGroupIsDerived = navGroupIsDerived,
             Order = primary.Order ?? fallback.Order,
             HideFromPublicNav = primary.HideFromPublicNav ?? fallback.HideFromPublicNav,
             HideFromSearch = primary.HideFromSearch ?? fallback.HideFromSearch,
             RelatedPages = MergeLists(primary.RelatedPages, fallback.RelatedPages),
-            CanonicalSlug = PreferNonBlank(primary.CanonicalSlug, fallback.CanonicalSlug),
+            CanonicalSlug = DocTrustMergeHelpers.PreferNonBlank(primary.CanonicalSlug, fallback.CanonicalSlug),
             Breadcrumbs = breadcrumbs,
             BreadcrumbsMatchPathTargets = breadcrumbsMatchPathTargets,
             FeaturedPages = MergeLists(primary.FeaturedPages, fallback.FeaturedPages),

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -12,6 +12,7 @@ Documentation site generation and hosting for Runnable web applications.
 - `AddRazorDocs()` for typed options binding and core service registration
 - `DocAggregator` plus the built-in Markdown and C# harvesters
 - Search UI assets and the `/docs` MVC surface used by RazorDocs consumers
+- Structured trust metadata plus a built-in trust bar for release notes, upgrade guides, and other pages that need status and provenance near the top
 - Precompiled Tailwind-powered styling with layout-time path resolution for root-module and embedded hosts
 
 ## Styling Boundary
@@ -145,6 +146,47 @@ The `/docs/search-index.json` payload continues to emit the raw `pageType` metad
 - `pageTypeVariant` for the built-in badge variant suffix used by CSS classes such as `docs-page-badge--guide`
 
 These fields let custom search clients stay visually aligned with the landing and detail experiences without re-implementing the mapping table.
+
+## Trust Metadata For Release Notes And Policy Pages
+
+RazorDocs can also render a top-of-page trust bar from nested `trust` metadata. Runnable uses this for its own release notes, upgrade policy, and changelog pages so the product doubles as a working example for consumers.
+
+```yaml
+trust:
+  status: Unreleased
+  summary: This page is provisional until the next tag is cut.
+  freshness: Updated as changes land on main.
+  change_scope: Repository-wide.
+  migration:
+    label: Read the upgrade policy
+    href: /docs/releases/upgrade-policy.md.html
+  archive: Tagged release notes will keep the final narrative once the version ships.
+  sources:
+    - CHANGELOG.md
+    - releases/unreleased.md
+```
+
+### Field behavior
+
+- `status` is the compact top-level state, such as `Unreleased` or `Pre-1.0 policy`.
+- `summary` is the short trust statement shown beside the status.
+- `freshness` explains how current the page is and how stable readers should assume it is.
+- `change_scope` calls out which surfaces the note covers.
+- `migration` is an optional label plus browser-facing `href` to the adoption guidance.
+- `archive` explains where the durable tagged record or long-term home lives.
+- `sources` is an optional list of provenance notes or upstream artifacts.
+
+### Merge behavior
+
+- Inline front matter and sidecar YAML both use the same nested `trust` schema.
+- Inline metadata wins over sidecar metadata field by field.
+- Explicit empty lists such as `sources: []` are authoritative and suppress fallback lists.
+
+### Pitfalls
+
+- Use a browser-facing `href` for `migration`, not a source path, because the trust bar renders a plain link without path rewriting.
+- Keep private maintainer-only runbooks outside harvested docs. Hidden pages are removed from nav and search, but they are still public if linked directly.
+- Do not turn the trust bar into marketing chrome. It should answer status, safety, and provenance questions quickly.
 
 ## Related Projects
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -271,14 +271,21 @@ public class DocAggregator
 
                        var sanitizedNodes = allNodes
                            .Select(
-                               n => new DocNode(
-                                   n.Title,
-                                   n.Path,
-                                   sanitizer.Sanitize(n.Content),
-                                   n.ParentPath,
-                                   n.IsDirectory,
-                                   BuildCanonicalPath(n.Path),
-                                   n.Metadata))
+                               n =>
+                               {
+                                   var sanitizedContent = string.IsNullOrEmpty(n.Content)
+                                       ? string.Empty
+                                       : sanitizer.Sanitize(n.Content) ?? string.Empty;
+
+                                   return new DocNode(
+                                       n.Title,
+                                       n.Path,
+                                       DocContentLinkRewriter.RewriteInternalDocLinks(n.Path, sanitizedContent),
+                                       n.ParentPath,
+                                       n.IsDirectory,
+                                       DocRoutePath.BuildCanonicalPath(n.Path),
+                                       n.Metadata);
+                               })
                            .ToList();
 
                        MergeNamespaceReadmes(sanitizedNodes);
@@ -752,31 +759,4 @@ public class DocAggregator
         return canonical[(hashIndex + 1)..];
     }
 
-    /// <summary>
-    /// Constructs a canonical browser-facing path (e.g., with .html extension) for a given documentation source path.
-    /// </summary>
-    /// <param name="sourcePath">The relative path to the documentation source.</param>
-    /// <returns>The canonical browser-facing path.</returns>
-    private static string BuildCanonicalPath(string sourcePath)
-    {
-        var hashIndex = sourcePath.IndexOf('#');
-        var fragment = hashIndex >= 0 ? sourcePath[hashIndex..] : string.Empty;
-        var trimmed = NormalizeLookupPath(sourcePath);
-        if (string.IsNullOrEmpty(trimmed))
-        {
-            return "index.html" + fragment;
-        }
-
-        var directory = Path.GetDirectoryName(trimmed);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            directory = directory.Replace('\\', '/');
-        }
-
-        var fileName = Path.GetFileName(trimmed);
-        var safeFileName = fileName.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
-            ? fileName
-            : fileName + ".html";
-        return (string.IsNullOrEmpty(directory) ? safeFileName : $"{directory}/{safeFileName}") + fragment;
-    }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
@@ -1,5 +1,5 @@
-using System.Net;
-using System.Text.RegularExpressions;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
 
 namespace ForgeTrust.Runnable.Web.RazorDocs.Services;
 
@@ -11,15 +11,6 @@ internal static class DocContentLinkRewriter
 {
     private const string DocsRootPath = "/docs";
     private const string DocsFrameId = "doc-content";
-    private static readonly Regex AnchorTagRegex = new(
-        "<a\\b[^>]*>",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
-    private static readonly Regex HrefAttributeRegex = new(
-        "\\bhref\\s*=\\s*(?:([\"'])(?<value>.*?)\\1|(?<value>[^\\s>]+))",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
-    private static readonly Regex TargetAttributeRegex = new(
-        "\\btarget\\s*=\\s*(?:([\"'])(?<value>.*?)\\1|(?<value>[^\\s>]+))",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
 
     /// <summary>
     /// Rewrites internal documentation anchors in rendered HTML so they point at canonical RazorDocs routes and carry
@@ -38,69 +29,44 @@ internal static class DocContentLinkRewriter
             return html;
         }
 
-        return AnchorTagRegex.Replace(
-            html,
-            match => RewriteAnchorTag(sourcePath, match.Value));
+        var parser = new HtmlParser();
+        var document = parser.ParseDocument(html);
+        foreach (var anchor in document.QuerySelectorAll("a[href]"))
+        {
+            RewriteAnchorElement(sourcePath, anchor);
+        }
+
+        return document.Body?.InnerHtml ?? html;
     }
 
-    private static string RewriteAnchorTag(string sourcePath, string anchorTag)
+    private static void RewriteAnchorElement(string sourcePath, IElement anchor)
     {
-        if (HasNonSelfTarget(anchorTag))
+        if (HasNonSelfTarget(anchor))
         {
-            return anchorTag;
+            return;
         }
 
-        var href = GetAttributeValue(anchorTag, HrefAttributeRegex);
+        var href = anchor.GetAttribute("href");
         if (!TryBuildDocsHref(sourcePath, href, out var docsHref))
         {
-            return anchorTag;
+            return;
         }
 
-        var rewrittenTag = ReplaceOrAppendAttribute(anchorTag, "href", docsHref);
-        rewrittenTag = ReplaceOrAppendAttribute(rewrittenTag, "data-turbo-frame", DocsFrameId);
-        rewrittenTag = ReplaceOrAppendAttribute(rewrittenTag, "data-turbo-action", "advance");
+        anchor.SetAttribute("href", docsHref);
+        anchor.SetAttribute("data-turbo-frame", DocsFrameId);
+        anchor.SetAttribute("data-turbo-action", "advance");
 
         if (docsHref.Contains('#'))
         {
-            rewrittenTag = ReplaceOrAppendAttribute(rewrittenTag, "data-doc-anchor-link", "true");
+            anchor.SetAttribute("data-doc-anchor-link", "true");
         }
-
-        return rewrittenTag;
     }
 
-    private static bool HasNonSelfTarget(string anchorTag)
+    private static bool HasNonSelfTarget(IElement anchor)
     {
-        var target = GetAttributeValue(anchorTag, TargetAttributeRegex);
+        var target = anchor.GetAttribute("target")?.Trim();
         return !string.IsNullOrWhiteSpace(target)
                && !string.Equals(target, "_self", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string? GetAttributeValue(string tag, Regex attributeRegex)
-    {
-        var match = attributeRegex.Match(tag);
-        if (!match.Success)
-        {
-            return null;
-        }
-
-        return WebUtility.HtmlDecode(match.Groups["value"].Value).Trim();
-    }
-
-    private static string ReplaceOrAppendAttribute(string tag, string attributeName, string value)
-    {
-        var encodedValue = WebUtility.HtmlEncode(value);
-        var attributePattern = new Regex(
-            $"(?<![A-Za-z0-9_:-]){Regex.Escape(attributeName)}\\s*=\\s*(?:([\"']).*?\\1|[^\\s>]+)",
-            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline);
-        var replacement = $"{attributeName}=\"{encodedValue}\"";
-
-        if (attributePattern.IsMatch(tag))
-        {
-            return attributePattern.Replace(tag, replacement, 1);
-        }
-
-        var insertIndex = tag.EndsWith("/>", StringComparison.Ordinal) ? tag.Length - 2 : tag.Length - 1;
-        return tag.Insert(insertIndex, $" {replacement}");
     }
 
     private static bool TryBuildDocsHref(string sourcePath, string? href, out string docsHref)
@@ -114,10 +80,21 @@ internal static class DocContentLinkRewriter
         var trimmedHref = href.Trim();
         var (path, query, fragment) = SplitHref(trimmedHref);
 
-        if (string.Equals(path, DocsRootPath, StringComparison.OrdinalIgnoreCase)
-            || path.StartsWith(DocsRootPath + "/", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(path, DocsRootPath, StringComparison.OrdinalIgnoreCase))
         {
-            docsHref = path + query + fragment;
+            docsHref = DocsRootPath + query + fragment;
+            return true;
+        }
+
+        if (path.StartsWith(DocsRootPath + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            var docsRelativePath = path[(DocsRootPath.Length + 1)..];
+            if (!LooksLikeDocTarget(docsRelativePath))
+            {
+                return false;
+            }
+
+            docsHref = BuildDocsHref(docsRelativePath, query, fragment);
             return true;
         }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
@@ -127,8 +127,7 @@ internal static class DocContentLinkRewriter
             return true;
         }
 
-        if (Uri.TryCreate(trimmedHref, UriKind.Absolute, out _)
-            || trimmedHref.StartsWith("//", StringComparison.Ordinal))
+        if (trimmedHref.StartsWith("//", StringComparison.Ordinal))
         {
             return false;
         }
@@ -141,13 +140,18 @@ internal static class DocContentLinkRewriter
         if (path.StartsWith("/", StringComparison.Ordinal))
         {
             var rootedTarget = path.TrimStart('/');
-            if (!LooksLikeDocTarget(rootedTarget))
+            if (!LooksLikeRootedDocTarget(rootedTarget))
             {
                 return false;
             }
 
             docsHref = BuildDocsHref(rootedTarget, query, fragment);
             return true;
+        }
+
+        if (Uri.TryCreate(trimmedHref, UriKind.Absolute, out _))
+        {
+            return false;
         }
 
         var resolvedTarget = ResolveRelativePath(sourcePath, path);
@@ -167,6 +171,12 @@ internal static class DocContentLinkRewriter
 
     private static bool LooksLikeDocTarget(string path)
     {
+        return LooksLikeRootedDocTarget(path)
+               || path.EndsWith(".html", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksLikeRootedDocTarget(string path)
+    {
         if (string.IsNullOrWhiteSpace(path))
         {
             return false;
@@ -174,7 +184,6 @@ internal static class DocContentLinkRewriter
 
         return path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
                || path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
-               || path.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
                || path.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
                || path.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
     }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Services;
+
+/// <summary>
+/// Rewrites harvested documentation links so authored Markdown can use repository-relative source links while the
+/// rendered docs experience still navigates through canonical RazorDocs routes.
+/// </summary>
+internal static class DocContentLinkRewriter
+{
+    private const string DocsRootPath = "/docs";
+    private const string DocsFrameId = "doc-content";
+    private static readonly Regex AnchorTagRegex = new(
+        "<a\\b[^>]*>",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex HrefAttributeRegex = new(
+        "\\bhref\\s*=\\s*(?:([\"'])(?<value>.*?)\\1|(?<value>[^\\s>]+))",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
+    private static readonly Regex TargetAttributeRegex = new(
+        "\\btarget\\s*=\\s*(?:([\"'])(?<value>.*?)\\1|(?<value>[^\\s>]+))",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline);
+
+    /// <summary>
+    /// Rewrites internal documentation anchors in rendered HTML so they point at canonical RazorDocs routes and carry
+    /// Turbo navigation attributes that keep browser history aligned with frame navigation.
+    /// </summary>
+    /// <param name="sourcePath">The harvested source path whose content is being rewritten.</param>
+    /// <param name="html">The rendered and sanitized HTML fragment to rewrite.</param>
+    /// <returns>The rewritten HTML fragment.</returns>
+    internal static string RewriteInternalDocLinks(string sourcePath, string html)
+    {
+        ArgumentNullException.ThrowIfNull(sourcePath);
+        ArgumentNullException.ThrowIfNull(html);
+
+        if (html.IndexOf("<a", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return html;
+        }
+
+        return AnchorTagRegex.Replace(
+            html,
+            match => RewriteAnchorTag(sourcePath, match.Value));
+    }
+
+    private static string RewriteAnchorTag(string sourcePath, string anchorTag)
+    {
+        if (HasNonSelfTarget(anchorTag))
+        {
+            return anchorTag;
+        }
+
+        var href = GetAttributeValue(anchorTag, HrefAttributeRegex);
+        if (!TryBuildDocsHref(sourcePath, href, out var docsHref))
+        {
+            return anchorTag;
+        }
+
+        var rewrittenTag = ReplaceOrAppendAttribute(anchorTag, "href", docsHref);
+        rewrittenTag = ReplaceOrAppendAttribute(rewrittenTag, "data-turbo-frame", DocsFrameId);
+        rewrittenTag = ReplaceOrAppendAttribute(rewrittenTag, "data-turbo-action", "advance");
+
+        if (docsHref.Contains('#'))
+        {
+            rewrittenTag = ReplaceOrAppendAttribute(rewrittenTag, "data-doc-anchor-link", "true");
+        }
+
+        return rewrittenTag;
+    }
+
+    private static bool HasNonSelfTarget(string anchorTag)
+    {
+        var target = GetAttributeValue(anchorTag, TargetAttributeRegex);
+        return !string.IsNullOrWhiteSpace(target)
+               && !string.Equals(target, "_self", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? GetAttributeValue(string tag, Regex attributeRegex)
+    {
+        var match = attributeRegex.Match(tag);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        return WebUtility.HtmlDecode(match.Groups["value"].Value).Trim();
+    }
+
+    private static string ReplaceOrAppendAttribute(string tag, string attributeName, string value)
+    {
+        var encodedValue = WebUtility.HtmlEncode(value);
+        var attributePattern = new Regex(
+            $"(?<![A-Za-z0-9_:-]){Regex.Escape(attributeName)}\\s*=\\s*(?:([\"']).*?\\1|[^\\s>]+)",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+        var replacement = $"{attributeName}=\"{encodedValue}\"";
+
+        if (attributePattern.IsMatch(tag))
+        {
+            return attributePattern.Replace(tag, replacement, 1);
+        }
+
+        var insertIndex = tag.EndsWith("/>", StringComparison.Ordinal) ? tag.Length - 2 : tag.Length - 1;
+        return tag.Insert(insertIndex, $" {replacement}");
+    }
+
+    private static bool TryBuildDocsHref(string sourcePath, string? href, out string docsHref)
+    {
+        docsHref = string.Empty;
+        if (string.IsNullOrWhiteSpace(href))
+        {
+            return false;
+        }
+
+        var trimmedHref = href.Trim();
+        var (path, query, fragment) = SplitHref(trimmedHref);
+
+        if (string.Equals(path, DocsRootPath, StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith(DocsRootPath + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            docsHref = path + query + fragment;
+            return true;
+        }
+
+        if (trimmedHref.StartsWith('#'))
+        {
+            docsHref = $"{DocsRootPath}/{DocRoutePath.BuildCanonicalPath(GetSourceDocumentPath(sourcePath))}{fragment}";
+            return true;
+        }
+
+        if (Uri.TryCreate(trimmedHref, UriKind.Absolute, out _)
+            || trimmedHref.StartsWith("//", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        if (path.StartsWith("/", StringComparison.Ordinal))
+        {
+            var rootedTarget = path.TrimStart('/');
+            if (!LooksLikeDocTarget(rootedTarget))
+            {
+                return false;
+            }
+
+            docsHref = BuildDocsHref(rootedTarget, query, fragment);
+            return true;
+        }
+
+        var resolvedTarget = ResolveRelativePath(sourcePath, path);
+        if (!LooksLikeDocTarget(resolvedTarget))
+        {
+            return false;
+        }
+
+        docsHref = BuildDocsHref(resolvedTarget, query, fragment);
+        return true;
+    }
+
+    private static string BuildDocsHref(string docPath, string query, string fragment)
+    {
+        return $"{DocsRootPath}/{DocRoutePath.BuildCanonicalPath(docPath)}{query}{fragment}";
+    }
+
+    private static bool LooksLikeDocTarget(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        return path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+               || path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+               || path.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
+               || path.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
+               || path.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolveRelativePath(string sourcePath, string relativePath)
+    {
+        var normalizedSourcePath = GetSourceDocumentPath(sourcePath).Replace('\\', '/').Trim('/');
+        var sourceDirectory = Path.GetDirectoryName(normalizedSourcePath)?.Replace('\\', '/');
+        var basePath = string.IsNullOrWhiteSpace(sourceDirectory)
+            ? "/"
+            : "/" + sourceDirectory.Trim('/') + "/";
+        var baseUri = new Uri(new Uri("http://docs.local"), basePath);
+        var resolvedUri = new Uri(baseUri, relativePath);
+        return resolvedUri.AbsolutePath.TrimStart('/');
+    }
+
+    private static string GetSourceDocumentPath(string sourcePath)
+    {
+        var hashIndex = sourcePath.IndexOf('#');
+        return hashIndex >= 0 ? sourcePath[..hashIndex] : sourcePath;
+    }
+
+    private static (string Path, string Query, string Fragment) SplitHref(string href)
+    {
+        var fragmentIndex = href.IndexOf('#');
+        var fragment = fragmentIndex >= 0 ? href[fragmentIndex..] : string.Empty;
+        var withoutFragment = fragmentIndex >= 0 ? href[..fragmentIndex] : href;
+        var queryIndex = withoutFragment.IndexOf('?');
+        var query = queryIndex >= 0 ? withoutFragment[queryIndex..] : string.Empty;
+        var path = queryIndex >= 0 ? withoutFragment[..queryIndex] : withoutFragment;
+        return (path, query, fragment);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
@@ -171,11 +171,16 @@ internal static class DocContentLinkRewriter
 
     private static bool LooksLikeDocTarget(string path)
     {
-        return LooksLikeRootedDocTarget(path)
-               || path.EndsWith(".html", StringComparison.OrdinalIgnoreCase);
+        return LooksLikeSourceDocTarget(path)
+               || LooksLikeCanonicalDocTarget(path);
     }
 
     private static bool LooksLikeRootedDocTarget(string path)
+    {
+        return LooksLikeDocTarget(path);
+    }
+
+    private static bool LooksLikeSourceDocTarget(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -186,6 +191,20 @@ internal static class DocContentLinkRewriter
                || path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
                || path.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
                || path.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksLikeCanonicalDocTarget(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        return path.EndsWith(".md.html", StringComparison.OrdinalIgnoreCase)
+               || path.EndsWith(".cs.html", StringComparison.OrdinalIgnoreCase)
+               || path.Equals("Namespaces.html", StringComparison.OrdinalIgnoreCase)
+               || (path.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase)
+                   && path.EndsWith(".html", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string ResolveRelativePath(string sourcePath, string relativePath)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocMetadataFactory.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocMetadataFactory.cs
@@ -36,15 +36,23 @@ internal static class DocMetadataFactory
         bool? summaryIsDerived = string.IsNullOrWhiteSpace(merged.Summary)
             ? null
             : string.IsNullOrWhiteSpace(explicitMetadata?.Summary);
+        var authoredBreadcrumbCount = explicitMetadata?.Breadcrumbs?
+            .Count(label => !string.IsNullOrWhiteSpace(label))
+            ?? 0;
         var breadcrumbs = merged.Breadcrumbs is { Count: > 0 }
             ? merged.Breadcrumbs
             : BuildDefaultBreadcrumbs(normalizedNavGroup, resolvedTitle);
+        bool? breadcrumbsMatchPathTargets = authoredBreadcrumbCount > 0
+                                            && authoredBreadcrumbCount == GetMarkdownBreadcrumbTargetCount(path)
+            ? true
+            : null;
 
         return merged with
         {
             NavGroup = normalizedNavGroup,
             SummaryIsDerived = summaryIsDerived,
-            Breadcrumbs = breadcrumbs
+            Breadcrumbs = breadcrumbs,
+            BreadcrumbsMatchPathTargets = breadcrumbsMatchPathTargets
         };
     }
 
@@ -224,6 +232,21 @@ internal static class DocMetadataFactory
         return string.Equals(navGroup, resolvedTitle, StringComparison.OrdinalIgnoreCase)
             ? [navGroup]
             : [navGroup, resolvedTitle];
+    }
+
+    private static int GetMarkdownBreadcrumbTargetCount(string path)
+    {
+        var segments = NormalizePath(path)
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        if (segments.Count > 1
+            && segments[^1].Equals("README.md", StringComparison.OrdinalIgnoreCase))
+        {
+            segments.RemoveAt(segments.Count - 1);
+        }
+
+        return segments.Count;
     }
 
     private static IReadOnlyList<string> BuildApiReferenceBreadcrumbs(string title, string namespaceName)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocMetadataFactory.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocMetadataFactory.cs
@@ -42,8 +42,20 @@ internal static class DocMetadataFactory
         var breadcrumbs = merged.Breadcrumbs is { Count: > 0 }
             ? merged.Breadcrumbs
             : BuildDefaultBreadcrumbs(normalizedNavGroup, resolvedTitle);
+        var firstAuthoredBreadcrumb = explicitMetadata?.Breadcrumbs?
+            .FirstOrDefault(label => !string.IsNullOrWhiteSpace(label))?
+            .Trim();
+        var breadcrumbTargetCount = GetMarkdownBreadcrumbTargetCount(path);
+        var authoredBreadcrumbsMatchPathTargets = authoredBreadcrumbCount == breadcrumbTargetCount;
+        var authoredBreadcrumbsIncludeNavGroupParent = !string.IsNullOrWhiteSpace(normalizedNavGroup)
+                                                       && authoredBreadcrumbCount == breadcrumbTargetCount + 1
+                                                       && string.Equals(
+                                                           firstAuthoredBreadcrumb,
+                                                           normalizedNavGroup,
+                                                           StringComparison.OrdinalIgnoreCase);
         bool? breadcrumbsMatchPathTargets = authoredBreadcrumbCount > 0
-                                            && authoredBreadcrumbCount == GetMarkdownBreadcrumbTargetCount(path)
+                                            && (authoredBreadcrumbsMatchPathTargets
+                                                || authoredBreadcrumbsIncludeNavGroupParent)
             ? true
             : null;
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocRoutePath.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocRoutePath.cs
@@ -1,0 +1,52 @@
+namespace ForgeTrust.Runnable.Web.RazorDocs.Services;
+
+/// <summary>
+/// Normalizes harvested documentation source paths into the canonical browser-facing routes used by RazorDocs.
+/// </summary>
+internal static class DocRoutePath
+{
+    /// <summary>
+    /// Constructs a canonical browser-facing path for a harvested documentation source path.
+    /// </summary>
+    /// <param name="sourcePath">The harvested source path, optionally including a fragment.</param>
+    /// <returns>
+    /// The canonical docs route path, including the <c>.html</c> suffix RazorDocs serves to browsers and any original
+    /// fragment identifier.
+    /// </returns>
+    internal static string BuildCanonicalPath(string sourcePath)
+    {
+        ArgumentNullException.ThrowIfNull(sourcePath);
+
+        var hashIndex = sourcePath.IndexOf('#');
+        var fragment = hashIndex >= 0 ? sourcePath[hashIndex..] : string.Empty;
+        var trimmed = NormalizeLookupPath(sourcePath);
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return "index.html" + fragment;
+        }
+
+        var directory = Path.GetDirectoryName(trimmed);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            directory = directory.Replace('\\', '/');
+        }
+
+        var fileName = Path.GetFileName(trimmed);
+        var safeFileName = fileName.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
+            ? fileName
+            : fileName + ".html";
+        return (string.IsNullOrEmpty(directory) ? safeFileName : $"{directory}/{safeFileName}") + fragment;
+    }
+
+    private static string NormalizeLookupPath(string path)
+    {
+        var sanitized = path.Trim().Replace('\\', '/').Trim('/');
+        var hashIndex = sanitized.IndexOf('#');
+        if (hashIndex >= 0)
+        {
+            sanitized = sanitized[..hashIndex];
+        }
+
+        return sanitized;
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/MarkdownFrontMatterParser.cs
@@ -43,7 +43,8 @@ internal static class MarkdownFrontMatterParser
     /// <returns>The normalized metadata model, or <c>null</c> when the YAML document is explicitly empty or null.</returns>
     /// <remarks>
     /// This entry point is shared by inline Markdown front matter and paired sidecar metadata files so both authoring styles
-    /// normalize through the same schema, defaults, and empty-list handling.
+    /// normalize through the same schema, defaults, and empty-list handling. Nested metadata such as <c>featured_pages</c>
+    /// and <c>trust</c> is normalized here as well.
     /// </remarks>
     /// <exception cref="YamlException">Thrown when <paramref name="yaml"/> cannot be parsed as YAML.</exception>
     internal static DocMetadata? ParseMetadataYaml(string yaml)
@@ -75,6 +76,7 @@ internal static class MarkdownFrontMatterParser
             CanonicalSlug = Normalize(document.CanonicalSlug) ?? Normalize(document.Slug),
             Breadcrumbs = NormalizeList(document.Breadcrumbs),
             FeaturedPages = NormalizeFeaturedPages(document.FeaturedPages),
+            Trust = NormalizeTrust(document.Trust),
             PageTypeIsDerived = document.PageType is not null ? false : null,
             AudienceIsDerived = document.Audience is not null ? false : null,
             ComponentIsDerived = document.Component is not null ? false : null,
@@ -156,6 +158,53 @@ internal static class MarkdownFrontMatterParser
             .ToArray();
     }
 
+    private static DocTrustMetadata? NormalizeTrust(FrontMatterTrustDocument? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var trust = new DocTrustMetadata
+        {
+            Status = Normalize(value.Status),
+            Summary = Normalize(value.Summary),
+            Freshness = Normalize(value.Freshness),
+            ChangeScope = Normalize(value.ChangeScope),
+            Migration = NormalizeTrustLink(value.Migration),
+            Archive = Normalize(value.Archive),
+            Sources = NormalizeList(value.Sources)
+        };
+
+        return trust.Status is null
+               && trust.Summary is null
+               && trust.Freshness is null
+               && trust.ChangeScope is null
+               && trust.Migration is null
+               && trust.Archive is null
+               && trust.Sources is null
+            ? null
+            : trust;
+    }
+
+    private static DocTrustLink? NormalizeTrustLink(FrontMatterTrustLinkDocument? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var link = new DocTrustLink
+        {
+            Label = Normalize(value.Label),
+            Href = Normalize(value.Href)
+        };
+
+        return link.Label is null && link.Href is null
+            ? null
+            : link;
+    }
+
     private sealed class FrontMatterDocument
     {
         public string? Title { get; init; }
@@ -193,6 +242,8 @@ internal static class MarkdownFrontMatterParser
         public List<string>? Breadcrumbs { get; init; }
 
         public List<FrontMatterFeaturedPageDefinition?>? FeaturedPages { get; init; }
+
+        public FrontMatterTrustDocument? Trust { get; init; }
     }
 
     private sealed class FrontMatterFeaturedPageDefinition
@@ -204,5 +255,29 @@ internal static class MarkdownFrontMatterParser
         public string? SupportingCopy { get; init; }
 
         public int? Order { get; init; }
+    }
+
+    private sealed class FrontMatterTrustDocument
+    {
+        public string? Status { get; init; }
+
+        public string? Summary { get; init; }
+
+        public string? Freshness { get; init; }
+
+        public string? ChangeScope { get; init; }
+
+        public FrontMatterTrustLinkDocument? Migration { get; init; }
+
+        public string? Archive { get; init; }
+
+        public List<string>? Sources { get; init; }
+    }
+
+    private sealed class FrontMatterTrustLinkDocument
+    {
+        public string? Label { get; init; }
+
+        public string? Href { get; init; }
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
@@ -68,13 +68,21 @@
     }
     else
     {
-        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var segments = normalizedPath
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+        if (segments.Count > 1
+            && string.Equals(segments[^1], "README.md", StringComparison.OrdinalIgnoreCase))
+        {
+            segments.RemoveAt(segments.Count - 1);
+        }
+
         var current = string.Empty;
-        for (var i = 0; i < segments.Length; i++)
+        for (var i = 0; i < segments.Count; i++)
         {
             var segment = segments[i];
             current = string.IsNullOrEmpty(current) ? segment : $"{current}/{segment}";
-            var isLast = i == segments.Length - 1;
+            var isLast = i == segments.Count - 1;
             var href = isLast ? null : $"/docs/{current}.html";
             parsedBreadcrumbs.Add((segment, href));
         }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
@@ -93,15 +93,25 @@
     var hasMetadataBreadcrumbs = metadataBreadcrumbCount > 0;
     var metadataBreadcrumbsMatchPathTargets = metadata?.BreadcrumbsMatchPathTargets == true;
     var metadataBreadcrumbCountMatchesPath = metadataBreadcrumbCount == parsedBreadcrumbs.Count;
+    var metadataBreadcrumbCountIncludesNavGroupParent = metadataBreadcrumbCount == parsedBreadcrumbs.Count + 1
+                                                       && !string.IsNullOrWhiteSpace(metadata?.NavGroup)
+                                                       && string.Equals(
+                                                           metadataBreadcrumbs?[0],
+                                                           metadata!.NavGroup!.Trim(),
+                                                           StringComparison.OrdinalIgnoreCase);
     var canUseMetadataBreadcrumbs = hasMetadataBreadcrumbs
                                     && metadataBreadcrumbsMatchPathTargets
-                                    && metadataBreadcrumbCountMatchesPath;
+                                    && (metadataBreadcrumbCountMatchesPath
+                                        || metadataBreadcrumbCountIncludesNavGroupParent);
 
     if (canUseMetadataBreadcrumbs)
     {
+        var parsedBreadcrumbOffset = metadataBreadcrumbCount - parsedBreadcrumbs.Count;
         for (var i = 0; i < metadataBreadcrumbs!.Count; i++)
         {
-            breadcrumbs.Add((metadataBreadcrumbs[i], parsedBreadcrumbs[i].Href));
+            var parsedBreadcrumbIndex = i - parsedBreadcrumbOffset;
+            var href = parsedBreadcrumbIndex >= 0 ? parsedBreadcrumbs[parsedBreadcrumbIndex].Href : null;
+            breadcrumbs.Add((metadataBreadcrumbs[i], href));
         }
     }
     else

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
@@ -17,6 +17,30 @@
     var audience = metadata?.AudienceIsDerived == true || string.IsNullOrWhiteSpace(metadata?.Audience)
         ? null
         : metadata!.Audience!.Trim();
+    var trust = metadata?.Trust;
+    var trustStatus = string.IsNullOrWhiteSpace(trust?.Status) ? null : trust!.Status!.Trim();
+    var trustSummary = string.IsNullOrWhiteSpace(trust?.Summary) ? null : trust!.Summary!.Trim();
+    var trustFreshness = string.IsNullOrWhiteSpace(trust?.Freshness) ? null : trust!.Freshness!.Trim();
+    var trustChangeScope = string.IsNullOrWhiteSpace(trust?.ChangeScope) ? null : trust!.ChangeScope!.Trim();
+    var trustArchive = string.IsNullOrWhiteSpace(trust?.Archive) ? null : trust!.Archive!.Trim();
+    var trustSources = trust?.Sources?
+        .Where(value => !string.IsNullOrWhiteSpace(value))
+        .Select(value => value.Trim())
+        .ToList()
+        ?? [];
+    var trustMigration = trust?.Migration;
+    var trustMigrationHref = string.IsNullOrWhiteSpace(trustMigration?.Href) ? null : trustMigration!.Href!.Trim();
+    var trustMigrationLabel = string.IsNullOrWhiteSpace(trustMigration?.Label)
+        ? "Migration guidance"
+        : trustMigration!.Label!.Trim();
+    var trustMigrationUsesTurbo = trustMigrationHref?.StartsWith("/docs/", StringComparison.OrdinalIgnoreCase) == true;
+    var showTrustBar = trustStatus is not null
+                       || trustSummary is not null
+                       || trustFreshness is not null
+                       || trustChangeScope is not null
+                       || trustArchive is not null
+                       || trustMigrationHref is not null
+                       || trustSources.Count > 0;
     var normalizedPath = Model.Path.Trim().Trim('/');
     var isNamespacePath = normalizedPath.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
                           || normalizedPath.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
@@ -127,6 +151,72 @@
         {
             <p class="mt-3 max-w-3xl text-base text-slate-400">@summary</p>
         }
+    }
+    @if (showTrustBar)
+    {
+        <section class="docs-trust-bar" aria-label="Page trust and provenance">
+            @if (trustStatus is not null || trustSummary is not null)
+            {
+                <article class="docs-trust-bar-section">
+                    <p class="docs-trust-bar-label">Status</p>
+                    @if (trustStatus is not null)
+                    {
+                        <p class="docs-trust-bar-status-row">
+                            <span class="docs-trust-bar-status-badge">@trustStatus</span>
+                        </p>
+                    }
+                    @if (trustSummary is not null)
+                    {
+                        <p class="docs-trust-bar-value">@trustSummary</p>
+                    }
+                </article>
+            }
+            @if (trustChangeScope is not null || trustFreshness is not null || trustMigrationHref is not null)
+            {
+                <article class="docs-trust-bar-section">
+                    <p class="docs-trust-bar-label">Safe To Consume</p>
+                    @if (trustChangeScope is not null)
+                    {
+                        <p class="docs-trust-bar-value"><span class="docs-trust-bar-key">Scope:</span> @trustChangeScope</p>
+                    }
+                    @if (trustFreshness is not null)
+                    {
+                        <p class="docs-trust-bar-value"><span class="docs-trust-bar-key">Freshness:</span> @trustFreshness</p>
+                    }
+                    @if (trustMigrationHref is not null)
+                    {
+                        <p class="docs-trust-bar-value">
+                            <span class="docs-trust-bar-key">Migration:</span>
+                            <a href="@trustMigrationHref"
+                               class="docs-trust-bar-link"
+                               @if (trustMigrationUsesTurbo)
+                               {
+                                   <text>data-turbo-frame="doc-content" data-turbo-action="advance"</text>
+                               }>@trustMigrationLabel</a>
+                        </p>
+                    }
+                </article>
+            }
+            @if (trustArchive is not null || trustSources.Count > 0)
+            {
+                <article class="docs-trust-bar-section">
+                    <p class="docs-trust-bar-label">Record</p>
+                    @if (trustArchive is not null)
+                    {
+                        <p class="docs-trust-bar-value">@trustArchive</p>
+                    }
+                    @if (trustSources.Count > 0)
+                    {
+                        <ul class="docs-trust-bar-list">
+                            @foreach (var source in trustSources)
+                            {
+                                <li>@source</li>
+                            }
+                        </ul>
+                    }
+                </article>
+            }
+        </section>
     }
 </header>
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/wwwroot/docs/search.css
@@ -111,6 +111,86 @@
     margin-bottom: 1rem;
 }
 
+.docs-trust-bar {
+    margin-top: 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+    gap: 0.9rem;
+    border: 1px solid rgba(34, 211, 238, 0.18);
+    border-radius: 1rem;
+    background:
+        linear-gradient(180deg, rgba(8, 47, 73, 0.22), rgba(2, 6, 23, 0.78)),
+        rgba(2, 6, 23, 0.9);
+    padding: 1rem;
+}
+
+.docs-trust-bar-section {
+    display: grid;
+    gap: 0.55rem;
+    align-content: start;
+    min-width: 0;
+}
+
+.docs-trust-bar-label {
+    margin: 0;
+    font-size: 0.72rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #67e8f9;
+    font-weight: 700;
+}
+
+.docs-trust-bar-status-row,
+.docs-trust-bar-value {
+    margin: 0;
+}
+
+.docs-trust-bar-status-badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    border: 1px solid rgba(34, 211, 238, 0.35);
+    background: rgba(34, 211, 238, 0.12);
+    color: #a5f3fc;
+    padding: 0.3rem 0.7rem;
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.docs-trust-bar-value {
+    color: #dbeafe;
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+.docs-trust-bar-key {
+    color: #e2e8f0;
+    font-weight: 700;
+}
+
+.docs-trust-bar-link {
+    color: #67e8f9;
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: rgba(103, 232, 249, 0.45);
+    text-underline-offset: 0.18em;
+}
+
+.docs-trust-bar-link:hover {
+    color: #cffafe;
+    text-decoration-color: rgba(207, 250, 254, 0.7);
+}
+
+.docs-trust-bar-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    color: #cbd5e1;
+    display: grid;
+    gap: 0.35rem;
+}
+
 .docs-search-option a {
     display: block;
     padding: 0.65rem 0.75rem;

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
@@ -35,6 +35,14 @@ public sealed class RazorDocsLandingPlaywrightTests
         Assert.DoesNotContain(
             "Welcome to the technical documentation.",
             await page.InnerTextAsync("body"));
+        Assert.Equal("/docs/releases/README.md.html", await page.GetAttributeAsync("main a.group", "href"));
+
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/releases/README.md.html",
+            "What is shipping next, and how risky is the upgrade?",
+            "Releases",
+            "GUIDE");
 
         await AssertFeaturedCardAsync(
             page,
@@ -60,7 +68,41 @@ public sealed class RazorDocsLandingPlaywrightTests
             "What about CLI and worker flows?",
             "Console",
             "GUIDE");
+    }
 
+    [Fact]
+    public async Task Landing_NavigatesToReleaseHub_AndUnreleasedProofArtifact()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(_fixture.DocsUrl);
+        await page.Locator("main a[href='/docs/releases/README.md.html']").ClickAsync();
+        await WaitForPathAsync(page, "/docs/releases/README.md.html");
+        await page.WaitForSelectorAsync(".docs-trust-bar", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+
+        Assert.Equal("Releases", (await page.TextContentAsync("h1"))?.Trim());
+        Assert.Contains("Release contract", await page.InnerTextAsync(".docs-trust-bar"), StringComparison.OrdinalIgnoreCase);
+
+        await page.Locator(".docs-content a[href='./unreleased.md']").First.ClickAsync();
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('h1')?.textContent?.trim() === 'Unreleased'",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+        await page.WaitForSelectorAsync(".docs-trust-bar", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+
+        Assert.Equal("Unreleased", (await page.TextContentAsync("h1"))?.Trim());
+        var trustText = await page.InnerTextAsync(".docs-trust-bar");
+        Assert.Contains("provisional", trustText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Repository-wide", trustText, StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task AssertFeaturedCardAsync(
@@ -82,5 +124,13 @@ public sealed class RazorDocsLandingPlaywrightTests
         Assert.Contains(title, cardText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(badge, cardText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Open page", cardText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task WaitForPathAsync(IPage page, string expectedPath)
+    {
+        await page.WaitForFunctionAsync(
+            "path => window.location.pathname === path",
+            expectedPath,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
@@ -88,7 +88,8 @@ public sealed class RazorDocsLandingPlaywrightTests
         Assert.Equal("Releases", (await page.TextContentAsync("h1"))?.Trim());
         Assert.Contains("Release contract", await page.InnerTextAsync(".docs-trust-bar"), StringComparison.OrdinalIgnoreCase);
 
-        await page.Locator(".docs-content a[href='./unreleased.md']").First.ClickAsync();
+        await page.Locator(".docs-content a[href='/docs/releases/unreleased.md.html']").First.ClickAsync();
+        await WaitForPathAsync(page, "/docs/releases/unreleased.md.html");
         await page.WaitForFunctionAsync(
             "() => document.querySelector('h1')?.textContent?.trim() === 'Unreleased'",
             null,

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,42 @@
+# Release notes and change management
+
+Runnable now treats release notes as a product surface instead of a post-ship afterthought. This folder is the public record that answers three questions quickly:
+
+1. What is changing next?
+2. How risky is it to adopt?
+3. Where will the final tagged story live once a version ships?
+
+It also acts as a concrete RazorDocs example for teams that want stronger release notes in their own products.
+
+## Start here
+
+- [Unreleased](./unreleased.md) is the living proof artifact for the next coordinated Runnable version.
+- [Changelog](../CHANGELOG.md) is the compact ledger that points to unreleased and tagged stories.
+- [Pre-1.0 upgrade policy](./upgrade-policy.md) explains the stability contract before `v1.0.0`.
+- [Release authoring checklist](./release-authoring-checklist.md) is the maintainer workflow for turning the unreleased page into a tagged release.
+
+## Release format
+
+### Story first
+
+Each release note should open with the narrative that matters to evaluators and adopters. Explain what changed, why it matters, and which parts of the product surface are affected before dropping into mechanical lists.
+
+### Safety second
+
+Every release note should make upgrade risk obvious near the top. Call out whether the note is unreleased or tagged, which surfaces are affected, how fresh the information is, and where migration guidance lives.
+
+### Archive third
+
+Once Runnable starts cutting tags, the long-form release note will live in this folder and the compact summary will live in [`CHANGELOG.md`](../CHANGELOG.md). Tagged notes become the durable archive for migration details and release narrative.
+
+## What belongs in the release surface
+
+- Package behavior changes
+- CLI behavior changes
+- Docs-facing behavior changes that affect adopters or evaluators
+- Example changes that alter the recommended path
+- Release policy changes
+
+## What does not belong in public release notes
+
+Private maintainer-only recovery steps, secret handling, and operational escape hatches should live outside harvested docs. In this repository, those notes belong under `.github/`.

--- a/releases/README.md.yml
+++ b/releases/README.md.yml
@@ -1,0 +1,20 @@
+title: Releases
+summary: Start with the public release hub, then drill into the unreleased proof artifact, the compact changelog, and the pre-1.0 upgrade policy.
+page_type: guide
+nav_group: Releases
+order: 10
+breadcrumbs:
+  - Releases
+trust:
+  status: Release contract
+  summary: This hub is the public agreement for how Runnable explains unreleased work, tagged releases, and upgrade risk before automation is in place.
+  freshness: Updated whenever the release policy, release-note structure, or public proof artifacts change on main.
+  change_scope: Repository-wide. Runnable plans to release the entire monorepo in unison.
+  migration:
+    label: Read the pre-1.0 upgrade policy
+    href: /docs/releases/upgrade-policy.md.html
+  archive: Tagged release notes will live beside this page under /docs/releases/ and remain linked from CHANGELOG.md.
+  sources:
+    - CHANGELOG.md
+    - releases/unreleased.md
+    - releases/release-authoring-checklist.md

--- a/releases/release-authoring-checklist.md
+++ b/releases/release-authoring-checklist.md
@@ -1,0 +1,23 @@
+# Release authoring checklist
+
+Use this checklist when turning the living unreleased story into a tagged Runnable release.
+
+## Before the release branch or tag
+
+- make sure the pull request queue has updated [`unreleased.md`](./unreleased.md)
+- regroup the story so the opening narrative explains what changed and why it matters
+- confirm every breaking or behavior-changing update has migration guidance
+- update [`CHANGELOG.md`](../CHANGELOG.md) so the compact ledger matches the narrative release note
+
+## When cutting the tagged release note
+
+- start from the [tagged release template](./templates/tagged-release-template.md)
+- replace provisional language with tagged facts: version, date, shipped scope, and finalized migration steps
+- keep the trust bar accurate for the release state and archive location
+- link the tagged note from [`CHANGELOG.md`](../CHANGELOG.md)
+
+## After the tag ships
+
+- trim [`unreleased.md`](./unreleased.md) back to the next in-flight version
+- keep only still-unreleased items in the proof artifact
+- verify the `/docs` release hub resolves to the new tagged note and current policy pages

--- a/releases/release-authoring-checklist.md.yml
+++ b/releases/release-authoring-checklist.md.yml
@@ -1,0 +1,8 @@
+title: Release authoring checklist
+summary: Maintainer workflow for turning the unreleased proof artifact into a tagged release note.
+page_type: how-to
+nav_group: Releases
+order: 40
+breadcrumbs:
+  - Releases
+  - Release authoring checklist

--- a/releases/templates/tagged-release-template.md
+++ b/releases/templates/tagged-release-template.md
@@ -1,0 +1,37 @@
+# Release x.y.z
+
+Replace every placeholder in this template before publishing a tagged Runnable release note.
+
+## Why this release matters
+
+Write the short story first. Explain what changed, who should care, and which parts of the Runnable surface moved in this version.
+
+## Highlights
+
+- Highlight one
+- Highlight two
+- Highlight three
+
+## What shipped
+
+### Packages and APIs
+
+- Describe package-level changes here.
+
+### CLI and tooling
+
+- Describe CLI and developer workflow changes here.
+
+### Docs and examples
+
+- Describe docs-facing and example changes here.
+
+## Migration guidance
+
+- List the concrete upgrade steps here.
+- Link back to the compact summary in `CHANGELOG.md`.
+
+## Reference links
+
+- Changelog entry: `../CHANGELOG.md`
+- Previous release note: add link if one exists

--- a/releases/templates/tagged-release-template.md.yml
+++ b/releases/templates/tagged-release-template.md.yml
@@ -1,0 +1,10 @@
+title: Tagged release template
+summary: Maintainer template for future versioned Runnable release notes.
+page_type: guide
+nav_group: Releases
+order: 50
+hide_from_public_nav: true
+hide_from_search: true
+breadcrumbs:
+  - Releases
+  - Tagged release template

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -1,0 +1,51 @@
+# Unreleased
+
+This is the living release note for the next coordinated Runnable version. It is intentionally written in the same blog-style shape we want future tagged releases to use, but everything here remains provisional until a tag is cut.
+
+## What is taking shape
+
+Runnable is putting the release contract in place before `v0.1.0`. This slice is about making release notes auditable, public, and reusable:
+
+- a root changelog that acts as the compact ledger
+- a public unreleased proof artifact
+- a pre-1.0 upgrade policy with a clear migration home
+- a top-of-page trust bar for release notes and policy pages
+- pull-request guards that keep PR titles and unreleased entries aligned with future release automation
+
+## Included in the next coordinated version
+
+### Release and docs surface
+
+- The `/docs` landing now promotes a Releases entry point alongside product proof paths.
+- Runnable now ships a public release hub, a changelog, an unreleased page, and a tagged release template inside the repository.
+- Release-note pages can show status, freshness, scope, migration guidance, and provenance in a shared trust bar instead of bespoke page chrome.
+
+### Contribution contract
+
+- Pull request titles are now expected to follow Conventional Commits so the merge history is machine-readable for future automation.
+- Pull requests are expected to update this page unless maintainers explicitly mark the change as outside the public release story.
+- Markdown-only changes on `main` now republish the docs surface, so release-note and policy edits are treated as first-class product updates.
+
+### RazorDocs product example
+
+- Runnable's own release pages now double as a working RazorDocs example for consumers who want better release notes.
+- The release contract is designed so future tooling can generate both a changelog entry and a blog-style tagged release note from the same underlying signals.
+
+## Migration watch
+
+There is no tagged migration guide yet because Runnable has not cut `v0.1.0`. Until then:
+
+- breaking changes should be called out here as soon as they land
+- the stable policy lives in [Pre-1.0 upgrade policy](./upgrade-policy.md)
+- finalized migration steps move into the tagged release note when the version ships
+
+## Proof artifacts
+
+- [Release hub](./README.md)
+- [Changelog](../CHANGELOG.md)
+- [Pre-1.0 upgrade policy](./upgrade-policy.md)
+- [Release authoring checklist](./release-authoring-checklist.md)
+
+## Before the first tag
+
+The current intent is that everything already in this repository can be part of `v0.1.0` when Runnable is ready to release. This page is where that pile becomes visible and reviewable before the tag exists.

--- a/releases/unreleased.md.yml
+++ b/releases/unreleased.md.yml
@@ -1,0 +1,21 @@
+title: Unreleased
+summary: Living proof artifact for the next coordinated Runnable release. This page is intentionally provisional until a version is tagged.
+page_type: release-note
+nav_group: Releases
+order: 15
+breadcrumbs:
+  - Releases
+  - Unreleased
+trust:
+  status: Unreleased
+  summary: This page tracks merged work that is intended for the next coordinated Runnable release. The grouping and wording can still change before the tag is cut.
+  freshness: Updated as changes land on main. Treat it as current but provisional.
+  change_scope: Repository-wide. Packages, CLI tooling, examples, and docs-facing behavior all roll into the same next version.
+  migration:
+    label: Read the pre-1.0 upgrade policy
+    href: /docs/releases/upgrade-policy.md.html
+  archive: When a version is tagged, the final narrative moves into a versioned release note and the compact summary is recorded in CHANGELOG.md.
+  sources:
+    - Pull request titles follow Conventional Commits.
+    - CHANGELOG.md is the compact ledger.
+    - Tagged release notes carry the final migration narrative.

--- a/releases/upgrade-policy.md
+++ b/releases/upgrade-policy.md
@@ -1,0 +1,36 @@
+# Pre-1.0 upgrade policy
+
+Runnable is still before `v1.0.0`, so rapid change is expected. That does not mean changes should be surprising. This policy explains how Runnable will talk about risk and where migration guidance belongs before the first stable release.
+
+## Core policy
+
+- Runnable releases the monorepo in unison. One version applies to the whole repository.
+- Breaking and behavior-changing updates are allowed before `v1.0.0`, but they must be called out in the public release surface.
+- Migration guidance must have a durable home. The short form belongs in [`CHANGELOG.md`](../CHANGELOG.md), and the detailed walkthrough belongs in the matching release note.
+
+## Where migration notes live
+
+- Before a version is tagged: put provisional guidance in [`unreleased.md`](./unreleased.md).
+- When a version is tagged: move the finalized guidance into the versioned release note under `releases/`.
+- Keep [`CHANGELOG.md`](../CHANGELOG.md) concise and link readers to the full release note when more detail is needed.
+
+## What counts as a release-note-worthy change
+
+- API changes that alter signatures, defaults, ordering requirements, or expected lifecycle behavior
+- CLI changes that alter commands, flags, defaults, or output that users depend on
+- Example changes that replace the recommended way to compose Runnable
+- Docs-facing behavior changes that affect how consumers discover, configure, or trust the product
+
+## What does not count as a migration note by itself
+
+- private maintainer-only recovery notes
+- secret or credential handling details
+- repo maintenance that does not affect adopters
+
+Those belong outside harvested public docs.
+
+## Expectations before `v0.1.0`
+
+- Prefer documenting a breaking change the same day it lands.
+- If a change is large enough to require choreography, add explicit step-by-step guidance to the unreleased note.
+- Do not hide pre-1.0 instability. Make it legible.

--- a/releases/upgrade-policy.md.yml
+++ b/releases/upgrade-policy.md.yml
@@ -1,0 +1,20 @@
+title: Pre-1.0 upgrade policy
+summary: Stability and migration contract for Runnable before the first tagged release.
+page_type: guide
+nav_group: Releases
+order: 30
+breadcrumbs:
+  - Releases
+  - Pre-1.0 upgrade policy
+trust:
+  status: Pre-1.0 policy
+  summary: Runnable can still make breaking changes before v1.0.0, but those changes must be called out publicly and paired with clear migration guidance.
+  freshness: Updated when Runnable changes the release contract or clarifies what belongs in public migration notes.
+  change_scope: Repository-wide. The same policy applies to packages, CLI tooling, examples, and docs-facing behavior.
+  migration:
+    label: See the current unreleased note
+    href: /docs/releases/unreleased.md.html
+  archive: Version-specific migration steps belong in tagged release pages, while this page stays stable as the standing policy.
+  sources:
+    - CHANGELOG.md
+    - releases/unreleased.md


### PR DESCRIPTION
## Summary
- add a release contract and release operations documentation for the monorepo
- add release hub content for changelog, unreleased notes, and upgrade policy discovery
- enforce the unreleased note update contract in CI and wire RazorDocs to preserve canonical release-doc navigation

## Why
This establishes the contracts needed before the first coordinated monorepo release and makes the release surface part of the product itself so consumers can follow the same pattern.

## Root Cause
The repo did not yet have a formal release contract, a proof artifact for unreleased work, or a canonical docs-navigation path for release content.

## User Impact
- maintainers get a documented release workflow and a CI guard for unreleased notes
- readers get a first-class release hub with working canonical doc routes and curated breadcrumbs
- future releases have a clearer path to automated changelog and release-note generation

## Validation
- `dotnet build ForgeTrust.Runnable.slnx`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --filter FullyQualifiedName~RazorDocsLandingPlaywrightTests`
- `./scripts/coverage-solution.sh`
- `coderabbit review --plain --base main -c AGENTS.md`

Fixes #121