### PR TITLE
fix(razordocs): validate links against published docs

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -141,12 +141,13 @@ public class DocAggregatorTests : IDisposable
             new(
                 "Releases",
                 "releases/README.md",
-                "<p><a href=\"./unreleased.md\">Unreleased</a> <a href=\"https://example.com/releases\">External</a></p>")
+                "<p><a href=\"./unreleased.md\">Unreleased</a> <a href=\"https://example.com/releases\">External</a></p>"),
+            new("Unreleased", "releases/unreleased.md", "<p>Draft</p>")
         };
 
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
 
-        var result = Assert.Single((await _aggregator.GetDocsAsync()).ToList());
+        var result = (await _aggregator.GetDocsAsync()).Single(doc => doc.Path == "releases/README.md");
 
         Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", result.Content);
         Assert.Contains("data-turbo-frame=\"doc-content\"", result.Content);
@@ -162,18 +163,40 @@ public class DocAggregatorTests : IDisposable
             new(
                 "Guide",
                 "README.md",
-                "<p><a href=\"guide.md\" title=\"1 > 0\">guide</a></p>")
+                "<p><a href=\"guide.md\" title=\"1 > 0\">guide</a></p>"),
+            new("Guide", "guide.md", "<p>Guide body</p>")
         };
 
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
 
-        var result = Assert.Single((await _aggregator.GetDocsAsync()).ToList());
+        var result = (await _aggregator.GetDocsAsync()).Single(doc => doc.Path == "README.md");
         var document = new HtmlParser().ParseDocument(result.Content);
         var anchor = Assert.Single(document.QuerySelectorAll("a"));
 
         Assert.Equal("/docs/guide.md.html", anchor.GetAttribute("href"));
         Assert.Equal("1 > 0", anchor.GetAttribute("title"));
         Assert.Equal("guide", anchor.TextContent);
+    }
+
+    [Fact]
+    public async Task GetDocsAsync_ShouldNotRewriteSourceLikeLinks_WhenTargetWasNotHarvested()
+    {
+        var harvestedDocs = new List<DocNode>
+        {
+            new(
+                "Releases",
+                "releases/README.md",
+                "<p><a href=\"./missing.md\">Missing</a> <a href=\"./unreleased.md\">Unreleased</a></p>"),
+            new("Unreleased", "releases/unreleased.md", "<p>Draft</p>")
+        };
+
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        var result = (await _aggregator.GetDocsAsync()).Single(doc => doc.Path == "releases/README.md");
+
+        Assert.Contains("href=\"./missing.md\"", result.Content);
+        Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", result.Content);
+        Assert.DoesNotContain("href=\"/docs/releases/missing.md.html\"", result.Content);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -691,7 +691,11 @@ public class DocAggregatorTests : IDisposable
         var harvestedDocs = new List<DocNode>
         {
             new("Web", "Namespaces/ForgeTrust.Web", namespaceContent),
-            new("README", "docs/ForgeTrust.Web/README.md", "<p>Namespace intro</p>")
+            new(
+                "README",
+                "docs/ForgeTrust.Web/README.md",
+                "<p>Namespace intro <a href=\"./README.md\">self</a> <a href=\"./guide.md\">guide</a></p>"),
+            new("Guide", "docs/ForgeTrust.Web/guide.md", "<p>Guide</p>")
         };
         A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
 
@@ -702,7 +706,10 @@ public class DocAggregatorTests : IDisposable
         var namespaceDoc = docs.Single(d => d.Path == "Namespaces/ForgeTrust.Web");
         Assert.DoesNotContain(docs, d => d.Path == "docs/ForgeTrust.Web/README.md");
         Assert.Contains("doc-namespace-intro", namespaceDoc.Content);
-        Assert.Contains("<p>Namespace intro</p>", namespaceDoc.Content);
+        Assert.Contains("Namespace intro", namespaceDoc.Content);
+        Assert.Contains("href=\"./README.md\"", namespaceDoc.Content);
+        Assert.Contains("href=\"/docs/docs/ForgeTrust.Web/guide.md.html\"", namespaceDoc.Content);
+        Assert.DoesNotContain("href=\"/docs/docs/ForgeTrust.Web/README.md.html\"", namespaceDoc.Content);
         Assert.Contains("</section><section class=\"doc-namespace-intro\">", namespaceDoc.Content);
     }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -35,6 +35,23 @@ public sealed class DocContentLinkRewriterTests
     }
 
     [Fact]
+    public void RewriteInternalDocLinks_ShouldLeaveFragmentOnlyLinksUnchanged_WhenSourceIsNotPublished()
+    {
+        var html = "<p><a href=\"#migration\">Migration</a></p>";
+        var manifest = DocLinkTargetManifest.FromPaths(["releases/unreleased.md"]);
+
+        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks(
+            "releases/draft.md",
+            html,
+            manifest);
+
+        Assert.Contains("href=\"#migration\"", rewritten);
+        Assert.DoesNotContain("data-doc-anchor-link=\"true\"", rewritten);
+        Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.DoesNotContain("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
     public void RewriteInternalDocLinks_ShouldDecorateCanonicalDocsLinks_WithoutChangingTheirRoutes()
     {
         var html = "<p><a href=\"/docs/releases/upgrade-policy.md.html\">Policy</a></p>";
@@ -242,6 +259,22 @@ public sealed class DocContentLinkRewriterTests
 
         Assert.Contains("href=\"./guide.md\"", rewritten);
         Assert.Contains("href=\"/docs/docs/guide.md.html\"", rewritten);
+    }
+
+    [Fact]
+    public void DocLinkTargetManifest_ShouldMatchRootedDocsRoutesWithQueryAndFragment()
+    {
+        var manifest = DocLinkTargetManifest.FromPaths(["releases/unreleased.md"]);
+
+        Assert.True(manifest.Contains("/docs/releases/unreleased.md.html?view=compact#summary"));
+    }
+
+    [Fact]
+    public void DocLinkTargetManifest_ShouldNotTreatDocsRootWithQueryAsDocumentTarget()
+    {
+        var manifest = DocLinkTargetManifest.FromPaths(["releases/unreleased.md"]);
+
+        Assert.False(manifest.Contains("/docs/?view=compact"));
     }
 
     private static string Rewrite(string sourcePath, string html, params string[] knownPaths)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocContentLinkRewriterTests.cs
@@ -14,7 +14,7 @@ public sealed class DocContentLinkRewriterTests
             </p>
             """;
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+        var rewritten = Rewrite("releases/README.md", html, "releases/unreleased.md", "CHANGELOG.md");
 
         Assert.Contains("class=\"proof-link\"", rewritten);
         Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
@@ -28,7 +28,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"#migration\">Migration</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+        var rewritten = Rewrite("releases/unreleased.md", html);
 
         Assert.Contains("href=\"/docs/releases/unreleased.md.html#migration\"", rewritten);
         Assert.Contains("data-doc-anchor-link=\"true\"", rewritten);
@@ -39,7 +39,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"/docs/releases/upgrade-policy.md.html\">Policy</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+        var rewritten = Rewrite("releases/unreleased.md", html, "releases/upgrade-policy.md");
 
         Assert.Contains("href=\"/docs/releases/upgrade-policy.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
@@ -51,7 +51,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"/docs/releases/upgrade-policy.md\">Policy</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+        var rewritten = Rewrite("releases/unreleased.md", html, "releases/upgrade-policy.md");
 
         Assert.Contains("href=\"/docs/releases/upgrade-policy.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
@@ -63,7 +63,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"/docs/search-index.json\">Search index</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+        var rewritten = Rewrite("releases/unreleased.md", html);
 
         Assert.Contains("href=\"/docs/search-index.json\"", rewritten);
         Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
@@ -75,7 +75,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"/docs\">Docs home</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/unreleased.md", html);
+        var rewritten = Rewrite("releases/unreleased.md", html);
 
         Assert.Contains("href=\"/docs\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
@@ -87,7 +87,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"/releases/unreleased.md\">Unreleased</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+        var rewritten = Rewrite("releases/README.md", html, "releases/unreleased.md");
 
         Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
@@ -104,7 +104,7 @@ public sealed class DocContentLinkRewriterTests
             </p>
             """;
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("CHANGELOG.md#history", html);
+        var rewritten = Rewrite("CHANGELOG.md#history", html, "README.md");
 
         Assert.Contains("href=\"/docs/README.md.html\"", rewritten);
         Assert.Contains("href=\"/docs/CHANGELOG.md.html#summary\"", rewritten);
@@ -116,7 +116,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"./README.md\">Start here</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks(string.Empty, html);
+        var rewritten = Rewrite(string.Empty, html, "README.md");
 
         Assert.Contains("href=\"/docs/README.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
@@ -128,7 +128,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"/privacy.html\">Privacy</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+        var rewritten = Rewrite("releases/README.md", html);
 
         Assert.Contains("href=\"/privacy.html\"", rewritten);
         Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
@@ -140,7 +140,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"../CHANGELOG.md.html\">Changelog</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+        var rewritten = Rewrite("releases/README.md", html, "CHANGELOG.md");
 
         Assert.Contains("href=\"/docs/CHANGELOG.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
@@ -152,7 +152,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<p><a href=\"../privacy.html\">Privacy</a> <a href=\"../../status.html\">Status</a></p>";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks(
+        var rewritten = Rewrite(
             "releases/templates/tagged-release-template.md",
             html);
 
@@ -167,7 +167,7 @@ public sealed class DocContentLinkRewriterTests
     {
         var html = "<a href=\"./unreleased.md\" />";
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+        var rewritten = Rewrite("releases/README.md", html, "releases/unreleased.md");
 
         Assert.Contains("href=\"/docs/releases/unreleased.md.html\"", rewritten);
         Assert.Contains("data-turbo-frame=\"doc-content\"", rewritten);
@@ -187,7 +187,7 @@ public sealed class DocContentLinkRewriterTests
             </p>
             """;
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+        var rewritten = Rewrite("releases/README.md", html);
 
         Assert.Contains("href=\"   \"", rewritten);
         Assert.Contains("href=\"//example.com/releases\"", rewritten);
@@ -207,10 +207,46 @@ public sealed class DocContentLinkRewriterTests
             </p>
             """;
 
-        var rewritten = DocContentLinkRewriter.RewriteInternalDocLinks("releases/README.md", html);
+        var rewritten = Rewrite("releases/README.md", html, "releases/unreleased.md");
 
         Assert.Contains("href=\"https://example.com/releases\"", rewritten);
         Assert.DoesNotContain("href=\"https://example.com/releases\" data-turbo-frame=\"doc-content\"", rewritten);
         Assert.Contains("href=\"./unreleased.md\" target=\"_blank\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldLeaveSourceLikeLinksUnchanged_WhenTargetIsNotHarvested()
+    {
+        var html = "<p><a href=\"./missing.md\">Missing</a> <a href=\"/docs/missing.md.html\">Missing route</a></p>";
+
+        var rewritten = Rewrite("releases/README.md", html, "releases/unreleased.md");
+
+        Assert.Contains("href=\"./missing.md\"", rewritten);
+        Assert.Contains("href=\"/docs/missing.md.html\"", rewritten);
+        Assert.DoesNotContain("href=\"/docs/releases/missing.md.html\"", rewritten);
+        Assert.DoesNotContain("data-turbo-frame=\"doc-content\"", rewritten);
+        Assert.DoesNotContain("data-turbo-action=\"advance\"", rewritten);
+    }
+
+    [Fact]
+    public void RewriteInternalDocLinks_ShouldNotTreatSourceDocsFolder_AsDocsRouteRoot()
+    {
+        var html = """
+            <p>
+              <a href="./guide.md">Wrong directory</a>
+              <a href="./docs/guide.md">Docs directory</a>
+            </p>
+            """;
+
+        var rewritten = Rewrite("README.md", html, "docs/guide.md");
+
+        Assert.Contains("href=\"./guide.md\"", rewritten);
+        Assert.Contains("href=\"/docs/docs/guide.md.html\"", rewritten);
+    }
+
+    private static string Rewrite(string sourcePath, string html, params string[] knownPaths)
+    {
+        var manifest = DocLinkTargetManifest.FromPaths(knownPaths.Prepend(sourcePath));
+        return DocContentLinkRewriter.RewriteInternalDocLinks(sourcePath, html, manifest);
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -80,6 +80,29 @@ Reference the package and add the module to your Runnable web application:
 await WebApp<RazorDocsWebModule>.RunAsync(args);
 ```
 
+## Docs Link Authoring
+
+RazorDocs rewrites links inside harvested Markdown so authors can use source-friendly paths while readers stay on canonical `/docs/...html` routes with Turbo history support.
+
+### Authoring contract
+
+- Link to another harvested doc with its source path, such as `./guide.md`, `../CHANGELOG.md`, or `/releases/unreleased.md`.
+- Link to an already canonical docs route only when the target is a harvested doc, such as `/docs/releases/unreleased.md.html`.
+- Use ordinary site URLs, such as `/privacy.html` or `../status.html`, for non-doc pages. RazorDocs leaves those links untouched.
+- Use browser-facing URLs for metadata fields that render plain anchors without content rewriting, such as `trust.migration.href`.
+
+### Manifest-backed rewriting
+
+During aggregation, RazorDocs builds a manifest from the harvested documentation nodes. Link rewriting consults that manifest before converting any source or canonical-looking link into `/docs/...`.
+
+This means a link is rewritten only when the target exists in the harvested docs set. A missing `./guide.md`, an ambiguous `/docs/missing.md.html`, or a normal site page like `../privacy.html` remains authored as-is instead of being guessed into a broken docs route.
+
+### Pitfalls
+
+- Do not rely on file extensions alone. A `.md`, `.cs`, or `.html` suffix does not make a link a RazorDocs target unless the target was harvested.
+- If a doc link is not rewritten, first confirm the target file is included by the active harvester and not excluded by directory policy.
+- Canonical `/docs/...html` links are safe for exported docs, but source-relative Markdown links are usually easier to keep portable in GitHub and editor previews.
+
 ## Landing Curation
 
 RazorDocs can turn the root docs landing into a curated proof-path surface by reading `featured_pages` from the repository-root `README.md` metadata.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -269,7 +269,6 @@ public class DocAggregator
                            allNodes.AddRange(result);
                        }
 
-                       var linkTargetManifest = DocLinkTargetManifest.FromNodes(allNodes);
                        var sanitizedNodes = allNodes
                            .Select(
                                n =>
@@ -281,20 +280,37 @@ public class DocAggregator
                                    return new DocNode(
                                        n.Title,
                                        n.Path,
-                                       DocContentLinkRewriter.RewriteInternalDocLinks(
-                                           n.Path,
-                                           sanitizedContent,
-                                           linkTargetManifest),
-                                       n.ParentPath,
-                                       n.IsDirectory,
-                                       DocRoutePath.BuildCanonicalPath(n.Path),
-                                       n.Metadata);
+                                      sanitizedContent,
+                                      n.ParentPath,
+                                      n.IsDirectory,
+                                      DocRoutePath.BuildCanonicalPath(n.Path),
+                                      n.Metadata);
                                })
                            .ToList();
 
-                       MergeNamespaceReadmes(sanitizedNodes);
+                       var targetNodes = sanitizedNodes.ToList();
+                       MergeNamespaceReadmes(targetNodes);
+                       var linkTargetManifest = DocLinkTargetManifest.FromNodes(targetNodes);
+                       // Rewrite before the real namespace merge so README-relative links keep their source path
+                       // context, while the manifest still reflects only final published docs targets.
+                       var rewrittenNodes = sanitizedNodes
+                           .Select(
+                               n => new DocNode(
+                                   n.Title,
+                                   n.Path,
+                                   DocContentLinkRewriter.RewriteInternalDocLinks(
+                                       n.Path,
+                                       n.Content,
+                                       linkTargetManifest),
+                                   n.ParentPath,
+                                   n.IsDirectory,
+                                   n.CanonicalPath,
+                                   n.Metadata))
+                           .ToList();
 
-                       var docsByPath = sanitizedNodes
+                       MergeNamespaceReadmes(rewrittenNodes);
+
+                       var docsByPath = rewrittenNodes
                            .GroupBy(n => n.Path)
                            .Select(g =>
                            {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -269,6 +269,7 @@ public class DocAggregator
                            allNodes.AddRange(result);
                        }
 
+                       var linkTargetManifest = DocLinkTargetManifest.FromNodes(allNodes);
                        var sanitizedNodes = allNodes
                            .Select(
                                n =>
@@ -280,7 +281,10 @@ public class DocAggregator
                                    return new DocNode(
                                        n.Title,
                                        n.Path,
-                                       DocContentLinkRewriter.RewriteInternalDocLinks(n.Path, sanitizedContent),
+                                       DocContentLinkRewriter.RewriteInternalDocLinks(
+                                           n.Path,
+                                           sanitizedContent,
+                                           linkTargetManifest),
                                        n.ParentPath,
                                        n.IsDirectory,
                                        DocRoutePath.BuildCanonicalPath(n.Path),

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocContentLinkRewriter.cs
@@ -18,11 +18,16 @@ internal static class DocContentLinkRewriter
     /// </summary>
     /// <param name="sourcePath">The harvested source path whose content is being rewritten.</param>
     /// <param name="html">The rendered and sanitized HTML fragment to rewrite.</param>
+    /// <param name="targetManifest">Manifest of harvested documentation targets that may be rewritten to docs routes.</param>
     /// <returns>The rewritten HTML fragment.</returns>
-    internal static string RewriteInternalDocLinks(string sourcePath, string html)
+    internal static string RewriteInternalDocLinks(
+        string sourcePath,
+        string html,
+        DocLinkTargetManifest targetManifest)
     {
         ArgumentNullException.ThrowIfNull(sourcePath);
         ArgumentNullException.ThrowIfNull(html);
+        ArgumentNullException.ThrowIfNull(targetManifest);
 
         if (html.IndexOf("<a", StringComparison.OrdinalIgnoreCase) < 0)
         {
@@ -33,13 +38,13 @@ internal static class DocContentLinkRewriter
         var document = parser.ParseDocument(html);
         foreach (var anchor in document.QuerySelectorAll("a[href]"))
         {
-            RewriteAnchorElement(sourcePath, anchor);
+            RewriteAnchorElement(sourcePath, anchor, targetManifest);
         }
 
         return document.Body?.InnerHtml ?? html;
     }
 
-    private static void RewriteAnchorElement(string sourcePath, IElement anchor)
+    private static void RewriteAnchorElement(string sourcePath, IElement anchor, DocLinkTargetManifest targetManifest)
     {
         if (HasNonSelfTarget(anchor))
         {
@@ -47,7 +52,7 @@ internal static class DocContentLinkRewriter
         }
 
         var href = anchor.GetAttribute("href");
-        if (!TryBuildDocsHref(sourcePath, href, out var docsHref))
+        if (!TryBuildDocsHref(sourcePath, href, targetManifest, out var docsHref))
         {
             return;
         }
@@ -69,7 +74,11 @@ internal static class DocContentLinkRewriter
                && !string.Equals(target, "_self", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool TryBuildDocsHref(string sourcePath, string? href, out string docsHref)
+    private static bool TryBuildDocsHref(
+        string sourcePath,
+        string? href,
+        DocLinkTargetManifest targetManifest,
+        out string docsHref)
     {
         docsHref = string.Empty;
         if (string.IsNullOrWhiteSpace(href))
@@ -89,7 +98,7 @@ internal static class DocContentLinkRewriter
         if (path.StartsWith(DocsRootPath + "/", StringComparison.OrdinalIgnoreCase))
         {
             var docsRelativePath = path[(DocsRootPath.Length + 1)..];
-            if (!LooksLikeDocTarget(docsRelativePath))
+            if (!targetManifest.Contains(docsRelativePath))
             {
                 return false;
             }
@@ -100,6 +109,11 @@ internal static class DocContentLinkRewriter
 
         if (trimmedHref.StartsWith('#'))
         {
+            if (!targetManifest.Contains(sourcePath))
+            {
+                return false;
+            }
+
             docsHref = $"{DocsRootPath}/{DocRoutePath.BuildCanonicalPath(GetSourceDocumentPath(sourcePath))}{fragment}";
             return true;
         }
@@ -117,7 +131,7 @@ internal static class DocContentLinkRewriter
         if (path.StartsWith("/", StringComparison.Ordinal))
         {
             var rootedTarget = path.TrimStart('/');
-            if (!LooksLikeRootedDocTarget(rootedTarget))
+            if (!targetManifest.Contains(rootedTarget))
             {
                 return false;
             }
@@ -132,7 +146,7 @@ internal static class DocContentLinkRewriter
         }
 
         var resolvedTarget = ResolveRelativePath(sourcePath, path);
-        if (!LooksLikeDocTarget(resolvedTarget))
+        if (!targetManifest.Contains(resolvedTarget))
         {
             return false;
         }
@@ -144,44 +158,6 @@ internal static class DocContentLinkRewriter
     private static string BuildDocsHref(string docPath, string query, string fragment)
     {
         return $"{DocsRootPath}/{DocRoutePath.BuildCanonicalPath(docPath)}{query}{fragment}";
-    }
-
-    private static bool LooksLikeDocTarget(string path)
-    {
-        return LooksLikeSourceDocTarget(path)
-               || LooksLikeCanonicalDocTarget(path);
-    }
-
-    private static bool LooksLikeRootedDocTarget(string path)
-    {
-        return LooksLikeDocTarget(path);
-    }
-
-    private static bool LooksLikeSourceDocTarget(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        return path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
-               || path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
-               || path.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
-               || path.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool LooksLikeCanonicalDocTarget(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        return path.EndsWith(".md.html", StringComparison.OrdinalIgnoreCase)
-               || path.EndsWith(".cs.html", StringComparison.OrdinalIgnoreCase)
-               || path.Equals("Namespaces.html", StringComparison.OrdinalIgnoreCase)
-               || (path.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase)
-                   && path.EndsWith(".html", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string ResolveRelativePath(string sourcePath, string relativePath)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocLinkTargetManifest.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocLinkTargetManifest.cs
@@ -1,0 +1,107 @@
+using ForgeTrust.Runnable.Web.RazorDocs.Models;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Services;
+
+/// <summary>
+/// Enumerates the documentation targets harvested into a RazorDocs snapshot so link rewriting can avoid guessing from
+/// file extensions alone.
+/// </summary>
+/// <remarks>
+/// The manifest stores both source paths, such as <c>guides/start.md</c>, and canonical browser paths, such as
+/// <c>guides/start.md.html</c>. Query strings and fragments are intentionally ignored because anchors and query
+/// parameters decorate a page target rather than defining a separate harvested document.
+/// </remarks>
+internal sealed class DocLinkTargetManifest
+{
+    private readonly HashSet<string> _targets;
+
+    private DocLinkTargetManifest(HashSet<string> targets)
+    {
+        _targets = targets;
+    }
+
+    /// <summary>
+    /// Creates a manifest from harvested documentation nodes.
+    /// </summary>
+    /// <param name="nodes">The harvested documentation nodes that may be linked through RazorDocs routes.</param>
+    /// <returns>A manifest containing source and canonical target forms for the supplied nodes.</returns>
+    internal static DocLinkTargetManifest FromNodes(IEnumerable<DocNode> nodes)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        return FromPaths(nodes.SelectMany(node => new[] { node.Path, node.CanonicalPath }));
+    }
+
+    /// <summary>
+    /// Creates a manifest from source or canonical documentation paths.
+    /// </summary>
+    /// <param name="paths">The documentation paths to register as known link targets.</param>
+    /// <returns>A manifest containing normalized source and canonical target forms.</returns>
+    internal static DocLinkTargetManifest FromPaths(IEnumerable<string?> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        var targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in paths)
+        {
+            AddTargetVariants(targets, path);
+        }
+
+        return new DocLinkTargetManifest(targets);
+    }
+
+    /// <summary>
+    /// Determines whether the supplied path resolves to a harvested documentation target.
+    /// </summary>
+    /// <param name="path">A source or canonical documentation path, optionally rooted, queried, or fragmented.</param>
+    /// <returns><c>true</c> when the normalized target is in the manifest; otherwise <c>false</c>.</returns>
+    internal bool Contains(string? path)
+    {
+        var normalizedPath = NormalizeTargetPath(path);
+        return !string.IsNullOrEmpty(normalizedPath)
+               && _targets.Contains(normalizedPath);
+    }
+
+    private static void AddTargetVariants(HashSet<string> targets, string? path)
+    {
+        var normalizedPath = NormalizeTargetPath(path);
+        if (string.IsNullOrEmpty(normalizedPath))
+        {
+            return;
+        }
+
+        targets.Add(normalizedPath);
+        targets.Add(DocRoutePath.BuildCanonicalPath(normalizedPath));
+    }
+
+    private static string NormalizeTargetPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        var normalized = path.Trim().Replace('\\', '/');
+        var isRootedDocsRoute = normalized.StartsWith("/docs/", StringComparison.OrdinalIgnoreCase);
+        var fragmentIndex = normalized.IndexOf('#');
+        if (fragmentIndex >= 0)
+        {
+            normalized = normalized[..fragmentIndex];
+        }
+
+        var queryIndex = normalized.IndexOf('?');
+        if (queryIndex >= 0)
+        {
+            normalized = normalized[..queryIndex];
+        }
+
+        normalized = normalized.Trim('/');
+        const string docsRoot = "docs/";
+        if (isRootedDocsRoute && normalized.StartsWith(docsRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[docsRoot.Length..];
+        }
+
+        return normalized;
+    }
+}

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -30,6 +30,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 
 - Runnable's own release pages now double as a working RazorDocs example for consumers who want better release notes.
 - The release contract is designed so future tooling can generate both a changelog entry and a blog-style tagged release note from the same underlying signals.
+- RazorDocs now rewrites authored doc links from a harvested target manifest instead of broad suffix heuristics, so normal site links such as `../privacy.html` stay untouched and missing doc targets do not become broken `/docs/...` routes.
 
 ## Migration watch
 


### PR DESCRIPTION
Fixes #166

## Summary
- Add a manifest-backed RazorDocs link target model so harvested Markdown links rewrite only when the target is a known docs page.
- Build the link manifest from the final published node set after namespace README folding, while preserving source-path context for relative links during rewrite.
- Document the docs link authoring contract and note the unreleased RazorDocs behavior change.

## Root Cause
RazorDocs link rewriting previously relied on path-shape heuristics, so links could be treated as docs targets even when the final published snapshot would not serve/export that route.

## Validation
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --no-restore --filter "FullyQualifiedName~DocContentLinkRewriterTests|FullyQualifiedName~DocAggregatorTests"` (65/65)
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --no-restore` (356/356)
- `dotnet build ForgeTrust.Runnable.slnx --no-restore`
- `/qa` browser pass against `http://localhost:5000/docs`, health score 100/100, report: `.gstack/qa-reports/qa-report-localhost-5000-2026-04-22.md`