### PR TITLE
fix(web): stabilize public enum values

### DIFF
--- a/ForgeTrust.Runnable.Core.Tests/StartupContextTests.cs
+++ b/ForgeTrust.Runnable.Core.Tests/StartupContextTests.cs
@@ -35,6 +35,14 @@ public class StartupContextTests
         Assert.Equal(ConsoleOutputMode.CommandFirst, context.ConsoleOutputMode);
     }
 
+    [Theory]
+    [InlineData(ConsoleOutputMode.Default, 0)]
+    [InlineData(ConsoleOutputMode.CommandFirst, 1)]
+    public void ConsoleOutputMode_NumericValues_AreStable(ConsoleOutputMode value, int expected)
+    {
+        Assert.Equal(expected, (int)value);
+    }
+
     private class DummyModule : IRunnableHostModule
     {
         public void ConfigureServices(StartupContext context, IServiceCollection services)

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.Tests/PublicEnumContractTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.Tests/PublicEnumContractTests.cs
@@ -1,0 +1,15 @@
+namespace ForgeTrust.Runnable.Web.RazorWire.Tests;
+
+public class PublicEnumContractTests
+{
+    [Theory]
+    [InlineData(RazorWireFormFailureMode.Auto, 0)]
+    [InlineData(RazorWireFormFailureMode.Manual, 1)]
+    [InlineData(RazorWireFormFailureMode.Off, 2)]
+    public void RazorWireFormFailureMode_NumericValues_AreStable(
+        RazorWireFormFailureMode value,
+        int expected)
+    {
+        Assert.Equal(expected, (int)value);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorWire/RazorWireOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire/RazorWireOptions.cs
@@ -126,6 +126,8 @@ public class RazorWireFormOptions
 /// <remarks>
 /// This enum only applies when <see cref="RazorWireFormOptions.EnableFailureUx"/> is enabled. Per-form
 /// <c>data-rw-form-failure</c> values may narrow behavior for a specific form, but the global kill switch always wins.
+/// The numeric values are explicit because this public enum may be persisted, serialized, or bound by
+/// applications. New values should be appended without changing the values documented here.
 /// </remarks>
 public enum RazorWireFormFailureMode
 {
@@ -138,7 +140,7 @@ public enum RazorWireFormFailureMode
     /// <see cref="Bridge.RazorWireStreamBuilder.FormError(string,string,string)"/> or
     /// <see cref="Bridge.RazorWireStreamBuilder.FormValidationErrors(string,Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary,string,int,string)"/>.
     /// </remarks>
-    Auto,
+    Auto = 0,
 
     /// <summary>
     /// Emit request markers and lifecycle events, but do not render fallback UI.
@@ -147,7 +149,7 @@ public enum RazorWireFormFailureMode
     /// Choose this when the app needs RazorWire request classification and cancelable failure events but wants to own
     /// every visible error surface.
     /// </remarks>
-    Manual,
+    Manual = 1,
 
     /// <summary>
     /// Disable RazorWire's failed-form request markers, events, and fallback UI by default.
@@ -156,5 +158,5 @@ public enum RazorWireFormFailureMode
     /// Choose this when most forms should behave like plain enhanced Turbo forms and only selected forms should opt back
     /// into RazorWire failure handling with per-form attributes.
     /// </remarks>
-    Off
+    Off = 2
 }

--- a/Web/ForgeTrust.Runnable.Web.Tests/PublicEnumContractTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.Tests/PublicEnumContractTests.cs
@@ -1,0 +1,25 @@
+namespace ForgeTrust.Runnable.Web.Tests;
+
+public class PublicEnumContractTests
+{
+    [Theory]
+    [InlineData(ConventionalNotFoundPageMode.Auto, 0)]
+    [InlineData(ConventionalNotFoundPageMode.Enabled, 1)]
+    [InlineData(ConventionalNotFoundPageMode.Disabled, 2)]
+    public void ConventionalNotFoundPageMode_NumericValues_AreStable(
+        ConventionalNotFoundPageMode value,
+        int expected)
+    {
+        Assert.Equal(expected, (int)value);
+    }
+
+    [Theory]
+    [InlineData(MvcSupport.None, 0)]
+    [InlineData(MvcSupport.Controllers, 1)]
+    [InlineData(MvcSupport.ControllersWithViews, 2)]
+    [InlineData(MvcSupport.Full, 3)]
+    public void MvcSupport_NumericValues_AreStable(MvcSupport value, int expected)
+    {
+        Assert.Equal(expected, (int)value);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web/ConventionalNotFoundPageMode.cs
+++ b/Web/ForgeTrust.Runnable.Web/ConventionalNotFoundPageMode.cs
@@ -10,6 +10,8 @@ namespace ForgeTrust.Runnable.Web;
 /// Runnable needs to upgrade MVC support to controllers with views during startup. Use
 /// <see cref="Disabled"/> for API-first applications or when another status-code handling strategy should
 /// remain fully in control.
+/// The numeric values are explicit because this public enum may be persisted, serialized, or bound by
+/// applications. New values should be appended without changing the values documented here.
 /// </remarks>
 public enum ConventionalNotFoundPageMode
 {
@@ -21,7 +23,7 @@ public enum ConventionalNotFoundPageMode
     /// turns it on for apps whose MVC support is already <see cref="MvcSupport.ControllersWithViews"/> or
     /// higher.
     /// </remarks>
-    Auto,
+    Auto = 0,
 
     /// <summary>
     /// Always enables the conventional page and allows Runnable to upgrade MVC support when needed.
@@ -31,7 +33,7 @@ public enum ConventionalNotFoundPageMode
     /// from a controller-only configuration. This mode may increase MVC support to
     /// <see cref="MvcSupport.ControllersWithViews"/> so Razor views can render.
     /// </remarks>
-    Enabled,
+    Enabled = 1,
 
     /// <summary>
     /// Always disables Runnable's conventional page.
@@ -40,5 +42,5 @@ public enum ConventionalNotFoundPageMode
     /// Choose this when an app wants blank, JSON, API, or custom middleware-driven status responses without
     /// Runnable injecting the reserved <c>/_runnable/errors/404</c> route or browser-only 404 handling.
     /// </remarks>
-    Disabled
+    Disabled = 2
 }

--- a/Web/ForgeTrust.Runnable.Web/MvcOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web/MvcOptions.cs
@@ -26,25 +26,29 @@ public record MvcOptions
 /// <summary>
 /// Specifies the level of MVC feature support to enable in the web application.
 /// </summary>
+/// <remarks>
+/// The numeric values are explicit because this public enum may be persisted, serialized, or bound by
+/// applications. New values should be appended without changing the values documented here.
+/// </remarks>
 public enum MvcSupport
 {
     /// <summary>
     /// No MVC services are registered.
     /// </summary>
-    None,
+    None = 0,
 
     /// <summary>
     /// Only basic controller support (without views) is registered via <c>AddControllers()</c>.
     /// </summary>
-    Controllers,
+    Controllers = 1,
 
     /// <summary>
     /// Controller and Razor View support is registered via <c>AddControllersWithViews()</c>.
     /// </summary>
-    ControllersWithViews,
+    ControllersWithViews = 2,
 
     /// <summary>
     /// Full MVC support, including Pages and other features, is registered via <c>AddMvc()</c>.
     /// </summary>
-    Full
+    Full = 3
 }

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -61,6 +61,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Runnable web hosts now choose a deterministic localhost-only development URL when no endpoint is configured, while production, staging, container, and appsettings-based endpoint choices remain untouched.
 - Tailwind development watch mode now treats a missing standalone CLI as a recoverable local-tooling gap: the app keeps serving existing CSS and logs a warning that points to the runtime package or `TailwindCliPath` override.
 - Runnable's conventional browser 404 page now prioritizes user recovery paths, including documentation search for missing `/docs/...` routes and a home link for other misses, while still documenting how app owners can override the default page.
+- Runnable now assigns explicit numeric values to public Web and RazorWire enums, preserving existing ordinals for consumers that persist, serialize, bind, or compare those values.
 
 ### RazorWire package guidance
 


### PR DESCRIPTION
## Summary

- Assign explicit numeric values to remaining public Web and RazorWire enums while preserving current implicit ordinals.
- Document the enum ordinal compatibility expectation in XML remarks.
- Add focused contract tests for Core, Web, and RazorWire public enum numeric values.

## Why

Public enum ordinals can become part of consumer compatibility when values are persisted, serialized, bound, or compared numerically. Making the current values explicit protects existing consumers and makes future enum additions safer.

Fixes #202.

## Validation

- `git diff --check`
- `dotnet test ForgeTrust.Runnable.Core.Tests/ForgeTrust.Runnable.Core.Tests.csproj`
- `dotnet test Web/ForgeTrust.Runnable.Web.Tests/ForgeTrust.Runnable.Web.Tests.csproj`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.Tests/ForgeTrust.Runnable.Web.RazorWire.Tests.csproj`
