### PR TITLE
feat(core): add explicit static utility logging

### DIFF
--- a/ForgeTrust.Runnable.Core.Tests/EnumerableExtensionsTests.cs
+++ b/ForgeTrust.Runnable.Core.Tests/EnumerableExtensionsTests.cs
@@ -1,4 +1,5 @@
 using ForgeTrust.Runnable.Core.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.Runnable.Core.Tests;
 
@@ -234,6 +235,37 @@ public class EnumerableExtensionsTests
     }
 
     [Fact]
+    public async Task ParallelSelectAsync_CancellationToken_DoesNotLogCleanupFailure_WhenLoggerProvided()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 100);
+        using var cts = new CancellationTokenSource();
+        var logger = new TestLogger();
+        var processedCount = 0;
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await input.ParallelSelectAsync(
+                async (x, ct) =>
+                {
+                    if (Interlocked.Increment(ref processedCount) >= 5)
+                    {
+                        await cts.CancelAsync();
+                    }
+
+                    await Task.Delay(50, ct);
+                    return x;
+                },
+                maxDegreeOfParallelism: 2,
+                cancellationToken: cts.Token,
+                logger: logger);
+        });
+
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
     public async Task ParallelSelectAsync_BodyThrowsException_PropagatesException()
     {
         // Arrange
@@ -254,6 +286,76 @@ public class EnumerableExtensionsTests
                 },
                 maxDegreeOfParallelism: 3);
         });
+    }
+
+    [Fact]
+    public async Task ParallelSelectAsync_BodyThrowsException_LogsSuppressedCleanupFailure_WhenLoggerProvided()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 5);
+        var logger = new TestLogger();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await input.ParallelSelectAsync(
+                async (x, ct) =>
+                {
+                    await Task.Delay(10, ct);
+                    if (x == 2)
+                    {
+                        throw new InvalidOperationException("Primary failure");
+                    }
+
+                    return x;
+                },
+                maxDegreeOfParallelism: 2,
+                cancellationToken: CancellationToken.None,
+                logger: logger);
+        });
+
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Level == LogLevel.Debug
+                && entry.EventId.Id == 1102
+                && entry.Exception is InvalidOperationException
+                && entry.Message.Contains("suppressed task cleanup failures", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ParallelSelectAsync_WithLoggerOverload_ThrowsWhenLoggerIsNull()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 5);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+        {
+            await input.ParallelSelectAsync(
+                async (x, ct) => await Task.FromResult(x),
+                maxDegreeOfParallelism: 2,
+                cancellationToken: CancellationToken.None,
+                logger: null!);
+        });
+    }
+
+    [Fact]
+    public async Task ParallelSelectAsync_WithLoggerOverload_ReturnsResults_WhenSuccessful()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 5);
+        var logger = new TestLogger();
+
+        // Act
+        var results = await input.ParallelSelectAsync(
+            async (x, ct) => await Task.FromResult(x * 2),
+            maxDegreeOfParallelism: 2,
+            cancellationToken: CancellationToken.None,
+            logger: logger);
+
+        // Assert
+        Assert.Equal(new[] { 2, 4, 6, 8, 10 }, results);
+        Assert.Empty(logger.Entries);
     }
 
     [Fact]
@@ -463,6 +565,46 @@ public class EnumerableExtensionsTests
     }
 
     [Fact]
+    public async Task ParallelSelectAsyncEnumerable_Cancellation_DoesNotLogCleanupFailure_WhenLoggerProvided()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 50);
+        using var cts = new CancellationTokenSource();
+        var logger = new TestLogger();
+        var results = new List<int>();
+
+        // Act
+        try
+        {
+            await foreach (var item in input.ParallelSelectAsyncEnumerable(
+                               async (x, ct) =>
+                               {
+                                   await Task.Delay(20, ct);
+                                   return x;
+                               },
+                               maxDegreeOfParallelism: 3,
+                               bufferMultiplier: 4,
+                               cancellationToken: cts.Token,
+                               logger: logger))
+            {
+                results.Add(item);
+                if (results.Count >= 5)
+                {
+                    await cts.CancelAsync();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        // Assert
+        Assert.True(results.Count < 50);
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
     public async Task ParallelSelectAsyncEnumerable_CustomBufferMultiplier_Works()
     {
         // Arrange
@@ -539,6 +681,83 @@ public class EnumerableExtensionsTests
     }
 
     [Fact]
+    public async Task ParallelSelectAsyncEnumerable_BodyThrowsException_LogsSuppressedCleanupFailure_WhenLoggerProvided()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 5);
+        var logger = new TestLogger();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in input.ParallelSelectAsyncEnumerable(
+                               async (x, ct) =>
+                               {
+                                   await Task.Delay(10, ct);
+                                   if (x == 2)
+                                   {
+                                       throw new InvalidOperationException("Primary failure");
+                                   }
+
+                                   return x;
+                               },
+                               maxDegreeOfParallelism: 2,
+                               bufferMultiplier: 4,
+                               cancellationToken: CancellationToken.None,
+                               logger: logger))
+            {
+            }
+        });
+
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Level == LogLevel.Debug
+                && entry.EventId.Id == 1105
+                && entry.Exception is InvalidOperationException
+                && entry.Message.Contains("suppressed task cleanup failures", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ParallelSelectAsyncEnumerable_WithLoggerOverload_ThrowsWhenLoggerIsNull()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 5);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            input.ParallelSelectAsyncEnumerable(
+                async (x, ct) => await Task.FromResult(x),
+                maxDegreeOfParallelism: 2,
+                bufferMultiplier: 4,
+                cancellationToken: CancellationToken.None,
+                logger: null!));
+    }
+
+    [Fact]
+    public async Task ParallelSelectAsyncEnumerable_WithLoggerOverload_ReturnsResults_WhenSuccessful()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 5);
+        var logger = new TestLogger();
+
+        // Act
+        var results = new List<int>();
+        await foreach (var item in input.ParallelSelectAsyncEnumerable(
+                           async (x, ct) => await Task.FromResult(x * 2),
+                           maxDegreeOfParallelism: 2,
+                           bufferMultiplier: 4,
+                           cancellationToken: CancellationToken.None,
+                           logger: logger))
+        {
+            results.Add(item);
+        }
+
+        // Assert
+        Assert.Equal(new[] { 2, 4, 6, 8, 10 }, results);
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
     public async Task ParallelSelectAsyncEnumerable_OverflowCapacity_ClampsToIntMax()
     {
         // Act
@@ -582,11 +801,8 @@ public class EnumerableExtensionsTests
     }
 
     [Fact]
-    public async Task ParallelSelectAsync_CancellationToken_DisposedSemaphore_Ignored()
+    public async Task ParallelSelectAsync_CancellationToken_JoinsActiveTasksBeforeDisposal()
     {
-        // This test aims to hit the catch block for ObjectDisposedException in ParallelSelectAsync
-        // by cancelling while tasks are still completing.
-
         // Arrange
         var input = Enumerable.Range(1, 10);
         using var cts = new CancellationTokenSource();

--- a/ForgeTrust.Runnable.Core.Tests/PathUtilsTests.cs
+++ b/ForgeTrust.Runnable.Core.Tests/PathUtilsTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace ForgeTrust.Runnable.Core.Tests;
 
 public class PathUtilsTests : IDisposable
@@ -64,6 +66,76 @@ public class PathUtilsTests : IDisposable
 
         // Assert
         Assert.Equal(repoRoot, result);
+    }
+
+    [Fact]
+    public void FindRepositoryRoot_ShouldLogWarning_WhenPathDoesNotExist()
+    {
+        // Arrange
+        var repoRoot = Path.Combine(_testRoot, "logged-existing-repo");
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
+        var nonExistentPath = Path.Combine(repoRoot, "missing", "child");
+        var logger = new TestLogger();
+
+        // Act
+        var result = PathUtils.FindRepositoryRoot(nonExistentPath, logger);
+
+        // Assert
+        Assert.Equal(repoRoot, result);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(1001, entry.EventId.Id);
+        Assert.Contains(nonExistentPath, entry.Message);
+        Assert.Contains(repoRoot, entry.Message);
+    }
+
+    [Fact]
+    public void FindRepositoryRoot_WithLoggerOverload_ThrowsWhenLoggerIsNull()
+    {
+        // Arrange
+        var someDir = Path.Combine(_testRoot, "null-logger");
+        Directory.CreateDirectory(someDir);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => PathUtils.FindRepositoryRoot(someDir, logger: null!));
+    }
+
+    [Fact]
+    public void FindRepositoryRoot_WithLoggerOverload_ReturnsRepositoryRoot_WhenPathExists()
+    {
+        // Arrange
+        var repoRoot = Path.Combine(_testRoot, "explicit-logger-repo");
+        var nestedDir = Path.Combine(repoRoot, "src");
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
+        Directory.CreateDirectory(nestedDir);
+        var logger = new TestLogger();
+
+        // Act
+        var result = PathUtils.FindRepositoryRoot(nestedDir, logger);
+
+        // Assert
+        Assert.Equal(repoRoot, result);
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public void FindRepositoryRoot_WithLoggerOverload_DoesNotWarn_WhenStartPathIsFile()
+    {
+        // Arrange
+        var repoRoot = Path.Combine(_testRoot, "file-start-repo");
+        var nestedDir = Path.Combine(repoRoot, "src");
+        var startFile = Path.Combine(nestedDir, "Program.cs");
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
+        Directory.CreateDirectory(nestedDir);
+        File.WriteAllText(startFile, string.Empty);
+        var logger = new TestLogger();
+
+        // Act
+        var result = PathUtils.FindRepositoryRoot(startFile, logger);
+
+        // Assert
+        Assert.Equal(repoRoot, result);
+        Assert.Empty(logger.Entries);
     }
 
     [Fact]

--- a/ForgeTrust.Runnable.Core.Tests/TestLogger.cs
+++ b/ForgeTrust.Runnable.Core.Tests/TestLogger.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.Runnable.Core.Tests;
+
+internal sealed class TestLogger : ILogger
+{
+    public List<TestLogEntry> Entries { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        Entries.Add(new TestLogEntry(logLevel, eventId, formatter(state, exception), exception));
+    }
+}
+
+internal sealed record TestLogEntry(LogLevel Level, EventId EventId, string Message, Exception? Exception);

--- a/ForgeTrust.Runnable.Core/Extensions/EnumerableExtensions.cs
+++ b/ForgeTrust.Runnable.Core/Extensions/EnumerableExtensions.cs
@@ -1,12 +1,13 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.Runnable.Core.Extensions;
 
 /// <summary>
 /// Provides extension methods for <see cref="IEnumerable{T}"/> to perform parallel operations.
 /// </summary>
-public static class EnumerableExtensions
+public static partial class EnumerableExtensions
 {
     /// <summary>
     /// Projects each element of a sequence into a new form with bounded concurrency and preserves the input order of results.
@@ -25,6 +26,51 @@ public static class EnumerableExtensions
         Func<TSource, CancellationToken, Task<TResult>> body,
         int maxDegreeOfParallelism,
         CancellationToken cancellationToken = default)
+    {
+        return await ParallelSelectAsyncCore(
+            source,
+            body,
+            maxDegreeOfParallelism,
+            cancellationToken,
+            logger: null);
+    }
+
+    /// <summary>
+    /// Projects each element of a sequence into a new form with bounded concurrency, preserves the input order of results, observes <paramref name="cancellationToken"/>, and logs suppressed cleanup diagnostics through <paramref name="logger"/>.
+    /// </summary>
+    /// <param name="source">The sequence of input items.</param>
+    /// <param name="body">An asynchronous transform that receives an input item and a cancellation token and produces a result.</param>
+    /// <param name="maxDegreeOfParallelism">The maximum number of concurrent invocations of <paramref name="body"/>; must be greater than zero.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for tasks to complete.</param>
+    /// <param name="logger">Logger for cleanup diagnostics that would otherwise be suppressed to preserve the primary exception.</param>
+    /// <returns>An <see cref="IEnumerable{T}"/> of results in the same order as the input sequence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/>, <paramref name="body"/>, or <paramref name="logger"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxDegreeOfParallelism"/> is less than or equal to zero.</exception>
+    /// <exception cref="OperationCanceledException">The operation was canceled via <paramref name="cancellationToken"/>.</exception>
+    /// <remarks>Exceptions thrown by the <paramref name="body"/> function propagate to the returned task.</remarks>
+    public static async Task<IEnumerable<TResult>> ParallelSelectAsync<TSource, TResult>(
+        this IEnumerable<TSource> source,
+        Func<TSource, CancellationToken, Task<TResult>> body,
+        int maxDegreeOfParallelism,
+        CancellationToken cancellationToken,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        return await ParallelSelectAsyncCore(
+            source,
+            body,
+            maxDegreeOfParallelism,
+            cancellationToken,
+            logger);
+    }
+
+    private static async Task<IEnumerable<TResult>> ParallelSelectAsyncCore<TSource, TResult>(
+        IEnumerable<TSource> source,
+        Func<TSource, CancellationToken, Task<TResult>> body,
+        int maxDegreeOfParallelism,
+        CancellationToken cancellationToken,
+        ILogger? logger)
     {
         if (source == null) throw new ArgumentNullException(nameof(source));
         if (body == null) throw new ArgumentNullException(nameof(body));
@@ -53,16 +99,8 @@ public static class EnumerableExtensions
                             }
                             finally
                             {
-                                try
-                                {
-                                    // ReSharper disable AccessToDisposedClosure
-                                    semaphore.Release();
-                                    // ReSharper restore AccessToDisposedClosure
-                                }
-                                catch (ObjectDisposedException)
-                                {
-                                    // Intentionally ignored: the operation was cancelled and the semaphore was disposed
-                                }
+                                // ReSharper disable once AccessToDisposedClosure
+                                semaphore.Release();
                             }
                         },
                         cancellationToken));
@@ -78,9 +116,12 @@ public static class EnumerableExtensions
             {
                 await Task.WhenAll(tasks);
             }
-            catch
+            catch (Exception ex)
             {
-                // Exceptions in individual tasks are already captured by the main Task.WhenAll
+                if (logger != null && ShouldLogCleanupFailure(ex, cancellationToken))
+                {
+                    LogParallelSelectAsyncTaskCleanupFailure(logger, ex);
+                }
             }
 
             throw;
@@ -128,6 +169,57 @@ public static class EnumerableExtensions
         int maxDegreeOfParallelism,
         int bufferMultiplier = 4,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var result in ParallelSelectAsyncEnumerableCore(
+                           source,
+                           body,
+                           maxDegreeOfParallelism,
+                           bufferMultiplier,
+                           cancellationToken,
+                           logger: null))
+        {
+            yield return result;
+        }
+    }
+
+    /// <summary>
+    /// Produces an asynchronous sequence of results by applying <paramref name="body"/> to each element of <paramref name="source"/>, limiting concurrency, preserving input order, observing <paramref name="cancellationToken"/>, and logging suppressed cleanup diagnostics through <paramref name="logger"/>.
+    /// </summary>
+    /// <param name="source">The input sequence to project; must not be null.</param>
+    /// <param name="body">A selector that projects an element to a <see cref="Task{TResult}"/>; it receives the element and a cancellation token that is signaled when the operation is canceled.</param>
+    /// <param name="maxDegreeOfParallelism">The maximum number of selector tasks that may run concurrently; must be greater than zero.</param>
+    /// <param name="bufferMultiplier">A multiplier used to compute the internal channel capacity as <c>maxDegreeOfParallelism * bufferMultiplier</c> (capped to <see cref="int.MaxValue"/>); must be at least 1.</param>
+    /// <param name="cancellationToken">Token to observe for cooperative cancellation of the overall operation.</param>
+    /// <param name="logger">Logger for cleanup diagnostics that would otherwise be suppressed to preserve the primary exception.</param>
+    /// <returns>An <see cref="IAsyncEnumerable{TResult}"/> that yields projected results in the same order as the source sequence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/>, <paramref name="body"/>, or <paramref name="logger"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="maxDegreeOfParallelism"/> is less than or equal to zero or if <paramref name="bufferMultiplier"/> is less than 1.</exception>
+    public static IAsyncEnumerable<TResult> ParallelSelectAsyncEnumerable<TSource, TResult>(
+        this IEnumerable<TSource> source,
+        Func<TSource, CancellationToken, Task<TResult>> body,
+        int maxDegreeOfParallelism,
+        int bufferMultiplier,
+        CancellationToken cancellationToken,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        return ParallelSelectAsyncEnumerableCore(
+            source,
+            body,
+            maxDegreeOfParallelism,
+            bufferMultiplier,
+            cancellationToken: cancellationToken,
+            logger: logger);
+    }
+
+    private static async IAsyncEnumerable<TResult> ParallelSelectAsyncEnumerableCore<TSource, TResult>(
+        IEnumerable<TSource> source,
+        Func<TSource, CancellationToken, Task<TResult>> body,
+        int maxDegreeOfParallelism,
+        int bufferMultiplier,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken,
+        ILogger? logger)
     {
         if (source == null)
         {
@@ -198,17 +290,8 @@ public static class EnumerableExtensions
                                 }
                                 finally
                                 {
-                                    // Release concurrency limit slot when task completes
-                                    try
-                                    {
-                                        // ReSharper disable AccessToDisposedClosure
-                                        semaphore.Release();
-                                        // ReSharper restore AccessToDisposedClosure
-                                    }
-                                    catch (ObjectDisposedException)
-                                    {
-                                        // Intentionally ignored: the operation was cancelled and the semaphore was disposed
-                                    }
+                                    // ReSharper disable once AccessToDisposedClosure
+                                    semaphore.Release();
                                 }
                             },
                             // ReSharper disable AccessToDisposedClosure
@@ -256,14 +339,6 @@ public static class EnumerableExtensions
             {
                 // Expected on cancellation
             }
-            catch (Exception _)
-            {
-                // Cleanup failures during producer termination are suppressed to avoid shadowing main exceptions
-#if DEBUG
-                System.Diagnostics.Debug.WriteLine(
-                    $"Error during ParallelSelectAsyncEnumerable cleanup (producer): {_}");
-#endif
-            }
 
             // JOIN ALL ACTIVE TASKS before disposing the semaphore and CTS
             // This is critical because they capture the semaphore and CTS in their closures.
@@ -273,15 +348,32 @@ public static class EnumerableExtensions
             }
             catch (Exception ex)
             {
-                // Exceptions in individual tasks are already handled/re-thrown via the channel/yield return.
-                // We ignore them here to ensure disposal of resources like the semaphore and CTS continues.
-#if DEBUG
-                System.Diagnostics.Debug.WriteLine(
-                    $"Ignored task exception during ParallelSelectAsyncEnumerable disposal: {ex}");
-#endif
+                if (logger != null && ShouldLogCleanupFailure(ex, cts.Token))
+                {
+                    LogParallelSelectAsyncEnumerableTaskCleanupFailure(logger, ex);
+                }
             }
         }
     }
+
+    private static bool ShouldLogCleanupFailure(Exception exception, CancellationToken cancellationToken)
+    {
+        return !cancellationToken.IsCancellationRequested || exception is not OperationCanceledException;
+    }
+
+    [LoggerMessage(
+        EventId = 1102,
+        Level = LogLevel.Debug,
+        Message = "ParallelSelectAsync suppressed task cleanup failures while preserving the primary failure.")]
+    private static partial void LogParallelSelectAsyncTaskCleanupFailure(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        EventId = 1105,
+        Level = LogLevel.Debug,
+        Message = "ParallelSelectAsyncEnumerable suppressed task cleanup failures while disposing concurrency resources.")]
+    private static partial void LogParallelSelectAsyncEnumerableTaskCleanupFailure(
+        ILogger logger,
+        Exception exception);
 
     /// <summary>
     /// Projects each element of <paramref name="source"/> using the provided task-returning selector with bounded concurrency and yields the results in the same order as the source.

--- a/ForgeTrust.Runnable.Core/PathUtils.cs
+++ b/ForgeTrust.Runnable.Core/PathUtils.cs
@@ -1,9 +1,11 @@
+using Microsoft.Extensions.Logging;
+
 namespace ForgeTrust.Runnable.Core;
 
 /// <summary>
 /// Provides utility methods for operations on file and directory paths.
 /// </summary>
-public static class PathUtils
+public static partial class PathUtils
 {
     /// <summary>
     /// Locates the nearest ancestor directory (starting at <paramref name="startPath"/>) that contains a `.git` directory or file, effectively identifying the repository root.
@@ -13,21 +15,49 @@ public static class PathUtils
     /// <exception cref="ArgumentException">Thrown when <paramref name="startPath"/> is null, empty, or consists only of whitespace.</exception>
     public static string FindRepositoryRoot(string startPath)
     {
+        return FindRepositoryRootCore(startPath, logger: null);
+    }
+
+    /// <summary>
+    /// Locates the nearest ancestor directory (starting at <paramref name="startPath"/>) that contains a `.git` directory or file, effectively identifying the repository root.
+    /// </summary>
+    /// <param name="startPath">The path from which to begin searching upward for a repository root; may refer to a file or directory.</param>
+    /// <param name="logger">
+    /// Logger for diagnostic warnings when repository-root discovery has to recover from a path that does not exist.
+    /// </param>
+    /// <returns>The full path of the nearest ancestor directory containing a `.git` directory or file, or the original <paramref name="startPath"/> if none is found.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="startPath"/> is null, empty, or consists only of whitespace.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger"/> is null.</exception>
+    public static string FindRepositoryRoot(string startPath, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        return FindRepositoryRootCore(startPath, logger);
+    }
+
+    private static string FindRepositoryRootCore(string startPath, ILogger? logger)
+    {
         if (string.IsNullOrWhiteSpace(startPath))
         {
             throw new ArgumentException("Start path cannot be null or whitespace.", nameof(startPath));
         }
 
-        var current = new DirectoryInfo(startPath);
+        var fileExists = File.Exists(startPath);
+        DirectoryInfo? current = fileExists
+            ? new DirectoryInfo(Path.GetDirectoryName(Path.GetFullPath(startPath))!)
+            : new DirectoryInfo(startPath);
+        var fallbackFromMissingPath = !fileExists && !current.Exists;
 
-        // If startPath doesn't exist, walk up until we find one that does
         while (current is { Exists: false })
         {
             current = current.Parent;
+        }
 
-            if (current == null)
+        if (fallbackFromMissingPath)
+        {
+            if (logger != null && current != null)
             {
-                break;
+                LogMissingPathFallback(logger, startPath, current.FullName);
             }
         }
 
@@ -44,4 +74,11 @@ public static class PathUtils
 
         return startPath;
     }
+
+    [LoggerMessage(
+        EventId = 1001,
+        Level = LogLevel.Warning,
+        Message = "Repository-root search started from missing path {StartPath}; continuing from nearest existing ancestor {FallbackPath}.")]
+    private static partial void LogMissingPathFallback(ILogger logger, string startPath, string fallbackPath);
+
 }

--- a/ForgeTrust.Runnable.Core/README.md
+++ b/ForgeTrust.Runnable.Core/README.md
@@ -16,6 +16,22 @@ The Core library is designed to be lightweight and implementation-agnostic. it p
 - **`ConsoleOutputMode`**: Shared core enum that lets console-oriented packages describe whether command output should remain host-centric or command-first.
 - **`RunnableStartup`**: The base class that orchestrates the host building and service registration process.
 
+## Logging in Static Utilities
+
+Core static utilities stay host-agnostic: they do not reach into a global logger, service provider, or ambient startup state. When a public static helper has useful diagnostics, expose an additive overload with an explicit non-null `ILogger` parameter and keep the existing no-logger overload silent. Private shared implementations may accept `ILogger?` only to avoid duplicating logic between the silent and diagnostic paths.
+
+Use this pattern when a helper performs fallback behavior that callers may want to audit. For example, `PathUtils.FindRepositoryRoot(startPath, logger)` logs a warning when `startPath` does not exist and repository-root discovery has to continue from the nearest existing ancestor.
+
+Prefer ordinary dependency injection for services, modules, hosted services, and application-owned classes. The optional logger pattern is only for static helpers where injecting a service instance would make the API harder to use or force unrelated callers to construct infrastructure.
+
+Define static helper log messages with the source-generated `[LoggerMessage]` attribute on private static partial methods. Give each message a stable event ID, level, and template. Do not use ad hoc `logger.Log...` calls for new Core diagnostics when the message is part of an intentional API behavior.
+
+Pitfalls:
+
+- Do not create a static `LoggerFactory` inside a utility. That couples Core to a console/logging policy the host did not choose.
+- Do not throw only because a fallback warning was logged. Keep the documented return behavior unless the input contract itself is invalid.
+- Do not swallow cleanup failures silently when a logger is available. Log them at `Debug` when they are intentionally suppressed to preserve the primary exception or cancellation path.
+
 ## Usage
 
 Most users will use a more specialized package like `ForgeTrust.Runnable.Web` or `ForgeTrust.Runnable.Console`, which inherit from the abstractions provided here.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -63,7 +63,7 @@ public class DocAggregator
     /// </summary>
     /// <param name="harvesters">Collection of <see cref="IDocHarvester"/> instances used to harvest documentation nodes.</param>
     /// <param name="options">Typed RazorDocs options that determine the active source mode and optional repository root override.</param>
-    /// <param name="environment">Hosting environment; used to locate the repository root via <see cref="PathUtils.FindRepositoryRoot"/> when options do not provide it.</param>
+    /// <param name="environment">Hosting environment; used to locate the repository root via <see cref="PathUtils.FindRepositoryRoot(string, ILogger)"/> when options do not provide it.</param>
     /// <param name="memo">Memoized cache used to store harvested documentation.</param>
     /// <param name="sanitizer">HTML sanitizer used to clean document content before caching.</param>
     /// <param name="logger">Logger used for recording aggregation events and errors.</param>
@@ -144,7 +144,8 @@ public class DocAggregator
         {
             RazorDocsMode.Source => ResolveRepositoryRoot(
                 options.Source ?? throw new ArgumentNullException(nameof(options.Source)),
-                environment.ContentRootPath),
+                environment.ContentRootPath,
+                logger),
             RazorDocsMode.Bundle => throw new NotSupportedException(
                 "RazorDocs bundle mode is not implemented yet. Use RazorDocs:Mode=Source for Slice 1."),
             _ => throw new NotSupportedException($"Unsupported RazorDocs mode '{options.Mode}'.")
@@ -157,14 +158,18 @@ public class DocAggregator
         }
     }
 
-    private static string ResolveRepositoryRoot(RazorDocsSourceOptions sourceOptions, string contentRootPath)
+    private static string ResolveRepositoryRoot(
+        RazorDocsSourceOptions sourceOptions,
+        string contentRootPath,
+        ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(sourceOptions);
         ArgumentNullException.ThrowIfNull(contentRootPath);
+        ArgumentNullException.ThrowIfNull(logger);
 
         if (sourceOptions.RepositoryRoot is null)
         {
-            return PathUtils.FindRepositoryRoot(contentRootPath);
+            return PathUtils.FindRepositoryRoot(contentRootPath, logger);
         }
 
         var normalizedRepositoryRoot = sourceOptions.RepositoryRoot.Trim();

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -39,6 +39,10 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Project exports now disable persistent MSBuild build servers during CLI-controlled publish and assembly-name probes so captured tool output cannot hang on reused build nodes.
 - RazorWire CLI process cleanup now waits for asynchronous stdout and stderr callbacks to flush before disposing launched target processes, which keeps short-lived command output observable in tests and diagnostics.
 
+### Core diagnostics
+
+- Core static utilities now use explicit `ILogger` overloads and source-generated `[LoggerMessage]` definitions for host-owned diagnostics. `PathUtils.FindRepositoryRoot` can warn when discovery falls back from a missing path, and parallel enumerable cleanup paths now log suppressed cleanup failures at `Debug` when a caller supplies a logger.
+
 ### Dependency maintenance
 
 - The centrally managed `YamlDotNet` dependency now targets `17.0.1`, and the affected PackageIndex, RazorDocs, and Aspire lock files have been regenerated.


### PR DESCRIPTION
Fixes #36

## Summary
- add explicit logger overloads for Core static utility diagnostics while keeping existing no-logger overloads silent
- define Core diagnostic messages with source-generated `[LoggerMessage]` methods and stable event IDs
- log PathUtils missing-path fallback warnings and suppressed parallel enumerable cleanup failures when a caller supplies an `ILogger`
- document the static utility logging decision and update the unreleased release notes

## Validation
- `dotnet format ForgeTrust.Runnable.slnx --include ForgeTrust.Runnable.Core/PathUtils.cs ForgeTrust.Runnable.Core/Extensions/EnumerableExtensions.cs ForgeTrust.Runnable.Core.Tests/PathUtilsTests.cs ForgeTrust.Runnable.Core.Tests/EnumerableExtensionsTests.cs ForgeTrust.Runnable.Core.Tests/TestLogger.cs --verbosity minimal`
- `dotnet test ForgeTrust.Runnable.Core.Tests/ForgeTrust.Runnable.Core.Tests.csproj --no-restore`
- `dotnet build ForgeTrust.Runnable.slnx --no-restore`

## Notes
- `./scripts/coverage-solution.sh` reached 95.46% line / 93.13% branch coverage but exited nonzero because `RazorDocsWayfindingPlaywrightTests.DetailsPage_RendersOutline_AndSequenceWayfinding` expected `Security & Anti-Forgery` and saw `razorwire-mvc`; that appears outside this Core logging change.