### PR TITLE
docs: add contributor feedback issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,13 @@
 name: Bug report
 description: Report a reproducible problem in Runnable packages, examples, docs, or tooling.
-title: "fix: "
+title: "bug: "
 labels:
   - bug
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a problem. Concrete reproduction steps help us decide whether the fix belongs in a package, an example, the docs, or a release note.
+        Thanks for reporting a problem. Concrete reproduction steps help us decide whether the fix belongs in a package, an example, the docs, or a release note. Do not use this public form for suspected vulnerabilities; use the private security path in SECURITY.md instead.
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,8 +68,10 @@ body:
     id: logs
     attributes:
       label: Logs or screenshots
-      description: Paste relevant output, stack traces, screenshots, or links to failing runs.
+      description: Paste relevant output, stack traces, screenshots, or links to failing runs. If none are available, say so.
       render: shell
+    validations:
+      required: true
   - type: checkboxes
     id: checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a reproducible problem in Runnable packages, examples, docs, or tooling.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Concrete reproduction steps help us decide whether the fix belongs in a package, an example, the docs, or a release note.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the unexpected behavior and what you expected instead.
+      placeholder: "I expected ..., but ..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Include commands, code snippets, request paths, or sample app steps.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Pick the closest package or repo surface.
+      options:
+        - Core startup pipeline
+        - Console
+        - Web
+        - RazorWire
+        - RazorDocs
+        - Caching
+        - Config
+        - Dependency injection
+        - Aspire
+        - Examples
+        - Documentation
+        - Release tooling
+        - Unsure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Runnable version or commit
+      description: Use a package version, tag, branch name, or commit SHA.
+      placeholder: "v0.1.0, main@abcdef0, or package version"
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, .NET SDK version, hosting target, browser, or CI runner when relevant.
+      placeholder: |
+        - OS:
+        - dotnet --version:
+        - Browser:
+        - Host/CI:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant output, stack traces, screenshots, or links to failing runs.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Filing checklist
+      options:
+        - label: I included the smallest reproduction I can provide.
+          required: true
+        - label: I checked whether the behavior is already described in the package README or release notes.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Runnable contribution guide
+    url: https://github.com/forge-trust/Runnable/blob/main/CONTRIBUTING.md
+    about: Read how to file focused feedback, propose docs changes, and prepare pull requests.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Runnable contribution guide
     url: https://github.com/forge-trust/Runnable/blob/main/CONTRIBUTING.md

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Private vulnerability report
+    url: https://github.com/forge-trust/Runnable/blob/main/SECURITY.md
+    about: Report suspected vulnerabilities privately instead of opening a public issue.
   - name: Runnable contribution guide
     url: https://github.com/forge-trust/Runnable/blob/main/CONTRIBUTING.md
     about: Read how to file focused feedback, propose docs changes, and prepare pull requests.

--- a/.github/ISSUE_TEMPLATE/docs_dx_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs_dx_feedback.yml
@@ -71,3 +71,5 @@ body:
         - label: This blocked me from completing the task.
         - label: This made me uncertain whether I was using the supported path.
         - label: This affected an example, quickstart, or first-run flow.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/docs_dx_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs_dx_feedback.yml
@@ -1,13 +1,13 @@
 name: Docs or developer experience feedback
 description: Report onboarding friction, confusing documentation, broken examples, or missing guidance.
-title: "docs: "
+title: "dx: "
 labels:
   - documentation
 body:
   - type: markdown
     attributes:
       value: |
-        Use this when the product may be working, but the path to understanding or adopting it was confusing. Specific moments of friction are the most useful signal.
+        Use this when the product may be working, but the path to understanding or adopting it was confusing. Specific moments of friction are the most useful signal. Do not use this public form for suspected vulnerabilities; use the private security path in SECURITY.md instead.
   - type: textarea
     id: goal
     attributes:
@@ -71,5 +71,6 @@ body:
         - label: This blocked me from completing the task.
         - label: This made me uncertain whether I was using the supported path.
         - label: This affected an example, quickstart, or first-run flow.
+        - label: This is a smaller docs or DX improvement that did not block a task.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/docs_dx_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs_dx_feedback.yml
@@ -1,0 +1,73 @@
+name: Docs or developer experience feedback
+description: Report onboarding friction, confusing documentation, broken examples, or missing guidance.
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the product may be working, but the path to understanding or adopting it was confusing. Specific moments of friction are the most useful signal.
+  - type: textarea
+    id: goal
+    attributes:
+      label: What were you trying to do?
+      description: Describe the task, decision, or question that brought you to the docs or example.
+      placeholder: "I was trying to ..."
+    validations:
+      required: true
+  - type: textarea
+    id: friction
+    attributes:
+      label: Where did you get stuck?
+      description: Include the exact page, section, command, example, or API that caused friction.
+      placeholder: "The confusing part was ..."
+    validations:
+      required: true
+  - type: input
+    id: entry-point
+    attributes:
+      label: Entry point
+      description: Link the README, docs page, package page, example, or search result where you started.
+      placeholder: "README.md, Web/.../README.md, /docs/..., NuGet, search result, etc."
+    validations:
+      required: true
+  - type: dropdown
+    id: feedback-type
+    attributes:
+      label: Feedback type
+      options:
+        - Onboarding or first run
+        - Missing concept explanation
+        - Broken command or example
+        - Link, anchor, or navigation issue
+        - API usage guidance
+        - Release or migration guidance
+        - Accessibility or readability
+        - Other docs friction
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What would have helped?
+      description: Name the explanation, example, command output, warning, or page you expected.
+      placeholder: "It would have helped if ..."
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Include package versions, .NET SDK version, browser, host app shape, or prior framework experience when relevant.
+      placeholder: |
+        - dotnet --version:
+        - Package/example:
+        - App type:
+        - Prior context:
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - label: This blocked me from completing the task.
+        - label: This made me uncertain whether I was using the supported path.
+        - label: This affected an example, quickstart, or first-run flow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Runnable is putting its release contract in place before the first tagged versio
 ## Feedback path
 
 Runnable treats docs and onboarding feedback as product input, not as a second-class support queue. File issues when a package, example, README, or release note leaves you unable to reproduce the intended path.
+For quick access, use GitHub's issue template chooser: [choose an issue template](https://github.com/forge-trust/Runnable/issues/new/choose).
 
 - Use the **Bug report** issue form when behavior is broken or surprising.
 - Use the **Docs or developer experience feedback** issue form when the code may work, but the route to understanding it is unclear.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,28 @@
 
 Runnable is putting its release contract in place before the first tagged version. This file explains the contribution rules that feed the public release surface.
 
+## Feedback path
+
+Runnable treats docs and onboarding feedback as product input, not as a second-class support queue. File issues when a package, example, README, or release note leaves you unable to reproduce the intended path.
+
+- Use the **Bug report** issue form when behavior is broken or surprising.
+- Use the **Docs or developer experience feedback** issue form when the code may work, but the route to understanding it is unclear.
+- Include the command, page, example, package, or API where the confusion started. The sharpest reports name the exact step that failed and the next thing you expected to see.
+- If you are unsure whether something is a bug or a docs gap, file the docs/DX form and explain the behavior you expected.
+
+Avoid broad requests such as "improve the docs" without a concrete page, task, or decision point. Narrow feedback is easier to verify and much more likely to turn into a useful change.
+
+## Working on docs
+
+Documentation changes should explain both how to use an API and why a reader would choose it. When a docs change touches public behavior, update the package-level README, repository-level entry point, or release note surface that helps someone discover the change.
+
+Good docs pull requests usually include:
+
+- Reference content for API shape, defaults, constraints, and examples.
+- Decision guidance that explains when to use the API and when another approach fits better.
+- Pitfalls that call out ordering requirements, generated output, hosting assumptions, or common mistakes.
+- Verification notes for commands, links, snippets, or examples that were checked.
+
 ## Release contract
 
 - Runnable releases the monorepo in unison. Packages, CLI tooling, examples, and docs-facing behavior all roll into the same next version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ For quick access, use GitHub's issue template chooser: [choose an issue template
 
 - Use the [**Bug report** issue form](https://github.com/forge-trust/Runnable/issues/new?template=bug_report.yml) when behavior is broken or surprising.
 - Use the [**Docs or developer experience feedback** issue form](https://github.com/forge-trust/Runnable/issues/new?template=docs_dx_feedback.yml) when the code may work, but the route to understanding it is unclear.
+- Do not use public issue forms for suspected vulnerabilities, leaked secrets, or exploit details. Use the [security policy](./SECURITY.md) and report sensitive findings privately.
 - Include the command, page, example, package, or API where the confusion started. The sharpest reports name the exact step that failed and the next thing you expected to see.
 - If you are unsure whether something is a bug or a docs gap, file the docs/DX form and explain the behavior you expected.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Runnable is putting its release contract in place before the first tagged versio
 Runnable treats docs and onboarding feedback as product input, not as a second-class support queue. File issues when a package, example, README, or release note leaves you unable to reproduce the intended path.
 For quick access, use GitHub's issue template chooser: [choose an issue template](https://github.com/forge-trust/Runnable/issues/new/choose).
 
-- Use the **Bug report** issue form when behavior is broken or surprising.
-- Use the **Docs or developer experience feedback** issue form when the code may work, but the route to understanding it is unclear.
+- Use the [**Bug report** issue form](https://github.com/forge-trust/Runnable/issues/new?template=bug_report.yml) when behavior is broken or surprising.
+- Use the [**Docs or developer experience feedback** issue form](https://github.com/forge-trust/Runnable/issues/new?template=docs_dx_feedback.yml) when the code may work, but the route to understanding it is unclear.
 - Include the command, page, example, package, or API where the confusion started. The sharpest reports name the exact step that failed and the next thing you expected to see.
 - If you are unsure whether something is a bug or a docs gap, file the docs/DX form and explain the behavior you expected.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Runnable is preparing to release the entire monorepo in unison. The public relea
 
 ## Feedback and contributing
 
-Runnable uses GitHub issue forms to keep bug reports and docs/developer-experience feedback concrete enough to reproduce. If an example, README, quickstart, or package API leaves you stuck, start with the [contribution guide](./CONTRIBUTING.md) and file the issue form that matches the problem.
+Runnable uses GitHub issue forms to keep bug reports and docs/developer-experience feedback concrete enough to reproduce. If an example, README, quickstart, or package API leaves you stuck, start with the [contribution guide](./CONTRIBUTING.md), [choose an issue template](https://github.com/forge-trust/Runnable/issues/new/choose), and file the form that matches the problem.
 
 Use docs/DX feedback for confusing guidance, missing concepts, broken links, snippet drift, or first-run friction. Use bug reports when runtime behavior, generated output, or package APIs do something unexpected.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Runnable is preparing to release the entire monorepo in unison. The public relea
 Runnable uses GitHub issue forms to keep bug reports and docs/developer-experience feedback concrete enough to reproduce. If an example, README, quickstart, or package API leaves you stuck, start with the [contribution guide](./CONTRIBUTING.md), [choose an issue template](https://github.com/forge-trust/Runnable/issues/new/choose), and file the form that matches the problem.
 
 Use docs/DX feedback for confusing guidance, missing concepts, broken links, snippet drift, or first-run friction. Use bug reports when runtime behavior, generated output, or package APIs do something unexpected.
+Do not file suspected vulnerabilities, leaked secrets, or exploit details in public issues; follow the [security policy](./SECURITY.md) instead.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Runnable is preparing to release the entire monorepo in unison. The public relea
 - [Pre-1.0 upgrade policy](./releases/upgrade-policy.md) - the stability and migration contract before `v1.0.0`.
 - [Contribution and release entry rules](./CONTRIBUTING.md) - how PR titles and unreleased entries feed the release surface.
 
+## Feedback and contributing
+
+Runnable uses GitHub issue forms to keep bug reports and docs/developer-experience feedback concrete enough to reproduce. If an example, README, quickstart, or package API leaves you stuck, start with the [contribution guide](./CONTRIBUTING.md) and file the issue form that matches the problem.
+
+Use docs/DX feedback for confusing guidance, missing concepts, broken links, snippet drift, or first-run friction. Use bug reports when runtime behavior, generated output, or package APIs do something unexpected.
+
 ## Examples
 
 The [examples](examples) directory contains sample applications that demonstrate

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Do not open a public GitHub issue for suspected vulnerabilities, leaked secrets,
 
 Use GitHub's private security advisory flow instead: [report a vulnerability privately](https://github.com/forge-trust/Runnable/security/advisories/new).
 
-If GitHub does not show the private reporting form for your account, contact a maintainer through an existing trusted channel and ask for a private disclosure path before sharing technical details.
+If GitHub does not show the private reporting form for your account, open a public issue titled `security contact request` with no vulnerability details and ask a maintainer for a private disclosure channel. Include only non-sensitive routing context, such as the affected package name, when that information is safe to share publicly.
 
 ## What to include
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+Runnable is pre-`v1.0.0`, but security reports still need a private path.
+
+## Reporting a vulnerability
+
+Do not open a public GitHub issue for suspected vulnerabilities, leaked secrets, exploit details, or reports that include sensitive deployment information.
+
+Use GitHub's private security advisory flow instead: [report a vulnerability privately](https://github.com/forge-trust/Runnable/security/advisories/new).
+
+If GitHub does not show the private reporting form for your account, contact a maintainer through an existing trusted channel and ask for a private disclosure path before sharing technical details.
+
+## What to include
+
+- The affected package, example, tool, or documentation surface.
+- The smallest reproduction you can safely share.
+- The potential impact and any known preconditions.
+- Whether the issue is already public or actively exploited.
+
+## Public issue forms
+
+The bug and docs/developer-experience issue forms are for non-sensitive reports only. Maintainers may move public issues into a private disclosure flow if a report contains security-sensitive details.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -25,6 +25,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Pull request titles are now expected to follow Conventional Commits so the merge history is machine-readable for future automation.
 - Pull requests are expected to update this page unless maintainers explicitly mark the change as outside the public release story.
 - Markdown-only changes on `main` now republish the docs surface, so release-note and policy edits are treated as first-class product updates.
+- Runnable now exposes focused GitHub issue forms for bug reports and docs/developer-experience feedback, with the root README and contribution guide pointing developers to that feedback path.
 
 ### Console and CLI polish
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -26,6 +26,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Pull requests are expected to update this page unless maintainers explicitly mark the change as outside the public release story.
 - Markdown-only changes on `main` now republish the docs surface, so release-note and policy edits are treated as first-class product updates.
 - Runnable now exposes focused GitHub issue forms for bug reports and docs/developer-experience feedback, with the root README and contribution guide pointing developers to that feedback path.
+- Public contribution surfaces now steer suspected vulnerabilities away from issue forms and into a private security reporting path.
 
 ### Console and CLI polish
 


### PR DESCRIPTION
## Summary

- add GitHub issue forms for bug reports and docs/developer-experience feedback
- document the feedback path in the root contribution guide and README
- record the contribution-surface change in the unreleased notes

Fixes #135

## Validation

- ruby YAML parse for .github/ISSUE_TEMPLATE/*.yml
- dotnet build
- dotnet test --no-build