### PR TITLE
fix(cli): rename RazorWire seed route option

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportCommandTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportCommandTests.cs
@@ -84,7 +84,28 @@ public class ExportCommandTests
         }
     }
 
-    private static ExportCommand CreateCommand(string? url, string? project, string? dll, string outputPath = "dist")
+    [Fact]
+    public async Task ExecuteAsync_Should_Use_SeedRoutesPath()
+    {
+        var missingSeedFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "seeds.txt");
+        var command = CreateCommand(
+            "http://localhost:5001",
+            null,
+            null,
+            seedRoutesPath: missingSeedFile);
+
+        var ex = await Assert.ThrowsAsync<FileNotFoundException>(
+            async () => await command.ExecuteAsync(A.Fake<IConsole>()));
+
+        Assert.Equal(missingSeedFile, ex.FileName);
+    }
+
+    private static ExportCommand CreateCommand(
+        string? url,
+        string? project,
+        string? dll,
+        string outputPath = "dist",
+        string? seedRoutesPath = null)
     {
         var logger = A.Fake<ILogger<ExportCommand>>();
         var engineLogger = A.Fake<ILogger<ExportEngine>>();
@@ -103,7 +124,8 @@ public class ExportCommandTests
             OutputPath = outputPath,
             BaseUrl = url,
             ProjectPath = project,
-            DllPath = dll
+            DllPath = dll,
+            SeedRoutesPath = seedRoutesPath
         };
     }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ProgramEntryPointTests.cs
@@ -67,6 +67,27 @@ public class ProgramEntryPointTests
     }
 
     [Fact]
+    public async Task EntryPoint_Should_Accept_Seeds_Option()
+    {
+        var missingSeedFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "missing-file.txt");
+
+        var result = await InvokeEntryPointAsync(
+            ["export", "--seeds", missingSeedFile, "--url", "http://localhost:5001"],
+            options =>
+            {
+                options.CustomRegistrations.Add(services =>
+                {
+                    services.AddSingleton<IHttpClientFactory>(
+                        new TestHttpHelpers.Factory(TestHttpHelpers.UrlAwareHtmlRoot("http://localhost:5001")));
+                });
+            });
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(missingSeedFile, result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Unrecognized option", result.AllText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task EntryPoint_Should_Print_Missing_Source_Validation_Without_Lifecycle_Noise()
     {
         var result = await InvokeEntryPointAsync(["export"]);

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ProgramEntryPointTests.cs
@@ -31,6 +31,8 @@ public class ProgramEntryPointTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("Export a RazorWire site to a static directory.", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("--seeds", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("--routes", result.AllText, StringComparison.Ordinal);
         Assert.DoesNotContain("Initializing Critical Service", result.AllText, StringComparison.Ordinal);
         Assert.DoesNotContain("Stopping Critical Service", result.AllText, StringComparison.Ordinal);
         Assert.DoesNotContain("Application started", result.AllText, StringComparison.Ordinal);
@@ -52,6 +54,16 @@ public class ProgramEntryPointTests
         Assert.DoesNotContain("Application is shutting down", result.AllText, StringComparison.Ordinal);
         Assert.DoesNotContain("Hosting environment", result.AllText, StringComparison.Ordinal);
         Assert.DoesNotContain("Run Exited - Shutting down", result.AllText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task EntryPoint_Should_Reject_Routes_Option()
+    {
+        var result = await InvokeEntryPointAsync(["export", "--routes", "seeds.txt", "--url", "http://localhost:5001"]);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("--routes", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("Unrecognized option", result.AllText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
@@ -20,8 +20,16 @@ public class ExportCommand : ICommand
     public string OutputPath { get; init; } = "dist";
 
     /// <summary>
-    /// Gets or sets an optional path to a file containing initial seed routes for the exporter.
+    /// Gets or sets an optional path to a plain-text file containing one initial seed route per line.
     /// </summary>
+    /// <remarks>
+    /// This property is bound from the <c>-r|--seeds</c> command option. When it is <see langword="null"/>
+    /// or empty, the exporter starts from the root route (<c>/</c>). When it points to a file, the exporter
+    /// reads each line, accepts root-relative routes and absolute HTTP(S) URLs, strips query strings and
+    /// fragments during normalization, and skips invalid, external, hash-only, JavaScript, or mailto entries.
+    /// If the file is missing or unreadable, export fails and returns a non-zero CLI exit code. If the file is
+    /// readable but contains no valid routes, the exporter logs a warning and falls back to the root route.
+    /// </remarks>
     [CommandOption("seeds", 'r', Description = "Path to a file containing seed routes.")]
     public string? SeedRoutesPath { get; init; }
 

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs
@@ -22,7 +22,7 @@ public class ExportCommand : ICommand
     /// <summary>
     /// Gets or sets an optional path to a file containing initial seed routes for the exporter.
     /// </summary>
-    [CommandOption("routes", 'r', Description = "Path to a file containing seed routes.")]
+    [CommandOption("seeds", 'r', Description = "Path to a file containing seed routes.")]
     public string? SeedRoutesPath { get; init; }
 
     /// <summary>

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Cli/README.md
@@ -26,7 +26,7 @@ Exports a RazorWire application to a static directory.
 
 **Options:**
 - **`-o|--output <path>`**: Output directory where the static files will be saved (default: `dist`).
-- **`-r|--routes <path>`**: Optional path to a file containing seed routes to crawl.
+- **`-r|--seeds <path>`**: Optional path to a file containing seed routes to crawl.
 - **`-u|--url <url>`**: Base URL of a running application used for crawling.
 - **`-p|--project <path.csproj>`**: Path to a .NET project to run automatically and export.
 - **`-d|--dll <path.dll>`**: Path to a .NET DLL to run automatically and export.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -30,6 +30,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 
 - Runnable console apps can now opt into a command-first output contract so public CLI help and validation flows stay quiet instead of printing Generic Host lifecycle chatter.
 - RazorWire CLI now uses that contract for `--help`, `export --help`, invalid option output, and missing-source validation while still preserving command-owned export progress logs.
+- RazorWire CLI now names export seed-route files with `-r|--seeds`, matching the seed terminology used throughout the exporter and docs.
 - The shared console startup seam now exposes `ConsoleOptions` and `ConsoleOutputMode`, so future public Runnable CLIs can adopt the same behavior without forking startup logic.
 
 ### Web host development defaults


### PR DESCRIPTION
## Summary

- Rename the RazorWire export seed route option from `--routes` to `--seeds` while keeping `-r`.
- Update the RazorWire CLI README to document the new option name.
- Add coverage for help text, rejected `--routes`, and seed route path execution.

Fixes #42

## Validation

- `dotnet format ForgeTrust.Runnable.slnx --include Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ExportCommand.cs Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ExportCommandTests.cs Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ProgramEntryPointTests.cs`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests.csproj`
- `git diff --check`
- CLI smoke checks for `export --help` and rejected `export --routes ...`