### PR TITLE
test: stabilize RazorDocs wayfinding title assertion

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -46,18 +46,26 @@ public sealed class RazorDocsWayfindingPlaywrightTests
             "/docs/Web/ForgeTrust.Runnable.Web.RazorWire/Docs/form-failures.md.html",
             await page.GetAttributeAsync("[data-doc-wayfinding='next']", "href"));
 
+        const string nextPagePath = "/docs/Web/ForgeTrust.Runnable.Web.RazorWire/Docs/form-failures.md.html";
+        const string nextPageTitle = "Failed Form UX";
+
         await page.ClickAsync("[data-doc-wayfinding='next']");
         await page.WaitForFunctionAsync(
-            "() => window.location.pathname.endsWith('/docs/Web/ForgeTrust.Runnable.Web.RazorWire/Docs/form-failures.md.html')",
-            null,
+            """
+            (args) => {
+              const heading = document.querySelector('#doc-content h1');
+              return window.location.pathname === args.path
+                && heading?.textContent?.trim() === args.title;
+            }
+            """,
+            new
+            {
+                path = nextPagePath,
+                title = nextPageTitle
+            },
             new PageWaitForFunctionOptions { Timeout = 15_000 });
-        await page.WaitForSelectorAsync("h1", new PageWaitForSelectorOptions
-        {
-            Timeout = 30_000,
-            State = WaitForSelectorState.Visible
-        });
 
-        Assert.Equal("Failed Form UX", (await page.TextContentAsync("h1"))?.Trim());
+        Assert.Equal(nextPageTitle, (await page.Locator("#doc-content h1").First.TextContentAsync())?.Trim());
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -39,15 +39,15 @@ public sealed class RazorDocsWayfindingPlaywrightTests
             "#files-behind-the-hero-flow",
             await page.GetAttributeAsync("#docs-page-outline a[href='#files-behind-the-hero-flow']", "href"));
 
+        const string nextPagePath = "/docs/Web/ForgeTrust.Runnable.Web.RazorWire/Docs/form-failures.md.html";
+        const string nextPageTitle = "Failed Form UX";
+
         Assert.Equal(
             "/docs/Web/ForgeTrust.Runnable.Web.RazorWire/README.md.html",
             await page.GetAttributeAsync("[data-doc-wayfinding='previous']", "href"));
         Assert.Equal(
-            "/docs/Web/ForgeTrust.Runnable.Web.RazorWire/Docs/form-failures.md.html",
+            nextPagePath,
             await page.GetAttributeAsync("[data-doc-wayfinding='next']", "href"));
-
-        const string nextPagePath = "/docs/Web/ForgeTrust.Runnable.Web.RazorWire/Docs/form-failures.md.html";
-        const string nextPageTitle = "Failed Form UX";
 
         await page.ClickAsync("[data-doc-wayfinding='next']");
         await page.WaitForFunctionAsync(

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -84,6 +84,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Shared RazorDocs badges, metadata chips, provenance strips, and trust bars now live in the shared package stylesheet while `search.css` stays focused on search-specific UI.
 - RazorDocs search now keeps failure recovery markup out of the active search shell until the index actually fails to load, so successful searches no longer expose hidden failure copy to text extraction tools.
 - RazorDocs now treats `Releases` as a first-class public section and suppresses breadcrumb links to generated parent routes that do not correspond to published docs pages, keeping static export warnings focused on actionable broken links.
+- RazorDocs wayfinding coverage now waits for docs content replacement before asserting sequence-link destinations, keeping the details-page proof path deterministic in CI.
 
 ### RazorWire form UX
 


### PR DESCRIPTION
## Summary

- stabilize the RazorDocs wayfinding Playwright assertion after navigating to the failed form UX details page
- wait for the docs content island heading to match the destination title instead of treating URL advancement as enough
- keep the user-visible outline and sequence wayfinding coverage intact

Fixes #212

## Validation

- dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --filter "FullyQualifiedName~RazorDocsWayfindingPlaywrightTests.DetailsPage_RendersOutline_AndSequenceWayfinding"
- dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --filter "FullyQualifiedName~RazorDocsWayfindingPlaywrightTests"
- ./scripts/coverage-solution.sh
- dotnet format --verify-no-changes