### PR TITLE
ci: enable docs provenance export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
@@ -79,6 +81,11 @@ jobs:
           dotnet build Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ForgeTrust.Runnable.Web.RazorWire.Cli.csproj -c Release
 
       - name: Export RazorDocs static site
+        env:
+          RazorDocs__Contributor__DefaultBranch: ${{ github.ref_name }}
+          RazorDocs__Contributor__SourceUrlTemplate: https://github.com/${{ github.repository }}/blob/{branch}/{path}
+          RazorDocs__Contributor__EditUrlTemplate: https://github.com/${{ github.repository }}/edit/{branch}/{path}
+          RazorDocs__Contributor__LastUpdatedMode: Git
         run: |
           dotnet run --project Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ForgeTrust.Runnable.Web.RazorWire.Cli.csproj -c Release -- \
             export \

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -59,6 +59,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - The release contract is designed so future tooling can generate both a changelog entry and a blog-style tagged release note from the same underlying signals.
 - RazorDocs now rewrites authored doc links from a harvested target manifest instead of broad suffix heuristics, so normal site links such as `../privacy.html` stay untouched and missing doc targets do not become broken `/docs/...` routes.
 - RazorDocs details pages can now render a `Source of truth` strip with `View source`, `Edit this page`, and relative `Last updated` evidence driven by contributor metadata, configured URL templates, and git freshness when available.
+- The primary RazorDocs Pages deployment now exports with contributor provenance configured and full git history available, so the public docs artifact can show the same `Source of truth` strip as local smoke tests.
 - Contributor provenance now degrades safely: namespace and API pages stay explicit-override-only for the MVP, and missing or slow git history omits only freshness instead of breaking docs rendering.
 - Shared RazorDocs badges, metadata chips, provenance strips, and trust bars now live in the shared package stylesheet while `search.css` stays focused on search-specific UI.
 


### PR DESCRIPTION
## Summary

- Configure the RazorDocs Pages export job with contributor provenance settings so Markdown detail pages can render the `Source of truth` strip.
- Fetch full git history for the export checkout so `Last updated` can resolve from git in CI.

## Root Cause

The primary docs deployment runs the standalone RazorDocs host during static export, but the workflow did not provide `RazorDocs:Contributor` settings. RazorDocs intentionally omits the provenance strip when it has no trustworthy source, edit, or freshness evidence.

## Validation

- `dotnet build Web/ForgeTrust.Runnable.Web.RazorWire.Cli/ForgeTrust.Runnable.Web.RazorWire.Cli.csproj -c Release`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj -c Release --filter "FullyQualifiedName~Contributor"`
- workflow YAML parse check

## Notes

A full local static export did not complete in a useful window, so the final deployment proof will be the next GitHub Pages artifact from `main`.