### PR TITLE
fix(razordocs): reduce export route warning noise

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocMetadataFactoryTests.cs
@@ -103,6 +103,55 @@ public sealed class DocMetadataFactoryTests
     }
 
     [Fact]
+    public void CreateMarkdownMetadata_ShouldAcceptReleaseNavGroupWithoutWarning()
+    {
+        var logger = A.Fake<ILogger>();
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(
+            "releases/unreleased.md",
+            "Unreleased",
+            new DocMetadata
+            {
+                NavGroup = "Releases",
+                Breadcrumbs = ["Releases", "Unreleased"]
+            },
+            null,
+            logger);
+
+        Assert.Equal("Releases", metadata.NavGroup);
+        Assert.False(metadata.NavGroupIsDerived);
+        Assert.Equal(["Releases", "Unreleased"], metadata.Breadcrumbs);
+        Assert.True(metadata.BreadcrumbsMatchPathTargets);
+        A.CallTo(logger)
+            .Where(call => call.Method.Name == "Log" && call.GetArgument<LogLevel>(0) == LogLevel.Warning)
+            .MustNotHaveHappened();
+    }
+
+    [Theory]
+    [InlineData("releases/README.md")]
+    [InlineData("releases/upgrade-policy.md")]
+    [InlineData("CHANGELOG.md")]
+    public void CreateMarkdownMetadata_ShouldDeriveReleaseSection_ForReleasePaths(string path)
+    {
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(path, "Release Notes", null, null);
+
+        Assert.Equal("Releases", metadata.NavGroup);
+        Assert.True(metadata.NavGroupIsDerived);
+        Assert.Equal(["Releases", "Release Notes"], metadata.Breadcrumbs);
+    }
+
+    [Theory]
+    [InlineData("docs/CHANGELOG.md")]
+    [InlineData("packages/CHANGELOG.md")]
+    public void CreateMarkdownMetadata_ShouldNotDeriveReleaseSection_ForNestedChangelogPaths(string path)
+    {
+        var metadata = DocMetadataFactory.CreateMarkdownMetadata(path, "Package Changelog", null, null);
+
+        Assert.Equal("How-to Guides", metadata.NavGroup);
+        Assert.True(metadata.NavGroupIsDerived);
+        Assert.Equal(["How-to Guides", "Package Changelog"], metadata.Breadcrumbs);
+    }
+
+    [Fact]
     public void CreateMarkdownMetadata_ShouldNotMarkExplicitBreadcrumbs_WhenTargetCountDoesNotMatch()
     {
         var metadata = DocMetadataFactory.CreateMarkdownMetadata(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocPublicSectionCatalogTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocPublicSectionCatalogTests.cs
@@ -4,10 +4,25 @@ namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
 
 public sealed class DocPublicSectionCatalogTests
 {
+    [Fact]
+    public void DocPublicSection_ShouldPreservePublicNumericContract()
+    {
+        Assert.Equal(0, (int)DocPublicSection.StartHere);
+        Assert.Equal(1, (int)DocPublicSection.Concepts);
+        Assert.Equal(2, (int)DocPublicSection.HowToGuides);
+        Assert.Equal(3, (int)DocPublicSection.Examples);
+        Assert.Equal(4, (int)DocPublicSection.ApiReference);
+        Assert.Equal(5, (int)DocPublicSection.Troubleshooting);
+        Assert.Equal(6, (int)DocPublicSection.Internals);
+        Assert.Equal(7, (int)DocPublicSection.Releases);
+    }
+
     [Theory]
     [InlineData("API Reference", DocPublicSection.ApiReference)]
     [InlineData("api", DocPublicSection.ApiReference)]
     [InlineData("reference", DocPublicSection.ApiReference)]
+    [InlineData("release-notes", DocPublicSection.Releases)]
+    [InlineData("changelog", DocPublicSection.Releases)]
     [InlineData("start_here", DocPublicSection.StartHere)]
     public void TryResolve_ShouldAcceptCanonicalLabelsSlugsAndAliases(string value, DocPublicSection expectedSection)
     {
@@ -20,8 +35,10 @@ public sealed class DocPublicSectionCatalogTests
     [Theory]
     [InlineData("api-reference", true, DocPublicSection.ApiReference)]
     [InlineData("API-REFERENCE", true, DocPublicSection.ApiReference)]
+    [InlineData("releases", true, DocPublicSection.Releases)]
     [InlineData("api", false, default)]
     [InlineData("reference", false, default)]
+    [InlineData("release-notes", false, default)]
     [InlineData("API Reference", false, default)]
     [InlineData("api_reference", false, default)]
     public void TryResolveSlug_ShouldAcceptOnlyCanonicalSectionSlugs(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -1151,6 +1151,78 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task Details_ShouldLinkReleaseBreadcrumbParentToSectionRoute_WhenParsedParentDocRouteIsSynthetic()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Releases",
+                "releases/README.md",
+                "<p>Release index</p>",
+                Metadata: new DocMetadata
+                {
+                    NavGroup = "Releases",
+                    Breadcrumbs = ["Releases"],
+                    BreadcrumbsMatchPathTargets = true,
+                    SectionLanding = true
+                }),
+            new(
+                "Unreleased",
+                "releases/unreleased.md",
+                "<p>Current release notes</p>",
+                Metadata: new DocMetadata
+                {
+                    NavGroup = "Releases",
+                    Breadcrumbs = ["release-notes", "Unreleased"],
+                    BreadcrumbsMatchPathTargets = true
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Details("releases/unreleased.md");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocDetailsViewModel>(viewResult.Model);
+        Assert.Equal(DocPublicSection.Releases, model.PublicSection);
+        Assert.Equal(
+            ["release-notes", "Unreleased"],
+            model.Breadcrumbs.Select(breadcrumb => breadcrumb.Label).ToArray());
+        Assert.Equal("/docs/sections/releases", model.Breadcrumbs[0].Href);
+        Assert.DoesNotContain(model.Breadcrumbs, breadcrumb => breadcrumb.Href == "/docs/releases.html");
+        AssertNoWarningsLogged();
+    }
+
+    [Fact]
+    public async Task Details_ShouldSuppressSyntheticParentDocBreadcrumbHrefs_WhenNoPublishedDocMatches()
+    {
+        var docs = new List<DocNode>
+        {
+            new(
+                "Web",
+                "Web/ForgeTrust.Runnable.Web/README.md",
+                "<p>Web package docs</p>",
+                Metadata: new DocMetadata
+                {
+                    NavGroup = "How-to Guides",
+                    Breadcrumbs = ["Web", "ForgeTrust.Runnable.Web"],
+                    BreadcrumbsMatchPathTargets = true
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+
+        var result = await _controller.Details("Web/ForgeTrust.Runnable.Web/README.md");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<DocDetailsViewModel>(viewResult.Model);
+        Assert.Equal(
+            ["Web", "ForgeTrust.Runnable.Web"],
+            model.Breadcrumbs.Select(breadcrumb => breadcrumb.Label).ToArray());
+        Assert.Null(model.Breadcrumbs[0].Href);
+        Assert.DoesNotContain(model.Breadcrumbs, breadcrumb => breadcrumb.Href == "/docs/Web.html");
+        AssertNoWarningsLogged();
+    }
+
+    [Fact]
     public async Task Details_ShouldReturnTurboFramePartial_WhenPartialSuffixRequested()
     {
         var docs = new List<DocNode> { new("Title", "target-path", "content") };
@@ -1268,7 +1340,7 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task Details_ShouldHonorMetadataBreadcrumbs_ForNonApiPublicDocs_WhenTargetsMatch()
+    public async Task Details_ShouldHonorMetadataBreadcrumbLabels_AndSuppressSyntheticParentDocHref()
     {
         var docs = new List<DocNode>
         {
@@ -1293,7 +1365,7 @@ public class DocsControllerTests : IDisposable
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<DocDetailsViewModel>(viewResult.Model);
         Assert.Equal(["Get Started", "Quickstart"], model.Breadcrumbs.Select(crumb => crumb.Label).ToArray());
-        Assert.Equal("/docs/guides.html", model.Breadcrumbs[0].Href);
+        Assert.Null(model.Breadcrumbs[0].Href);
         Assert.Null(model.Breadcrumbs[1].Href);
     }
 
@@ -2002,14 +2074,30 @@ public class DocsControllerTests : IDisposable
         Assert.True(controllerLogged || resolverLogged, $"Expected warning log containing '{expectedMessageFragment}'.");
     }
 
+    private void AssertNoWarningsLogged()
+    {
+        var controllerLoggedWarning = Fake.GetCalls(_controllerLoggerFake)
+            .Any(call => IsWarningLog(call));
+        var resolverLoggedWarning = Fake.GetCalls(_featuredPageResolverLoggerFake)
+            .Any(call => IsWarningLog(call));
+
+        Assert.False(controllerLoggedWarning || resolverLoggedWarning, "Expected no warning logs.");
+    }
+
     private static bool IsWarningLog(FakeItEasy.Core.IFakeObjectCall call, string expectedMessageFragment)
     {
-        if (call.Method.Name != nameof(ILogger.Log) || call.GetArgument<LogLevel>(0) != LogLevel.Warning)
+        if (!IsWarningLog(call))
         {
             return false;
         }
 
         var message = call.GetArgument<object>(2)?.ToString();
         return message?.Contains(expectedMessageFragment, StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private static bool IsWarningLog(FakeItEasy.Core.IFakeObjectCall call)
+    {
+        return call.Method.Name == nameof(ILogger.Log)
+               && call.GetArgument<LogLevel>(0) == LogLevel.Warning;
     }
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
@@ -8,6 +8,15 @@ namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
 public sealed class RazorDocsOptionsTests
 {
     [Fact]
+    public void PublicEnums_ShouldPreserveNumericContracts()
+    {
+        Assert.Equal(0, (int)RazorDocsMode.Source);
+        Assert.Equal(1, (int)RazorDocsMode.Bundle);
+        Assert.Equal(0, (int)RazorDocsLastUpdatedMode.None);
+        Assert.Equal(1, (int)RazorDocsLastUpdatedMode.Git);
+    }
+
+    [Fact]
     public void AddRazorDocs_ShouldFallbackToLegacyRepositoryRootSetting()
     {
         var services = new ServiceCollection();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -522,7 +522,7 @@ public class DocsController : Controller
             PageTypeBadge = pageTypeBadge,
             Component = component,
             Audience = audience,
-            Breadcrumbs = BuildBreadcrumbs(doc, currentSectionSnapshot, resolvedTitle),
+            Breadcrumbs = BuildBreadcrumbs(doc, currentSectionSnapshot, resolvedTitle, docs),
             PublicSection = currentSectionSnapshot?.Section,
             PublicSectionLabel = currentSectionSnapshot?.Label,
             PublicSectionHref = currentSectionSnapshot is null ? null : DocPublicSectionCatalog.GetHref(currentSectionSnapshot.Section),
@@ -536,8 +536,13 @@ public class DocsController : Controller
     private static IReadOnlyList<DocBreadcrumbViewModel> BuildBreadcrumbs(
         DocNode doc,
         DocSectionSnapshot? currentSectionSnapshot,
-        string resolvedTitle)
+        string resolvedTitle,
+        IReadOnlyList<DocNode> docs)
     {
+        var publishedDocHrefs = docs
+            .Where(item => !string.IsNullOrWhiteSpace(item.CanonicalPath))
+            .Select(item => $"/docs/{GetSnapshotCanonicalPath(item)}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var normalizedPath = doc.Path.Trim().Trim('/');
         var isNamespacePath = normalizedPath.Equals("Namespaces", StringComparison.OrdinalIgnoreCase)
                               || normalizedPath.StartsWith("Namespaces/", StringComparison.OrdinalIgnoreCase);
@@ -618,7 +623,7 @@ public class DocsController : Controller
                     ];
             }
 
-            return parsedBreadcrumbs;
+            return ResolveBreadcrumbHrefs(parsedBreadcrumbs, currentSectionSnapshot, publishedDocHrefs);
         }
 
         return metadataBreadcrumbs!
@@ -626,11 +631,61 @@ public class DocsController : Controller
                 (label, index) => new DocBreadcrumbViewModel
                 {
                     Label = label,
-                    Href = index - (metadataBreadcrumbCount - parsedBreadcrumbs.Count) >= 0
-                        ? parsedBreadcrumbs[index - (metadataBreadcrumbCount - parsedBreadcrumbs.Count)].Href
-                        : null
+                    Href = ResolveBreadcrumbHref(
+                        label,
+                        index == metadataBreadcrumbCount - 1,
+                        index - (metadataBreadcrumbCount - parsedBreadcrumbs.Count) >= 0
+                            ? parsedBreadcrumbs[index - (metadataBreadcrumbCount - parsedBreadcrumbs.Count)].Href
+                            : null,
+                        currentSectionSnapshot,
+                        publishedDocHrefs)
                 })
             .ToList();
+    }
+
+    private static IReadOnlyList<DocBreadcrumbViewModel> ResolveBreadcrumbHrefs(
+        IEnumerable<DocBreadcrumbViewModel> breadcrumbs,
+        DocSectionSnapshot? currentSectionSnapshot,
+        IReadOnlySet<string> publishedDocHrefs)
+    {
+        var items = breadcrumbs.ToArray();
+        return items
+            .Select(
+                (breadcrumb, index) => breadcrumb with
+                {
+                    Href = ResolveBreadcrumbHref(
+                        breadcrumb.Label,
+                        index == items.Length - 1,
+                        breadcrumb.Href,
+                        currentSectionSnapshot,
+                        publishedDocHrefs)
+                })
+            .ToArray();
+    }
+
+    private static string? ResolveBreadcrumbHref(
+        string label,
+        bool isLast,
+        string? candidateHref,
+        DocSectionSnapshot? currentSectionSnapshot,
+        IReadOnlySet<string> publishedDocHrefs)
+    {
+        if (isLast)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(candidateHref)
+            && publishedDocHrefs.Contains(candidateHref))
+        {
+            return candidateHref;
+        }
+
+        return currentSectionSnapshot is not null
+               && DocPublicSectionCatalog.TryResolve(label, out var section)
+               && section == currentSectionSnapshot.Section
+            ? DocPublicSectionCatalog.GetHref(currentSectionSnapshot.Section)
+            : null;
     }
 
     private static bool MetadataBreadcrumbsMatchPathTargets(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocModels.cs
@@ -494,42 +494,52 @@ public record DocNode(
 /// <summary>
 /// Enumerates the built-in public documentation sections used by RazorDocs.
 /// </summary>
+/// <remarks>
+/// Numeric values are a stable public compatibility contract for persisted and serialized representations. Do not
+/// remove, reorder, or renumber existing members. Presentation order is defined by
+/// <c>DocPublicSectionCatalog.OrderedSections</c>, so renderers should not infer UI ordering from enum ordinals.
+/// </remarks>
 public enum DocPublicSection
 {
     /// <summary>
     /// A first-read routing surface for evaluators who need to understand what the product is for before going deeper.
     /// </summary>
-    StartHere,
+    StartHere = 0,
 
     /// <summary>
     /// Explanatory material that builds conceptual understanding before implementation details.
     /// </summary>
-    Concepts,
+    Concepts = 1,
 
     /// <summary>
     /// Task-oriented guides that show a reader how to accomplish something concrete.
     /// </summary>
-    HowToGuides,
+    HowToGuides = 2,
 
     /// <summary>
     /// Concrete examples and proof artifacts that demonstrate the system working in practice.
     /// </summary>
-    Examples,
+    Examples = 3,
 
     /// <summary>
     /// API and namespace reference material intended for readers who already know what they are looking for.
     /// </summary>
-    ApiReference,
+    ApiReference = 4,
 
     /// <summary>
     /// Recovery-oriented material for failures, debugging, and operational honesty.
     /// </summary>
-    Troubleshooting,
+    Troubleshooting = 5,
 
     /// <summary>
     /// Contributor-oriented or otherwise internal material that should only appear when explicitly made public.
     /// </summary>
-    Internals
+    Internals = 6,
+
+    /// <summary>
+    /// Release notes, changelogs, upgrade policies, and other version-facing project history.
+    /// </summary>
+    Releases = 7
 }
 
 /// <summary>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocPublicSectionCatalog.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Models/DocPublicSectionCatalog.cs
@@ -61,6 +61,17 @@ internal static class DocPublicSectionCatalog
             "api",
             "reference"),
         new(
+            DocPublicSection.Releases,
+            "Releases",
+            "releases",
+            "Review changelogs, upgrade guidance, and release-facing project history.",
+            "release",
+            "changelog",
+            "change-log",
+            "release-notes",
+            "releasenotes",
+            "upgrades"),
+        new(
             DocPublicSection.Troubleshooting,
             "Troubleshooting",
             "troubleshooting",

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -184,6 +184,7 @@ RazorDocs now organizes public documentation around a fixed section-first model 
 - `How-to Guides`
 - `Examples`
 - `API Reference`
+- `Releases`
 - `Troubleshooting`
 - `Internals`
 
@@ -196,6 +197,7 @@ These sections back the `/docs` home, the sidebar shell, and the dedicated secti
 - Markdown docs with no explicit `nav_group` are derived into built-in sections using path and filename heuristics:
   - repository-root `README.md` and start-like names such as `quickstart` or `getting-started` fall into `Start Here`
   - `examples/` content falls into `Examples`
+  - `releases/` content and root changelogs fall into `Releases`
   - concepts, architecture, explanation, and glossary-style paths fall into `Concepts`
   - troubleshooting, faq, debug, and error-oriented paths fall into `Troubleshooting`
   - internal-oriented paths fall into `Internals`

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsOptions.cs
@@ -41,17 +41,22 @@ public sealed class RazorDocsOptions
 /// <summary>
 /// Enumerates the supported RazorDocs content source modes.
 /// </summary>
+/// <remarks>
+/// Numeric values are part of the public configuration and serialization contract. Do not reorder or renumber existing
+/// members; changing these assignments can break persisted configuration, serialized payloads, and consumers. Add new
+/// modes by appending members with new explicit values.
+/// </remarks>
 public enum RazorDocsMode
 {
     /// <summary>
     /// Harvest docs from source files at runtime.
     /// </summary>
-    Source,
+    Source = 0,
 
     /// <summary>
     /// Load docs from a prebuilt bundle. Reserved for a later implementation slice.
     /// </summary>
-    Bundle
+    Bundle = 1
 }
 
 /// <summary>
@@ -140,18 +145,23 @@ public sealed class RazorDocsContributorOptions
 /// <summary>
 /// Enumerates the supported contributor freshness modes for RazorDocs details pages.
 /// </summary>
+/// <remarks>
+/// Numeric values are part of the public configuration and serialization contract. Do not reorder or renumber existing
+/// members; changing these assignments can break persisted configuration, serialized payloads, and consumers. Add new
+/// modes by appending members with new explicit values.
+/// </remarks>
 public enum RazorDocsLastUpdatedMode
 {
     /// <summary>
     /// Do not render automatic contributor freshness.
     /// </summary>
-    None,
+    None = 0,
 
     /// <summary>
     /// Resolve contributor freshness from local git history when a trustworthy source path exists.
     /// Hosts should expect graceful omission when git history is unavailable, shallow, or not trustworthy for the page.
     /// </summary>
-    Git
+    Git = 1
 }
 
 /// <summary>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocMetadataFactory.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocMetadataFactory.cs
@@ -176,6 +176,11 @@ internal static class DocMetadataFactory
             return DocPublicSection.Internals;
         }
 
+        if (IsReleasePath(normalizedPath))
+        {
+            return DocPublicSection.Releases;
+        }
+
         var fileName = Path.GetFileNameWithoutExtension(normalizedPath);
         if (IsStartHereLikeName(fileName))
         {
@@ -296,6 +301,14 @@ internal static class DocMetadataFactory
                || segment.Contains(".Tests", StringComparison.OrdinalIgnoreCase)
                || segment.EndsWith("Tests", StringComparison.OrdinalIgnoreCase)
                || segment.Contains("Benchmark", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsReleasePath(string path)
+    {
+        var normalizedPath = NormalizePath(path);
+
+        return normalizedPath.StartsWith("releases/", StringComparison.OrdinalIgnoreCase)
+               || normalizedPath.Equals("CHANGELOG.md", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? NormalizeMetadataValue(string? value)

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -79,6 +79,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Contributor provenance now degrades safely: namespace and API pages stay explicit-override-only for the MVP, and missing or slow git history omits only freshness instead of breaking docs rendering.
 - Shared RazorDocs badges, metadata chips, provenance strips, and trust bars now live in the shared package stylesheet while `search.css` stays focused on search-specific UI.
 - RazorDocs search now keeps failure recovery markup out of the active search shell until the index actually fails to load, so successful searches no longer expose hidden failure copy to text extraction tools.
+- RazorDocs now treats `Releases` as a first-class public section and suppresses breadcrumb links to generated parent routes that do not correspond to published docs pages, keeping static export warnings focused on actionable broken links.
 
 ### RazorWire form UX
 


### PR DESCRIPTION
## Summary

- add a first-class RazorDocs `Releases` public section so release metadata no longer falls back with warning noise
- suppress generated breadcrumb hrefs unless they point at a published docs page or an explicit section route
- add explicit numeric values for RazorDocs public enums and contract tests for those values
- document the `Releases` section and release-path derivation rules

## Root Cause

Release docs authored `nav_group: Releases`, but `Releases` was not a known public section, so metadata normalization treated it as invalid. Breadcrumb generation also synthesized parent document links from path segments, which could create crawlable-but-nonexistent routes such as `/docs/releases.html` and `/docs/Web.html`.

## Validation

- `dotnet format ForgeTrust.Runnable.slnx --no-restore`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --no-restore`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests/ForgeTrust.Runnable.Web.RazorWire.Cli.Tests.csproj --no-build`
- `git diff --check`

Fixes #192.
