### PR TITLE
feat(config): support nested environment overrides

### DIFF
--- a/Config/ForgeTrust.Runnable.Config.Tests/DefaultConfigManagerTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/DefaultConfigManagerTests.cs
@@ -167,4 +167,174 @@ public class DefaultConfigManagerTests
 
         A.CallTo(logger).Where(c => c.Method.Name == "Log").MustHaveHappenedOnceExactly();
     }
+
+    [Fact]
+    public void GetValue_PatchesProviderObjectWithNestedEnvironmentVariable()
+    {
+        var innerEnvironment = A.Fake<ForgeTrust.Runnable.Core.IEnvironmentProvider>();
+        var fileProvider = A.Fake<IConfigProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+        var fileValue = new AppSettings
+        {
+            Mode = "file",
+            Database = new DatabaseOptions
+            {
+                Host = "db.from.file",
+                Port = 5432
+            }
+        };
+
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+        A.CallTo(() => fileProvider.Priority).Returns(1);
+        A.CallTo(() => fileProvider.Name).Returns("File");
+        A.CallTo(() => fileProvider.GetValue<AppSettings>("Production", "MyApp.Settings")).Returns(fileValue);
+
+        var environmentProvider = new EnvironmentConfigProvider(innerEnvironment);
+        var manager = new DefaultConfigManager(environmentProvider, [fileProvider], logger);
+
+        var value = manager.GetValue<AppSettings>("Production", "MyApp.Settings");
+
+        Assert.Same(fileValue, value);
+        Assert.NotNull(value);
+        Assert.Equal("file", value.Mode);
+        Assert.Equal("db.from.file", value.Database.Host);
+        Assert.Equal(6543, value.Database.Port);
+    }
+
+    [Fact]
+    public void GetValue_ReturnsDirectEnvironmentObjectBeforePatchingProviderValue()
+    {
+        var innerEnvironment = A.Fake<ForgeTrust.Runnable.Core.IEnvironmentProvider>();
+        var fileProvider = A.Fake<IConfigProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+        var directJson = """
+            {
+              "Mode": "environment",
+              "Database": {
+                "Host": "db.from.env",
+                "Port": 7000
+              }
+            }
+            """;
+
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable("MYAPP__SETTINGS", A<string?>._))
+            .Returns(directJson);
+
+        var environmentProvider = new EnvironmentConfigProvider(innerEnvironment);
+        var manager = new DefaultConfigManager(environmentProvider, [fileProvider], logger);
+
+        var value = manager.GetValue<AppSettings>("Production", "MyApp.Settings");
+
+        Assert.NotNull(value);
+        Assert.Equal("environment", value.Mode);
+        Assert.Equal("db.from.env", value.Database.Host);
+        Assert.Equal(7000, value.Database.Port);
+        A.CallTo(() => fileProvider.GetValue<AppSettings>(A<string>._, A<string>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public void GetValue_CreatesObjectFromNestedEnvironmentVariableWhenProvidersAreMissing()
+    {
+        var innerEnvironment = A.Fake<ForgeTrust.Runnable.Core.IEnvironmentProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable("MYAPP__SETTINGS__MODE", A<string?>._))
+            .Returns("environment");
+
+        var environmentProvider = new EnvironmentConfigProvider(innerEnvironment);
+        var manager = new DefaultConfigManager(environmentProvider, [], logger);
+
+        var value = manager.GetValue<AppSettings>("Production", "MyApp.Settings");
+
+        Assert.NotNull(value);
+        Assert.Equal("environment", value.Mode);
+    }
+
+    [Fact]
+    public void GetValue_PatchesProviderObjectWithGetterOnlyNestedObject()
+    {
+        var innerEnvironment = A.Fake<ForgeTrust.Runnable.Core.IEnvironmentProvider>();
+        var fileProvider = A.Fake<IConfigProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+        var fileValue = new GetterOnlyAppSettings
+        {
+            Mode = "file"
+        };
+        fileValue.Database.Host = "db.from.file";
+        fileValue.Database.Port = 5432;
+
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+        A.CallTo(() => fileProvider.Priority).Returns(1);
+        A.CallTo(() => fileProvider.GetValue<GetterOnlyAppSettings>("Production", "MyApp.Settings"))
+            .Returns(fileValue);
+
+        var environmentProvider = new EnvironmentConfigProvider(innerEnvironment);
+        var manager = new DefaultConfigManager(environmentProvider, [fileProvider], logger);
+
+        var value = manager.GetValue<GetterOnlyAppSettings>("Production", "MyApp.Settings");
+
+        Assert.Same(fileValue, value);
+        Assert.NotNull(value);
+        Assert.Equal("file", value.Mode);
+        Assert.Equal("db.from.file", value.Database.Host);
+        Assert.Equal(6543, value.Database.Port);
+    }
+
+    [Fact]
+    public void GetValue_PatchesProviderObjectWithGetterOnlyCollection()
+    {
+        var innerEnvironment = A.Fake<ForgeTrust.Runnable.Core.IEnvironmentProvider>();
+        var fileProvider = A.Fake<IConfigProvider>();
+        var logger = A.Fake<ILogger<DefaultConfigManager>>();
+        var fileValue = new GetterOnlyAppSettings();
+        fileValue.Endpoints.Add("https://file.example");
+
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable("MYAPP__SETTINGS__ENDPOINTS__0", A<string?>._))
+            .Returns("https://one.example");
+        A.CallTo(() => innerEnvironment.GetEnvironmentVariable("MYAPP__SETTINGS__ENDPOINTS__1", A<string?>._))
+            .Returns("https://two.example");
+        A.CallTo(() => fileProvider.Priority).Returns(1);
+        A.CallTo(() => fileProvider.GetValue<GetterOnlyAppSettings>("Production", "MyApp.Settings"))
+            .Returns(fileValue);
+
+        var environmentProvider = new EnvironmentConfigProvider(innerEnvironment);
+        var manager = new DefaultConfigManager(environmentProvider, [fileProvider], logger);
+
+        var value = manager.GetValue<GetterOnlyAppSettings>("Production", "MyApp.Settings");
+
+        Assert.Same(fileValue, value);
+        Assert.NotNull(value);
+        Assert.Equal(["https://one.example", "https://two.example"], value.Endpoints);
+    }
+
+    private sealed class AppSettings
+    {
+        public string? Mode { get; set; }
+
+        public DatabaseOptions Database { get; set; } = new();
+    }
+
+    private sealed class GetterOnlyAppSettings
+    {
+        public string? Mode { get; set; }
+
+        public DatabaseOptions Database { get; } = new();
+
+        public List<string> Endpoints { get; } = [];
+    }
+
+    private sealed class DatabaseOptions
+    {
+        public string? Host { get; set; }
+
+        public int Port { get; set; }
+    }
 }

--- a/Config/ForgeTrust.Runnable.Config.Tests/EnvironmentConfigProviderTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/EnvironmentConfigProviderTests.cs
@@ -450,4 +450,559 @@ public class EnvironmentConfigProviderTests
 
         Assert.Null(provider.GetValue<List<int>>("Production", "MyApp.Values"));
     }
+
+    [Fact]
+    public void TryPatch_PatchesNestedObjectFromDoubleUnderscoreVariables()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new AppSettings
+        {
+            Mode = "file",
+            Database = new DatabaseOptions
+            {
+                Host = "db.from.file",
+                Port = 5432
+            }
+        };
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out AppSettings? value);
+
+        Assert.True(patched);
+        Assert.Same(current, value);
+        Assert.NotNull(value);
+        Assert.Equal("file", value.Mode);
+        Assert.Equal("db.from.file", value.Database.Host);
+        Assert.Equal(6543, value.Database.Port);
+    }
+
+    [Fact]
+    public void TryPatch_CreatesNestedObjectWhenOnlyChildEnvironmentVariablesExist()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("PRODUCTION__MYAPP__SETTINGS__MODE", A<string?>._))
+            .Returns("env");
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("PRODUCTION__MYAPP__SETTINGS__DATABASE__HOST", A<string?>._))
+            .Returns("db.from.env");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        var patched = provider.TryPatch<AppSettings>("Production", "MyApp.Settings", null, out var value);
+
+        Assert.True(patched);
+        Assert.NotNull(value);
+        Assert.Equal("env", value.Mode);
+        Assert.NotNull(value.Database);
+        Assert.Equal("db.from.env", value.Database.Host);
+    }
+
+    [Fact]
+    public void TryPatch_PatchesIndexedCollectionMember()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__ENDPOINTS__0", A<string?>._))
+            .Returns("https://one.example");
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__ENDPOINTS__1", A<string?>._))
+            .Returns("https://two.example");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new AppSettings();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out AppSettings? value);
+
+        Assert.True(patched);
+        Assert.NotNull(value);
+        Assert.Equal(["https://one.example", "https://two.example"], value.Endpoints);
+    }
+
+    [Fact]
+    public void TryPatch_PatchesExistingGetterOnlyNestedObject()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new GetterOnlyAppSettings
+        {
+            Mode = "file"
+        };
+        current.Database.Host = "db.from.file";
+        current.Database.Port = 5432;
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out GetterOnlyAppSettings? value);
+
+        Assert.True(patched);
+        Assert.Same(current, value);
+        Assert.NotNull(value);
+        Assert.Equal("file", value.Mode);
+        Assert.Equal("db.from.file", value.Database.Host);
+        Assert.Equal(6543, value.Database.Port);
+    }
+
+    [Fact]
+    public void TryPatch_PatchesExistingGetterOnlyCollection()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__ENDPOINTS__0", A<string?>._))
+            .Returns("https://one.example");
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__ENDPOINTS__1", A<string?>._))
+            .Returns("https://two.example");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new GetterOnlyAppSettings();
+        current.Endpoints.Add("https://file.example");
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out GetterOnlyAppSettings? value);
+
+        Assert.True(patched);
+        Assert.Same(current, value);
+        Assert.NotNull(value);
+        Assert.Equal(["https://one.example", "https://two.example"], value.Endpoints);
+    }
+
+    [Fact]
+    public void TryPatch_PatchesExistingGetterOnlyCollectionFromEnvironmentScopedVariables()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("PRODUCTION__MYAPP__SETTINGS__ENDPOINTS__0", A<string?>._))
+            .Returns("https://one.example");
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("PRODUCTION__MYAPP__SETTINGS__ENDPOINTS__1", A<string?>._))
+            .Returns("https://two.example");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new GetterOnlyAppSettings();
+        current.Endpoints.Add("https://file.example");
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out GetterOnlyAppSettings? value);
+
+        Assert.True(patched);
+        Assert.NotNull(value);
+        Assert.Equal(["https://one.example", "https://two.example"], value.Endpoints);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotPatchScalarTopLevelValue()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        var patched = provider.TryPatch<string>("Production", "MyApp.Settings", null, out var value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotPatchNullableScalarTopLevelValue()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        var patched = provider.TryPatch<int?>("Production", "MyApp.Settings", null, out var value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotPatchTopLevelRuntimeScalarValue()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        var patched = provider.TryPatch<object>("Production", "MyApp.Settings", "file", out var value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotCreateTopLevelInterfaceValue()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        var provider = new EnvironmentConfigProvider(innerProvider);
+
+        var patched = provider.TryPatch<IConfigPatchContract>("Production", "MyApp.Settings", null, out var value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryPatch_SkipsIndexerProperties()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new IndexedOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out IndexedOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Equal("file", current[0]);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotPatchGetterOnlyScalarProperty()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__MODE", A<string?>._))
+            .Returns("environment");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new GetterOnlyScalarOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out GetterOnlyScalarOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Equal("file", current.Mode);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotPatchPrivateSetterScalarProperty()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__MODE", A<string?>._))
+            .Returns("environment");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new PrivateSetterOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out PrivateSetterOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Equal("file", current.Mode);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotAttachNullGetterOnlyNestedObject()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new NullGetterOnlyOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out NullGetterOnlyOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Null(current.Database);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotUsePrivateSetterToAttachNestedObject()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new PrivateSetterChildOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out PrivateSetterChildOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Null(current.Database);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotPatchGetterOnlyReadOnlyCollection()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__ENDPOINTS__0", A<string?>._))
+            .Returns("https://one.example");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new GetterOnlyReadOnlyCollectionOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out GetterOnlyReadOnlyCollectionOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Equal(["https://file.example"], current.Endpoints);
+    }
+
+    [Fact]
+    public void TryPatch_PatchesRootMemberWhenKeyIsEmpty()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MODE", A<string?>._))
+            .Returns("environment");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new AppSettings
+        {
+            Mode = "file"
+        };
+
+        var patched = provider.TryPatch("Production", string.Empty, current, out AppSettings? value);
+
+        Assert.True(patched);
+        Assert.Same(current, value);
+        Assert.Equal("environment", value?.Mode);
+    }
+
+    [Fact]
+    public void TryPatch_PatchesPublicWritableFields()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__MODE", A<string?>._))
+            .Returns("environment");
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__READ_ONLY_MODE", A<string?>._))
+            .Returns("environment-readonly");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new FieldBackedOptions();
+        current.Database.Host = "db.from.file";
+        current.Database.Port = 5432;
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out FieldBackedOptions? value);
+
+        Assert.True(patched);
+        Assert.Same(current, value);
+        Assert.NotNull(value);
+        Assert.Equal("environment", value.Mode);
+        Assert.Equal("file-readonly", value.ReadOnlyMode);
+        Assert.Equal("db.from.file", value.Database.Host);
+        Assert.Equal(6543, value.Database.Port);
+    }
+
+    [Fact]
+    public void TryPatch_CreatesNullFieldChildWhenChildEnvironmentVariablesExist()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("6543");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new NullableFieldBackedOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out NullableFieldBackedOptions? value);
+
+        Assert.True(patched);
+        Assert.Same(current, value);
+        Assert.NotNull(value?.Database);
+        Assert.Equal(6543, value.Database.Port);
+    }
+
+    [Fact]
+    public void TryPatch_SkipsNullInterfaceChildProperty()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__CHILD__VALUE", A<string?>._))
+            .Returns("environment");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new InterfaceChildOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out InterfaceChildOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Null(current.Child);
+    }
+
+    [Fact]
+    public void TryPatch_SkipsChildPropertyWhenConstructorThrows()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__CHILD__VALUE", A<string?>._))
+            .Returns("environment");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new ThrowingChildOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out ThrowingChildOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Null(current.Child);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotRecurseThroughCycles()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__CHILD__NAME", A<string?>._))
+            .Returns("environment");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new CyclicOptions();
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out CyclicOptions? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Equal("file", current.Name);
+    }
+
+    [Fact]
+    public void TryPatch_DoesNotReplaceExistingValueWhenChildEnvironmentVariableIsInvalid()
+    {
+        var innerProvider = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => innerProvider.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        A.CallTo(() => innerProvider.GetEnvironmentVariable("MYAPP__SETTINGS__DATABASE__PORT", A<string?>._))
+            .Returns("not-a-port");
+
+        var provider = new EnvironmentConfigProvider(innerProvider);
+        var current = new AppSettings
+        {
+            Database = new DatabaseOptions
+            {
+                Host = "db.from.file",
+                Port = 5432
+            }
+        };
+
+        var patched = provider.TryPatch("Production", "MyApp.Settings", current, out AppSettings? value);
+
+        Assert.False(patched);
+        Assert.Null(value);
+        Assert.Equal(5432, current.Database.Port);
+    }
+
+    private sealed class AppSettings
+    {
+        public string? Mode { get; set; }
+
+        public DatabaseOptions Database { get; set; } = new();
+
+        public List<string> Endpoints { get; set; } = [];
+    }
+
+    private sealed class GetterOnlyAppSettings
+    {
+        public string? Mode { get; set; }
+
+        public DatabaseOptions Database { get; } = new();
+
+        public List<string> Endpoints { get; } = [];
+    }
+
+    private interface IConfigPatchContract
+    {
+        string? Value { get; set; }
+    }
+
+    private sealed class IndexedOptions
+    {
+        public string this[int index]
+        {
+            get => "file";
+            set { }
+        }
+    }
+
+    private sealed class GetterOnlyScalarOptions
+    {
+        public string Mode { get; } = "file";
+    }
+
+    private sealed class PrivateSetterOptions
+    {
+        public string Mode { get; private set; } = "file";
+    }
+
+    private sealed class NullGetterOnlyOptions
+    {
+        public DatabaseOptions? Database { get; }
+    }
+
+    private sealed class PrivateSetterChildOptions
+    {
+        public DatabaseOptions? Database { get; private set; }
+    }
+
+    private sealed class GetterOnlyReadOnlyCollectionOptions
+    {
+        public IList<string> Endpoints { get; } = Array.AsReadOnly(["https://file.example"]);
+    }
+
+    private sealed class FieldBackedOptions
+    {
+        public string? Mode = "file";
+
+        public readonly string ReadOnlyMode = "file-readonly";
+
+        public DatabaseOptions Database = new();
+    }
+
+    private sealed class NullableFieldBackedOptions
+    {
+        public NullableFieldBackedOptions()
+        {
+            Database = null;
+        }
+
+        public DatabaseOptions? Database;
+    }
+
+    private sealed class InterfaceChildOptions
+    {
+        public IConfigPatchContract? Child { get; set; }
+    }
+
+    private sealed class ThrowingChildOptions
+    {
+        public ThrowingChild? Child { get; set; }
+    }
+
+    private sealed class ThrowingChild
+    {
+        public ThrowingChild()
+        {
+            throw new InvalidOperationException("Constructor should be treated as unpatchable.");
+        }
+
+        public string? Value { get; set; }
+    }
+
+    private sealed class CyclicOptions
+    {
+        public CyclicOptions()
+        {
+            Child = this;
+        }
+
+        public string Name { get; set; } = "file";
+
+        public CyclicOptions Child { get; set; }
+    }
+
+    private sealed class DatabaseOptions
+    {
+        public string? Host { get; set; }
+
+        public int Port { get; set; }
+    }
 }

--- a/Config/ForgeTrust.Runnable.Config/DefaultConfigManager.cs
+++ b/Config/ForgeTrust.Runnable.Config/DefaultConfigManager.cs
@@ -54,15 +54,33 @@ internal partial class DefaultConfigManager : IConfigManager
             return envValue;
         }
 
+        T? providerValue = default;
+        string? providerName = null;
         foreach (var provider in _otherProviders)
         {
             var value = provider.GetValue<T>(environment, key);
             if (value != null)
             {
-                LogRetrievedFromEnvironment(key, environment, provider.Name);
+                providerValue = value;
+                providerName = provider.Name;
 
-                return value;
+                break;
             }
+        }
+
+        if (_environmentProvider is IConfigValuePatcher patcher
+            && patcher.TryPatch(environment, key, providerValue, out var patchedValue))
+        {
+            LogRetrievedFromEnvironment(key, environment, "Environment");
+
+            return patchedValue;
+        }
+
+        if (providerValue != null)
+        {
+            LogRetrievedFromEnvironment(key, environment, providerName!);
+
+            return providerValue;
         }
 
         LogKeyNotFound(key, environment);

--- a/Config/ForgeTrust.Runnable.Config/EnvironmentConfigProvider.cs
+++ b/Config/ForgeTrust.Runnable.Config/EnvironmentConfigProvider.cs
@@ -1,4 +1,6 @@
 ﻿using System.Globalization;
+using System.Collections;
+using System.Reflection;
 using System.Text.Json;
 using ForgeTrust.Runnable.Core;
 
@@ -7,7 +9,7 @@ namespace ForgeTrust.Runnable.Config;
 /// <summary>
 /// A configuration provider that retrieves values from environment variables.
 /// </summary>
-internal class EnvironmentConfigProvider : IEnvironmentConfigProvider
+internal class EnvironmentConfigProvider : IEnvironmentConfigProvider, IConfigValuePatcher
 {
     // Safety limit for indexed env-var collections (KEY__0, KEY__1, ...).
     // Prevents unbounded probing while still supporting large lists.
@@ -58,14 +60,14 @@ internal class EnvironmentConfigProvider : IEnvironmentConfigProvider
             // lower-priority key formats as fallback when parsing fails.
         }
 
-        if (TryReadIndexedCollection<T>($"{envPrefix}__{hierarchicalKey}", out var envScopedCollection))
+        if (TryReadIndexedCollection(typeof(T), $"{envPrefix}__{hierarchicalKey}", out var envScopedCollection))
         {
-            return envScopedCollection;
+            return (T?)envScopedCollection;
         }
 
-        if (TryReadIndexedCollection<T>(hierarchicalKey, out var collection))
+        if (TryReadIndexedCollection(typeof(T), hierarchicalKey, out var collection))
         {
-            return collection;
+            return (T?)collection;
         }
 
         return default;
@@ -80,6 +82,42 @@ internal class EnvironmentConfigProvider : IEnvironmentConfigProvider
     /// <inheritdoc />
     public string? GetEnvironmentVariable(string name, string? defaultValue = null) =>
         _environmentProvider.GetEnvironmentVariable(name, defaultValue);
+
+    /// <inheritdoc />
+    public bool TryPatch<T>(string environment, string key, T? currentValue, out T? patchedValue)
+    {
+        patchedValue = default;
+
+        var targetType = typeof(T);
+        if (!IsPatchableComplexType(targetType) && currentValue == null)
+        {
+            return false;
+        }
+
+        var runtimeType = currentValue?.GetType() ?? targetType;
+        if (!IsPatchableComplexType(runtimeType))
+        {
+            return false;
+        }
+
+        object? target = currentValue;
+        if (target == null && !TryCreateInstance(runtimeType, out target))
+        {
+            return false;
+        }
+
+        var envPrefix = NormalizeSegment(environment);
+        var hierarchicalKey = NormalizeHierarchicalKey(key);
+        var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        if (!TryPatchObject(target!, runtimeType, envPrefix, hierarchicalKey, visited))
+        {
+            return false;
+        }
+
+        patchedValue = (T?)target!;
+        return true;
+    }
 
     /// <summary>
     /// Converts a key/environment segment to uppercase (via <see cref="string.ToUpperInvariant"/>)
@@ -137,10 +175,9 @@ internal class EnvironmentConfigProvider : IEnvironmentConfigProvider
         return true;
     }
 
-    private bool TryReadIndexedCollection<T>(string keyPrefix, out T? parsed)
+    private bool TryReadIndexedCollection(Type targetType, string keyPrefix, out object? parsed)
     {
         parsed = default;
-        var targetType = typeof(T);
         var elementType = GetCollectionElementType(targetType);
         if (elementType == null)
         {
@@ -164,7 +201,7 @@ internal class EnvironmentConfigProvider : IEnvironmentConfigProvider
             values.Add(value);
         }
 
-        var typedList = (System.Collections.IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType))!;
+        var typedList = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType))!;
         foreach (var value in values)
         {
             if (!TryConvertStringToType(value, elementType, out var element))
@@ -179,11 +216,11 @@ internal class EnvironmentConfigProvider : IEnvironmentConfigProvider
         {
             var array = Array.CreateInstance(elementType, typedList.Count);
             typedList.CopyTo(array, 0);
-            parsed = (T)(object)array;
+            parsed = array;
             return true;
         }
 
-        parsed = (T)typedList;
+        parsed = typedList;
         return true;
     }
 
@@ -301,4 +338,218 @@ internal class EnvironmentConfigProvider : IEnvironmentConfigProvider
         targetType.IsPrimitive
         || targetType == typeof(decimal)
         || targetType == typeof(DateTime);
+
+    private bool TryPatchObject(
+        object target,
+        Type targetType,
+        string envPrefix,
+        string hierarchicalKey,
+        HashSet<object> visited)
+    {
+        if (!visited.Add(target))
+        {
+            return false;
+        }
+
+        var patched = false;
+
+        foreach (var property in targetType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (property.GetIndexParameters().Length != 0)
+            {
+                continue;
+            }
+
+            var childKey = CombineHierarchicalKey(hierarchicalKey, property.Name);
+            if (TryReadMemberValue(property.PropertyType, envPrefix, childKey, out var propertyValue))
+            {
+                if (HasPublicSetter(property))
+                {
+                    property.SetValue(target, propertyValue);
+                    patched = true;
+                    continue;
+                }
+
+                if (property.GetMethod != null
+                    && TryPatchExistingCollection(property.GetValue(target), propertyValue))
+                {
+                    patched = true;
+                    continue;
+                }
+
+                continue;
+            }
+
+            if (!IsPatchableComplexType(property.PropertyType))
+            {
+                continue;
+            }
+
+            object? child = null;
+            if (property.GetMethod != null)
+            {
+                child = property.GetValue(target);
+            }
+
+            if (child == null)
+            {
+                if (!HasPublicSetter(property)
+                    || !TryCreateInstance(property.PropertyType, out child))
+                {
+                    continue;
+                }
+            }
+
+            var childToPatch = child!;
+            if (TryPatchObject(childToPatch, childToPatch.GetType(), envPrefix, childKey, visited))
+            {
+                if (HasPublicSetter(property))
+                {
+                    property.SetValue(target, childToPatch);
+                }
+
+                patched = true;
+            }
+        }
+
+        foreach (var field in targetType.GetFields(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (field.IsInitOnly)
+            {
+                continue;
+            }
+
+            var childKey = CombineHierarchicalKey(hierarchicalKey, field.Name);
+            if (TryReadMemberValue(field.FieldType, envPrefix, childKey, out var fieldValue))
+            {
+                field.SetValue(target, fieldValue);
+                patched = true;
+                continue;
+            }
+
+            if (!IsPatchableComplexType(field.FieldType))
+            {
+                continue;
+            }
+
+            var child = field.GetValue(target);
+            if (child == null)
+            {
+                if (!TryCreateInstance(field.FieldType, out child))
+                {
+                    continue;
+                }
+            }
+
+            var childToPatch = child!;
+            if (TryPatchObject(childToPatch, childToPatch.GetType(), envPrefix, childKey, visited))
+            {
+                field.SetValue(target, childToPatch);
+                patched = true;
+            }
+        }
+
+        // Remove on unwind so DAG-shaped graphs can revisit the same instance by another path;
+        // visited.Add(target) still returns false early for true cycles.
+        visited.Remove(target);
+        return patched;
+    }
+
+    private bool TryReadMemberValue(Type targetType, string envPrefix, string hierarchicalKey, out object? parsed)
+    {
+        var legacyKey = hierarchicalKey.Replace("__", "_", StringComparison.Ordinal);
+        foreach (var candidate in BuildDirectCandidates(envPrefix, legacyKey, hierarchicalKey))
+        {
+            var value = _environmentProvider.GetEnvironmentVariable(candidate);
+            if (value == null)
+            {
+                continue;
+            }
+
+            if (TryConvertStringToType(value, targetType, out parsed))
+            {
+                return true;
+            }
+        }
+
+        if (TryReadIndexedCollection(targetType, $"{envPrefix}__{hierarchicalKey}", out parsed))
+        {
+            return true;
+        }
+
+        if (TryReadIndexedCollection(targetType, hierarchicalKey, out parsed))
+        {
+            return true;
+        }
+
+        parsed = default;
+        return false;
+    }
+
+    private static bool TryPatchExistingCollection(object? targetCollection, object? replacement)
+    {
+        if (targetCollection is not IList targetList
+            || replacement is not IEnumerable replacementValues
+            || targetList.IsReadOnly
+            || targetList.IsFixedSize)
+        {
+            return false;
+        }
+
+        targetList.Clear();
+        foreach (var value in replacementValues)
+        {
+            targetList.Add(value);
+        }
+
+        return true;
+    }
+
+    private static bool HasPublicSetter(PropertyInfo property) =>
+        property.SetMethod?.IsPublic == true;
+
+    private static string CombineHierarchicalKey(string parentKey, string memberName)
+    {
+        var memberKey = NormalizeHierarchicalKey(memberName);
+        return string.IsNullOrEmpty(parentKey) ? memberKey : $"{parentKey}__{memberKey}";
+    }
+
+    private static bool IsPatchableComplexType(Type targetType)
+    {
+        var nullableUnderlying = Nullable.GetUnderlyingType(targetType);
+        if (nullableUnderlying != null)
+        {
+            targetType = nullableUnderlying;
+        }
+
+        return targetType != typeof(string)
+               && !IsSimpleType(targetType)
+               && !targetType.IsEnum
+               && targetType != typeof(Guid)
+               && targetType != typeof(DateTimeOffset)
+               && targetType != typeof(TimeSpan)
+               && GetCollectionElementType(targetType) == null
+               && !typeof(IDictionary).IsAssignableFrom(targetType);
+    }
+
+    private static bool TryCreateInstance(Type targetType, out object? instance)
+    {
+        instance = null;
+
+        if (targetType.IsAbstract || targetType.IsInterface)
+        {
+            return false;
+        }
+
+        try
+        {
+            instance = Activator.CreateInstance(targetType);
+            return instance != null;
+        }
+        catch (Exception ex) when (ex is MissingMethodException or MemberAccessException or TargetInvocationException
+                                       or NotSupportedException)
+        {
+            return false;
+        }
+    }
 }

--- a/Config/ForgeTrust.Runnable.Config/IConfigValuePatcher.cs
+++ b/Config/ForgeTrust.Runnable.Config/IConfigValuePatcher.cs
@@ -1,0 +1,27 @@
+namespace ForgeTrust.Runnable.Config;
+
+/// <summary>
+/// Provides object-graph patching for configuration providers that can supply child values beneath a requested key.
+/// </summary>
+/// <remarks>
+/// This is an internal provider seam, not a consumer-facing configuration API. <see cref="DefaultConfigManager"/>
+/// uses it after direct provider resolution so hierarchical override sources can update only the supplied child
+/// values instead of replacing an entire options object.
+/// </remarks>
+internal interface IConfigValuePatcher
+{
+    /// <summary>
+    /// Attempts to apply provider-owned child values beneath <paramref name="key"/> to
+    /// <paramref name="currentValue"/>.
+    /// </summary>
+    /// <typeparam name="T">The requested configuration value type.</typeparam>
+    /// <param name="environment">The active environment name.</param>
+    /// <param name="key">The configuration key whose child values may be present.</param>
+    /// <param name="currentValue">The value supplied by a lower-priority provider, or <see langword="default"/>.</param>
+    /// <param name="patchedValue">
+    /// When this method returns <see langword="true"/>, contains the patched value. Otherwise contains
+    /// <see langword="default"/>.
+    /// </param>
+    /// <returns><see langword="true"/> when at least one child value was applied.</returns>
+    bool TryPatch<T>(string environment, string key, T? currentValue, out T? patchedValue);
+}

--- a/Config/ForgeTrust.Runnable.Config/README.md
+++ b/Config/ForgeTrust.Runnable.Config/README.md
@@ -37,6 +37,58 @@ public sealed class DocsPathConfig : Config<string>
 
 Resolve them through the configuration services used by your module or application startup flow.
 
+## Environment Overrides
+
+Environment variables override file-based providers. Runnable supports both the legacy flattened shape and the
+hierarchical double-underscore shape commonly used by .NET configuration:
+
+```text
+PRODUCTION_APP_SETTINGS
+APP_SETTINGS
+PRODUCTION__APP__SETTINGS
+APP__SETTINGS
+```
+
+Use a direct value when one environment variable should replace the whole requested config value. For object-valued
+config, the direct value is parsed as JSON:
+
+```text
+APP__SETTINGS={"Database":{"Host":"db.example","Port":5432}}
+```
+
+Use child variables when deployment needs to override one member without replacing the rest of an options object loaded
+from JSON files, or when the target type can be built from child variables alone:
+
+```text
+APP__SETTINGS__DATABASE__PORT=6543
+```
+
+When `App.Settings` is resolved as an object, Runnable first looks for a direct environment value. If none exists,
+`DefaultConfigManager` asks `EnvironmentConfigProvider.TryPatch` to apply matching child variables. If a lower-priority
+provider supplied an object, child variables patch that object and preserve existing members. If no provider produced a
+value, `EnvironmentConfigProvider` can construct an instantiable target type from child variables alone. That means
+`APP__SETTINGS__DATABASE__PORT` can update only `Database.Port` while preserving `Database.Host` from `appsettings.json`,
+or create `App.Settings` from child variables such as `APP__SETTINGS__MODE=environment` when no provider value exists.
+
+Indexed collection variables are supported for top-level values and object members:
+
+```text
+APP__SETTINGS__ENDPOINTS__0=https://one.example
+APP__SETTINGS__ENDPOINTS__1=https://two.example
+```
+
+### Override Pitfalls
+
+- A direct object environment variable replaces the whole object; use child variables for partial overrides.
+- Child patching targets public settable properties, initialized getter-only mutable collections or nested objects, and
+  public writable fields. Types that cannot be instantiated need a lower-priority provider value or an already-initialized
+  nested member to patch.
+- Invalid child values are ignored instead of wiping out the lower-priority provider value. For example, a non-numeric
+  `APP__SETTINGS__DATABASE__PORT` leaves the existing `Port` unchanged.
+- Child environment variables patch provider-supplied values or construct an instantiable missing value; they do not patch
+  `Config<T>.DefaultValue`. Put deploy-time defaults in a normal provider when they need member-level environment
+  overrides.
+
 ## DataAnnotations Validation
 
 `Config<T>` and `ConfigStruct<T>` validate the resolved value during initialization when the value is present. Validation runs after provider/default resolution, so defaults are held to the same rules as provider-supplied values. Optional `ConfigStruct<T>` values resolve through nullable `T?` provider lookups so a missing struct value is not confused with a configured zero-initialized value.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -55,6 +55,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 
 - Strongly typed config wrappers now validate resolved object values with DataAnnotations during startup, including defaults, and report operator-friendly `ConfigurationValidationException` failures without echoing attempted values.
 - Nested config validation can now opt into Microsoft Options `[ValidateObjectMembers]` and `[ValidateEnumeratedItems]` markers while Runnable owns traversal, path formatting, and cycle protection.
+- Environment variables can now patch individual members of object-valued config loaded from lower-priority providers, so `APP__SETTINGS__DATABASE__PORT` can override one nested value without replacing the rest of the JSON-backed options object.
 
 ### Web host development defaults
 


### PR DESCRIPTION
## Summary

Fixes #54.

- add an internal config patching seam so environment variables can override child members beneath object-valued config
- allow nested double-underscore variables to patch provider-loaded options without replacing the whole object
- support initialized getter-only nested objects and getter-only `List<T>` collection members
- document direct-vs-child environment override behavior and pitfalls

## Validation

- `dotnet test Config/ForgeTrust.Runnable.Config.Tests/ForgeTrust.Runnable.Config.Tests.csproj`
- `dotnet format Config/ForgeTrust.Runnable.Config.Tests/ForgeTrust.Runnable.Config.Tests.csproj`
- `dotnet build`
- `git diff --check`