### PR TITLE
feat(razorwire): package CLI as dotnet tool

### DIFF
--- a/.github/release-ops.md
+++ b/.github/release-ops.md
@@ -19,5 +19,10 @@ The current workflow establishes the contracts that future release automation wi
 - Conventional Commits PR titles
 - one public unreleased proof artifact
 - tagged release notes plus a compact changelog
+- packageable CLI artifacts such as `ForgeTrust.Runnable.Web.RazorWire.Cli`
+
+Until that automation lands, package docs that show `dnx`, `dotnet tool execute`,
+or `dotnet tool install` assume either a manually published package source or an
+explicit local package source.
 
 Tracked follow-up: #161, "Automate coordinated monorepo releases from the public release contract".

--- a/Console/ForgeTrust.Runnable.Console/ForgeTrust.Runnable.Console.csproj
+++ b/Console/ForgeTrust.Runnable.Console/ForgeTrust.Runnable.Console.csproj
@@ -16,5 +16,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ForgeTrust.Runnable.Console.Tests"/>
+    <InternalsVisibleTo Include="ForgeTrust.Runnable.Web.RazorWire.Cli"/>
   </ItemGroup>
 </Project>

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportEngineTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportEngineTests.cs
@@ -55,7 +55,7 @@ public class ExportEngineTests
         Assert.True(result);
         Assert.Equal(expectedPath, normalized);
     }
-    
+
     [Theory]
     [InlineData("mailto:user@example.com")]
     [InlineData("tel:1234567890")]
@@ -75,7 +75,7 @@ public class ExportEngineTests
         // Arrange
         var html = @"<html><head><style>body { background-image: url('bg.png'); }</style></head><body><div style=""background: url('../foo.jpg')""></div></body></html>";
         var context = new ExportContext("dist", null, "http://localhost:5000");
-        
+
         // Act
         _sut.ExtractAssets(html, "/page", context);
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs
@@ -456,6 +456,7 @@ public class ExportSourceResolverTests
         Assert.NotNull(capturedPublishArgs);
         Assert.Equal("publish", capturedPublishArgs[0]);
         Assert.Contains(projectPath, capturedPublishArgs);
+        Assert.Contains("--disable-build-servers", capturedPublishArgs);
         Assert.Contains("-c", capturedPublishArgs);
         Assert.Contains("Release", capturedPublishArgs);
         Assert.Contains("-o", capturedPublishArgs);
@@ -620,6 +621,7 @@ public class ExportSourceResolverTests
             Path.Combine(tempDir.FullPath, "bin", "runnable-export", "MySite.dll"));
         Assert.Equal(normalizedExpected, resolved.SourceValue);
         Assert.NotNull(capturedPublishArgs);
+        Assert.Contains("--disable-build-servers", capturedPublishArgs);
         Assert.Contains("-f", capturedPublishArgs);
         Assert.Contains("net10.0", capturedPublishArgs);
     }
@@ -628,7 +630,7 @@ public class ExportSourceResolverTests
     public void ResolveBuiltDllPath_Should_Honor_Requested_Framework_When_Provided()
     {
         using var tempDir = new TempDirectory();
-        
+
         var net9Dir = Path.Combine(tempDir.FullPath, "bin", "Release", "net9.0", "publish");
         Directory.CreateDirectory(net9Dir);
         File.WriteAllBytes(Path.Combine(net9Dir, "MySite.dll"), [1, 2, 3]);
@@ -921,6 +923,7 @@ public class ExportSourceResolverTests
         Assert.Equal(projectPath, capturedArgs[1]);
         Assert.Contains("-getProperty:AssemblyName", capturedArgs);
         Assert.Contains("-nologo", capturedArgs);
+        Assert.Contains("-nodeReuse:false", capturedArgs);
         Assert.Contains("-p:Configuration=Release", capturedArgs);
         Assert.Contains("-p:TargetFramework=net10.0", capturedArgs);
     }
@@ -962,6 +965,7 @@ public class ExportSourceResolverTests
         Assert.Equal(projectPath, capturedArgs[1]);
         Assert.Contains("-getProperty:AssemblyName", capturedArgs);
         Assert.Contains("-nologo", capturedArgs);
+        Assert.Contains("-nodeReuse:false", capturedArgs);
         Assert.Contains("-p:Configuration=Release", capturedArgs);
         Assert.Contains("-p:TargetFramework=net10.0", capturedArgs);
     }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ToolPackageContractTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ToolPackageContractTests.cs
@@ -1,0 +1,348 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+
+namespace ForgeTrust.Runnable.Web.RazorWire.Cli.Tests;
+
+[Collection(ProgramEntryPointCollection.Name)]
+public sealed class ToolPackageContractTests
+{
+    private const string PackageId = "ForgeTrust.Runnable.Web.RazorWire.Cli";
+    private const string ToolCommandName = "razorwire";
+    private const string PackageDescription = "Command-line export tooling for RazorWire applications.";
+
+    [Fact]
+    [Trait("Category", "PackageVerification")]
+    public async Task PackagedTool_Should_Run_Through_Dnx_ToolInstall_And_InstalledExport()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        using var workspace = TempDirectory.Create("razorwire-tool-package-");
+        var packageDirectory = workspace.CreateSubdirectory("packages");
+        var cliHomeDirectory = workspace.CreateSubdirectory("dotnet-home");
+        var toolDirectory = workspace.CreateSubdirectory("tool-path");
+        var exportDirectory = workspace.CreateSubdirectory("export-output");
+        var version = "0.0.0-toolverifier." + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+        var repositoryRunner = new ToolProcessRunner(
+            repositoryRoot,
+            new Dictionary<string, string?>
+            {
+                ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
+                ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
+                ["DOTNET_NOLOGO"] = "1",
+                ["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1"
+            });
+        var isolatedToolRunner = new ToolProcessRunner(
+            repositoryRoot,
+            new Dictionary<string, string?>
+            {
+                ["DOTNET_CLI_HOME"] = cliHomeDirectory.Path,
+                ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
+                ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
+                ["DOTNET_NOLOGO"] = "1",
+                ["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1"
+            });
+
+        var packResult = await repositoryRunner.RunDotNetAsync(
+            TimeSpan.FromMinutes(3),
+            "pack",
+            Path.Combine("Web", "ForgeTrust.Runnable.Web.RazorWire.Cli", "ForgeTrust.Runnable.Web.RazorWire.Cli.csproj"),
+            "--configuration",
+            "Release",
+            "--no-restore",
+            "--output",
+            packageDirectory.Path,
+            $"/p:PackageVersion={version}");
+
+        packResult.AssertSucceeded("Expected the RazorWire CLI project to pack as a .NET tool package.");
+        var packagePath = Path.Combine(packageDirectory.Path, $"{PackageId}.{version}.nupkg");
+        Assert.True(File.Exists(packagePath), $"Expected package file to exist at {packagePath}.");
+
+        AssertToolPackageContract(packagePath, version);
+
+        var dnxResult = await isolatedToolRunner.RunDotNetAsync(
+            TimeSpan.FromMinutes(1),
+            "dnx",
+            $"{PackageId}@{version}",
+            "--yes",
+            "--source",
+            packageDirectory.Path,
+            "--",
+            "--help");
+
+        dnxResult.AssertSucceeded("Expected dnx to run the exact local RazorWire CLI package.");
+        Assert.Contains("usage", dnxResult.AllText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("export", dnxResult.AllText, StringComparison.Ordinal);
+
+        var installResult = await isolatedToolRunner.RunDotNetAsync(
+            TimeSpan.FromMinutes(1),
+            "tool",
+            "install",
+            PackageId,
+            "--tool-path",
+            toolDirectory.Path,
+            "--source",
+            packageDirectory.Path,
+            "--version",
+            version);
+
+        installResult.AssertSucceeded("Expected dotnet tool install to install the exact local RazorWire CLI package.");
+        var installedToolPath = Path.Combine(toolDirectory.Path, OperatingSystem.IsWindows() ? "razorwire.exe" : "razorwire");
+        Assert.True(File.Exists(installedToolPath), $"Expected installed tool shim to exist at {installedToolPath}.");
+
+        var rootHelpResult = await isolatedToolRunner.RunAsync(
+            installedToolPath,
+            TimeSpan.FromMinutes(1),
+            "--help");
+
+        rootHelpResult.AssertSucceeded("Expected the installed RazorWire tool to print root help.");
+        Assert.Contains("usage", rootHelpResult.AllText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("export", rootHelpResult.AllText, StringComparison.Ordinal);
+
+        var exportHelpResult = await isolatedToolRunner.RunAsync(
+            installedToolPath,
+            TimeSpan.FromMinutes(1),
+            "export",
+            "--help");
+
+        exportHelpResult.AssertSucceeded("Expected the installed RazorWire tool to print export help.");
+        Assert.Contains("Export a RazorWire site to a static directory.", exportHelpResult.AllText, StringComparison.Ordinal);
+
+        var sampleProjectPath = Path.Combine(
+            repositoryRoot,
+            "examples",
+            "razorwire-mvc",
+            "RazorWireWebExample.csproj");
+        var exportResult = await repositoryRunner.RunAsync(
+            installedToolPath,
+            TimeSpan.FromMinutes(4),
+            "export",
+            "--project",
+            sampleProjectPath,
+            "--output",
+            exportDirectory.Path);
+
+        exportResult.AssertSucceeded("Expected the installed RazorWire tool to export the MVC sample.");
+        var indexPath = Path.Combine(exportDirectory.Path, "index.html");
+        Assert.True(File.Exists(indexPath), $"Expected the export to create {indexPath}.");
+        var indexHtml = await File.ReadAllTextAsync(indexPath);
+        Assert.Contains("RazorWire", indexHtml, StringComparison.Ordinal);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "ForgeTrust.Runnable.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to find repository root from the current test assembly path.");
+    }
+
+    private static void AssertToolPackageContract(string packagePath, string expectedVersion)
+    {
+        using var archive = ZipFile.OpenRead(packagePath);
+        var nuspecEntry = Assert.Single(
+            archive.Entries,
+            entry => entry.FullName.EndsWith(".nuspec", StringComparison.Ordinal));
+        using var nuspecStream = nuspecEntry.Open();
+        var nuspec = XDocument.Load(nuspecStream);
+        var ns = nuspec.Root!.Name.Namespace;
+
+        Assert.Equal(PackageId, nuspec.Descendants(ns + "id").Single().Value);
+        Assert.Equal(expectedVersion, nuspec.Descendants(ns + "version").Single().Value);
+        var description = nuspec.Descendants(ns + "description").Single().Value;
+        Assert.Equal(PackageDescription, description);
+        Assert.DoesNotContain("Package Description", description, StringComparison.Ordinal);
+
+        var packageType = Assert.Single(nuspec.Descendants(ns + "packageType"));
+        Assert.Equal("DotnetTool", packageType.Attribute("name")?.Value);
+        Assert.Empty(nuspec.Descendants(ns + "dependencies"));
+
+        var settingsEntry = archive.GetEntry("tools/net10.0/any/DotnetToolSettings.xml");
+        Assert.NotNull(settingsEntry);
+        using var settingsStream = settingsEntry!.Open();
+        var settings = XDocument.Load(settingsStream);
+        var command = Assert.Single(settings.Descendants("Command"));
+        Assert.Equal(ToolCommandName, command.Attribute("Name")?.Value);
+        Assert.Equal("ForgeTrust.Runnable.Web.RazorWire.Cli.dll", command.Attribute("EntryPoint")?.Value);
+        Assert.Equal("dotnet", command.Attribute("Runner")?.Value);
+    }
+
+    private sealed class ToolProcessRunner(
+        string workingDirectory,
+        IReadOnlyDictionary<string, string?> environmentOverrides)
+    {
+        public Task<ToolProcessResult> RunDotNetAsync(TimeSpan timeout, params string[] arguments) =>
+            RunAsync("dotnet", timeout, arguments);
+
+        public async Task<ToolProcessResult> RunAsync(
+            string fileName,
+            TimeSpan timeout,
+            params string[] arguments)
+        {
+            using var timeoutSource = new CancellationTokenSource(timeout);
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            foreach (var argument in arguments)
+            {
+                process.StartInfo.ArgumentList.Add(argument);
+            }
+
+            foreach (var (key, value) in environmentOverrides)
+            {
+                if (value == null)
+                {
+                    process.StartInfo.Environment.Remove(key);
+                }
+                else
+                {
+                    process.StartInfo.Environment[key] = value;
+                }
+            }
+
+            var commandLine = BuildCommandLine(fileName, arguments);
+            if (!process.Start())
+            {
+                throw new InvalidOperationException($"Unable to start process: {commandLine}");
+            }
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var timedOut = false;
+
+            try
+            {
+                await process.WaitForExitAsync(timeoutSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                timedOut = true;
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // The process may have exited between the timeout and the kill attempt.
+                }
+
+                await process.WaitForExitAsync();
+            }
+
+            string stdout;
+            string stderr;
+            try
+            {
+                stdout = await stdoutTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                stdout = string.Empty;
+            }
+
+            try
+            {
+                stderr = await stderrTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                stderr = string.Empty;
+            }
+
+            int? exitCode = timedOut ? null : process.ExitCode;
+            return new ToolProcessResult(commandLine, exitCode, timedOut, stdout, stderr);
+        }
+
+        private static string BuildCommandLine(string fileName, IReadOnlyList<string> arguments)
+        {
+            var builder = new StringBuilder(EscapeArgument(fileName));
+            foreach (var argument in arguments)
+            {
+                builder.Append(' ');
+                builder.Append(EscapeArgument(argument));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string EscapeArgument(string argument) =>
+            argument.Any(char.IsWhiteSpace) || argument.Contains('"', StringComparison.Ordinal)
+                ? "\"" + argument.Replace("\"", "\\\"", StringComparison.Ordinal) + "\""
+                : argument;
+    }
+
+    private sealed record ToolProcessResult(
+        string CommandLine,
+        int? ExitCode,
+        bool TimedOut,
+        string Stdout,
+        string Stderr)
+    {
+        public string AllText => Stdout + Environment.NewLine + Stderr;
+
+        public void AssertSucceeded(string message)
+        {
+            Assert.False(
+                TimedOut,
+                $"{message}{Environment.NewLine}Process timed out: {CommandLine}{Environment.NewLine}STDOUT:{Environment.NewLine}{Stdout}{Environment.NewLine}STDERR:{Environment.NewLine}{Stderr}");
+            Assert.True(
+                ExitCode == 0,
+                $"{message}{Environment.NewLine}Command: {CommandLine}{Environment.NewLine}Exit code: {ExitCode?.ToString(CultureInfo.InvariantCulture) ?? "<timeout>"}{Environment.NewLine}STDOUT:{Environment.NewLine}{Stdout}{Environment.NewLine}STDERR:{Environment.NewLine}{Stderr}");
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        private TempDirectory(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TempDirectory Create(string prefix)
+        {
+            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return new TempDirectory(path);
+        }
+
+        public TempDirectory CreateSubdirectory(string name)
+        {
+            var path = System.IO.Path.Combine(Path, name);
+            Directory.CreateDirectory(path);
+            return new TempDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ToolPackageContractTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ToolPackageContractTests.cs
@@ -24,6 +24,7 @@ public sealed class ToolPackageContractTests
         var toolDirectory = workspace.CreateSubdirectory("tool-path");
         var exportDirectory = workspace.CreateSubdirectory("export-output");
         var version = "0.0.0-toolverifier." + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+        var nugetPackagesDirectory = GetDefaultNuGetPackagesPath();
         var repositoryRunner = new ToolProcessRunner(
             repositoryRoot,
             new Dictionary<string, string?>
@@ -38,6 +39,8 @@ public sealed class ToolPackageContractTests
             new Dictionary<string, string?>
             {
                 ["DOTNET_CLI_HOME"] = cliHomeDirectory.Path,
+                // Keep package assets pointed at a stable cache while isolating .NET CLI first-run state.
+                ["NUGET_PACKAGES"] = nugetPackagesDirectory,
                 ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
                 ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
                 ["DOTNET_NOLOGO"] = "1",
@@ -114,7 +117,7 @@ public sealed class ToolPackageContractTests
             "examples",
             "razorwire-mvc",
             "RazorWireWebExample.csproj");
-        var exportResult = await repositoryRunner.RunAsync(
+        var exportResult = await isolatedToolRunner.RunAsync(
             installedToolPath,
             TimeSpan.FromMinutes(4),
             "export",
@@ -146,6 +149,18 @@ public sealed class ToolPackageContractTests
         throw new InvalidOperationException("Unable to find repository root from the current test assembly path.");
     }
 
+    private static string GetDefaultNuGetPackagesPath()
+    {
+        var configuredPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return configuredPath;
+        }
+
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(userProfile, ".nuget", "packages");
+    }
+
     private static void AssertToolPackageContract(string packagePath, string expectedVersion)
     {
         using var archive = ZipFile.OpenRead(packagePath);
@@ -166,9 +181,12 @@ public sealed class ToolPackageContractTests
         Assert.Equal("DotnetTool", packageType.Attribute("name")?.Value);
         Assert.Empty(nuspec.Descendants(ns + "dependencies"));
 
-        var settingsEntry = archive.GetEntry("tools/net10.0/any/DotnetToolSettings.xml");
-        Assert.NotNull(settingsEntry);
-        using var settingsStream = settingsEntry!.Open();
+        var settingsEntry = Assert.Single(
+            archive.Entries,
+            entry =>
+                entry.FullName.StartsWith("tools/", StringComparison.Ordinal)
+                && entry.FullName.EndsWith("/any/DotnetToolSettings.xml", StringComparison.Ordinal));
+        using var settingsStream = settingsEntry.Open();
         var settings = XDocument.Load(settingsStream);
         var command = Assert.Single(settings.Descendants("Command"));
         Assert.Equal(ToolCommandName, command.Attribute("Name")?.Value);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ToolPackageContractTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ToolPackageContractTests.cs
@@ -179,7 +179,7 @@ public sealed class ToolPackageContractTests
 
         var packageType = Assert.Single(nuspec.Descendants(ns + "packageType"));
         Assert.Equal("DotnetTool", packageType.Attribute("name")?.Value);
-        Assert.Empty(nuspec.Descendants(ns + "dependencies"));
+        Assert.Empty(nuspec.Descendants(ns + "dependency"));
 
         var settingsEntry = Assert.Single(
             archive.Entries,

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs
@@ -204,6 +204,8 @@ public sealed class ExportSourceResolver
             {
                 "publish",
                 projectPath,
+                // Captured CLI executions should not leave reusable build servers holding inherited pipes open.
+                "--disable-build-servers",
                 "-c",
                 "Release",
                 "-o",
@@ -547,6 +549,8 @@ public sealed class ExportSourceResolver
                 projectPath,
                 "-getProperty:AssemblyName",
                 "-nologo",
+                // Keep MSBuild property probes one-shot for the same reason as publish.
+                "-nodeReuse:false",
                 "-p:Configuration=Release"
             };
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ForgeTrust.Runnable.Web.RazorWire.Cli.csproj
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ForgeTrust.Runnable.Web.RazorWire.Cli.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>razorwire</ToolCommandName>
+    <PackageId>ForgeTrust.Runnable.Web.RazorWire.Cli</PackageId>
+    <PackageDescription>Command-line export tooling for RazorWire applications.</PackageDescription>
+    <PackageTags>runnable;razorwire;static-site;cli;dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md
@@ -69,6 +69,7 @@ Exports a RazorWire application to a static directory.
 - **`-u|--url <url>`**: Base URL of a running application used for crawling.
 - **`-p|--project <path.csproj>`**: Path to a .NET project to run automatically and export.
 - **`-d|--dll <path.dll>`**: Path to a .NET DLL to run automatically and export.
+- **`-f|--framework <TFM>`**: Target framework for project exports. Required when `--project` points at a multi-targeted project.
 - **`--app-args <token>`**: Repeatable app-argument token to pass through when launching `--project` or `--dll`.
 - **`--no-build`**: Project mode only. Skips the release publish step and reuses existing published output.
 
@@ -79,6 +80,7 @@ When launched app processes are started by the CLI (`--project` or `--dll`), the
 When `--project` is used:
 - Project mode publishes a release build by default.
 - The publish probe disables persistent build servers so command output capture cannot be held open by reused MSBuild nodes.
+- Multi-targeted projects must pass `-f|--framework <TFM>` to select the target framework, for example `-f net6.0` or `--framework net7.0`; omitting it causes a CLI error before publish. `-f|--framework` can be combined with `--project` and `--no-build` when reusing existing published output.
 - Project mode resolves the published app DLL and launches that DLL for crawling.
 - Add `--no-build` to skip publishing and reuse existing published output.
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md
@@ -6,11 +6,50 @@ The CLI uses Runnable's command-first console mode. That means help and validati
 
 ## Installation
 
-You can run the CLI directly using the `dotnet run` command from the project directory, or build it as a global tool.
+The RazorWire CLI is packaged as a .NET tool with the command name `razorwire`.
+Use an exact package version when running release builds so exports are reproducible.
+The commands in this section require `ForgeTrust.Runnable.Web.RazorWire.Cli` to
+exist on one of your configured NuGet sources, or for you to pass an explicit
+local package source. Public package publishing is still manual until the
+coordinated release automation tracked in #161 lands.
+
+Run a published package without permanently installing it:
+
+```bash
+dnx ForgeTrust.Runnable.Web.RazorWire.Cli@<version> --yes -- export -o ./dist -p ./examples/razorwire-mvc/RazorWireWebExample.csproj
+```
+
+The equivalent SDK spelling is:
+
+```bash
+dotnet tool execute ForgeTrust.Runnable.Web.RazorWire.Cli@<version> --yes -- export -o ./dist -p ./examples/razorwire-mvc/RazorWireWebExample.csproj
+```
+
+Install the tool when you want a stable `razorwire` command on your PATH:
+
+```bash
+dotnet tool install --global ForgeTrust.Runnable.Web.RazorWire.Cli --version <version>
+razorwire export -o ./dist -p ./examples/razorwire-mvc/RazorWireWebExample.csproj
+```
+
+During repository development, run the CLI directly from source:
 
 ```bash
 dotnet run --project Web/ForgeTrust.Runnable.Web.RazorWire.Cli -- [command] [options]
 ```
+
+When testing an unpublished package from a local folder, pack it first, pass that
+folder as the package source, and keep the version exact:
+
+```bash
+dotnet pack Web/ForgeTrust.Runnable.Web.RazorWire.Cli -c Release -o ./artifacts/packages /p:PackageVersion=0.0.0-local.1
+```
+
+```bash
+dnx ForgeTrust.Runnable.Web.RazorWire.Cli@0.0.0-local.1 --yes --source ./artifacts/packages -- --help
+```
+
+Do not combine `--version` and `--prerelease` for exact tool installs on recent SDKs; exact prerelease versions install without the extra flag.
 
 ## Commands
 
@@ -39,6 +78,7 @@ When launched app processes are started by the CLI (`--project` or `--dll`), the
 
 When `--project` is used:
 - Project mode publishes a release build by default.
+- The publish probe disables persistent build servers so command output capture cannot be held open by reused MSBuild nodes.
 - Project mode resolves the published app DLL and launches that DLL for crawling.
 - Add `--no-build` to skip publishing and reuse existing published output.
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/RazorWireCliApp.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/RazorWireCliApp.cs
@@ -1,25 +1,85 @@
+using CliFx;
 using ForgeTrust.Runnable.Console;
 using ForgeTrust.Runnable.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.Runnable.Web.RazorWire.Cli;
 
 /// <summary>
-/// Provides the RazorWire CLI entry surface with the command-first console defaults required for public CLI flows.
+/// Provides the RazorWire CLI entry surface with the command-first console behavior required for public tool flows.
 /// </summary>
 internal static class RazorWireCliApp
 {
     /// <summary>
-    /// Runs the RazorWire CLI with command-first console behavior while still allowing targeted startup customization.
+    /// Runs the RazorWire CLI directly through the command service while still allowing targeted startup customization.
     /// </summary>
     /// <param name="args">Command-line arguments supplied to the CLI.</param>
-    /// <param name="configureOptions">Optional console startup customization applied after RazorWire's command-first defaults.</param>
-    /// <returns>A task that completes when the CLI host finishes running.</returns>
-    internal static Task RunAsync(string[] args, Action<ConsoleOptions>? configureOptions = null) =>
-        ConsoleApp<RazorWireCliModule>.RunAsync(
-            args,
-            options =>
-            {
-                options.OutputMode = ConsoleOutputMode.CommandFirst;
-                configureOptions?.Invoke(options);
-            });
+    /// <param name="configureOptions">Optional console startup customization applied after RazorWire's defaults.</param>
+    /// <returns>A task that completes when the CLI command finishes running.</returns>
+    /// <remarks>
+    /// Public command-line tool entry points need predictable command output for help, validation errors, and export
+    /// progress. Running the command service directly keeps those flows independent from the Generic Host lifecycle while
+    /// preserving Runnable's command registration, dependency injection, and unknown-option suggestions.
+    /// </remarks>
+    internal static async Task RunAsync(string[] args, Action<ConsoleOptions>? configureOptions = null)
+    {
+        var options = ConsoleOptions.Default with
+        {
+            OutputMode = ConsoleOutputMode.CommandFirst
+        };
+        configureOptions?.Invoke(options);
+
+        var module = new RazorWireCliModule();
+        var context = new StartupContext(args, module)
+        {
+            ConsoleOutputMode = options.OutputMode
+        };
+
+        var commandTypes = GetCommandTypes(context.EntryPointAssembly).ToArray();
+        var services = new ServiceCollection();
+        services.AddSingleton(context);
+        services.AddSingleton(context.EnvironmentProvider);
+        services.AddSingleton<IOptionSuggester, LevenshteinOptionSuggester>();
+        services.AddLogging(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        foreach (var commandType in commandTypes)
+        {
+            services.AddTransient(typeof(ICommand), commandType);
+            services.AddTransient(commandType);
+        }
+
+        module.ConfigureServices(context, services);
+        foreach (var customRegistration in options.CustomRegistrations)
+        {
+            customRegistration(services);
+        }
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var commands = commandTypes
+            .Select(commandType => (ICommand)serviceProvider.GetRequiredService(commandType))
+            .ToArray();
+        var suggester = serviceProvider.GetRequiredService<IOptionSuggester>();
+        var commandService = new CommandService(commands, context, suggester);
+        var previousServiceProvider = CommandService.PrimaryServiceProvider;
+
+        try
+        {
+            CommandService.PrimaryServiceProvider = serviceProvider;
+            await commandService.RunInternalAsync(CancellationToken.None);
+        }
+        finally
+        {
+            CommandService.PrimaryServiceProvider = previousServiceProvider;
+        }
+    }
+
+    private static IEnumerable<Type> GetCommandTypes(System.Reflection.Assembly assembly) =>
+        assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract && typeof(ICommand).IsAssignableFrom(type));
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire/README.md
@@ -248,7 +248,14 @@ RazorWire also supports hybrid islands where a server-rendered region mounts a c
 
 ## Static Export
 
-RazorWire can generate static or hybrid sites. For more details, see the [RazorWire CLI](../../Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md).
+RazorWire can generate static or hybrid sites with the installable `razorwire`
+.NET tool, or with the short-lived `dnx` tool execution path. Those
+package-based commands require a published package or an explicit local package
+source; public package publishing is still manual until the coordinated release
+automation tracked in #161 lands.
+
+For installation, `dnx`, local-package, and source-run examples, see the
+[RazorWire CLI](../../Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md).
 
 ## Examples
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -31,6 +31,8 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Runnable console apps can now opt into a command-first output contract so public CLI help and validation flows stay quiet instead of printing Generic Host lifecycle chatter.
 - RazorWire CLI now uses that contract for `--help`, `export --help`, invalid option output, and missing-source validation while still preserving command-owned export progress logs.
 - The shared console startup seam now exposes `ConsoleOptions` and `ConsoleOutputMode`, so future public Runnable CLIs can adopt the same behavior without forking startup logic.
+- RazorWire CLI now has a first-class .NET tool package contract with the `razorwire` command, supports exact-version `dnx` execution from published or explicit local package sources, and verifies the installed tool path through help and sample export smoke tests. Public package publishing remains manual until the coordinated release automation tracked in #161 lands.
+- Project exports now disable persistent MSBuild build servers during CLI-controlled publish and assembly-name probes so captured tool output cannot hang on reused build nodes.
 
 ### Web host development defaults
 


### PR DESCRIPTION
## Summary
- Package the RazorWire CLI as a .NET tool with the `razorwire` command.
- Run the tool entrypoint directly through the command service so help, validation, dnx, and installed-tool flows stay command-first.
- Add package contract coverage for local pack, dnx, tool install, installed help, and installed sample export.
- Document published-vs-local package source expectations while public package publishing remains manual until #161.

## Verification
- `git diff --check`
- `dotnet build --configuration Release` (passed; emitted NU1900 audit warnings when NuGet vulnerability data could not be fetched)
- `dotnet test --configuration Release --no-build --verbosity normal`
- `dotnet format --verify-no-changes --no-restore --include Web/ForgeTrust.Runnable.Web.RazorWire.Cli/RazorWireCliApp.cs Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportSourceResolver.cs Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ToolPackageContractTests.cs Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportSourceResolverTests.cs Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportEngineTests.cs`

Fixes #171