### PR TITLE
test: add OpenAPI module coverage

### DIFF
--- a/ForgeTrust.Runnable.slnx
+++ b/ForgeTrust.Runnable.slnx
@@ -45,6 +45,7 @@
     <Project Path="Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj" />
     <Project Path="Web/ForgeTrust.Runnable.Web.RazorDocs/ForgeTrust.Runnable.Web.RazorDocs.csproj" />
     <Project Path="Web/ForgeTrust.Runnable.Web.RazorDocs.Standalone/ForgeTrust.Runnable.Web.RazorDocs.Standalone.csproj" />
+    <Project Path="Web/ForgeTrust.Runnable.Web.OpenApi.Tests/ForgeTrust.Runnable.Web.OpenApi.Tests.csproj" />
     <Project Path="Web/ForgeTrust.Runnable.Web.OpenApi/ForgeTrust.Runnable.Web.OpenApi.csproj" />
     <Project Path="Web/ForgeTrust.Runnable.Web.Scalar.Tests/ForgeTrust.Runnable.Web.Scalar.Tests.csproj" />
     <Project Path="Web/ForgeTrust.Runnable.Web.Scalar/ForgeTrust.Runnable.Web.Scalar.csproj" />

--- a/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/ForgeTrust.Runnable.Web.OpenApi.Tests.csproj
+++ b/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/ForgeTrust.Runnable.Web.OpenApi.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="JunitXml.TestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ForgeTrust.Runnable.Web.OpenApi/ForgeTrust.Runnable.Web.OpenApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/README.md
+++ b/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/README.md
@@ -1,0 +1,12 @@
+# ForgeTrust.Runnable.Web.OpenApi.Tests
+
+This test project verifies the public behavior of `ForgeTrust.Runnable.Web.OpenApi`.
+
+## Coverage
+
+- `RunnableWebOpenApiModule.ConfigureServices` registers OpenAPI document generation and endpoint API explorer services.
+- `RunnableWebOpenApiModule.ConfigureEndpoints` maps the conventional `/openapi/{documentName}.json` endpoint.
+- Hosted integration coverage confirms generated OpenAPI documents use the `StartupContext.ApplicationName` title.
+- Hosted integration coverage confirms the default document and operation transformers remove framework-owned `ForgeTrust.Runnable.Web` tags while preserving consumer tags.
+
+The tests exercise the module through its public `IRunnableWebModule` entry points and a real `WebStartup<RunnableWebOpenApiModule>` host. This keeps the contract focused on observable package behavior rather than private OpenAPI option internals.

--- a/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/RunnableWebOpenApiModuleTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/RunnableWebOpenApiModuleTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Text.Json;
+using ForgeTrust.Runnable.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace ForgeTrust.Runnable.Web.OpenApi.Tests;
+
+public sealed class RunnableWebOpenApiModuleTests
+{
+    [Fact]
+    public void ConfigureServices_RegistersOpenApiAndEndpointApiExplorerServices()
+    {
+        var module = new RunnableWebOpenApiModule();
+        var services = new ServiceCollection();
+
+        module.ConfigureServices(CreateContext(module), services);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<OpenApiOptions>>().Get("v1");
+
+        Assert.Equal("v1", options.DocumentName);
+        Assert.Contains(services, service => service.ServiceType == typeof(IApiDescriptionGroupCollectionProvider));
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_MapsDefaultOpenApiEndpoint()
+    {
+        var module = new RunnableWebOpenApiModule();
+        var builder = WebApplication.CreateBuilder();
+        await using var app = builder.Build();
+
+        module.ConfigureEndpoints(CreateContext(module), app);
+
+        var routeEndpoints = ((IEndpointRouteBuilder)app)
+            .DataSources
+            .SelectMany(dataSource => dataSource.Endpoints)
+            .OfType<RouteEndpoint>();
+
+        Assert.Contains(
+            routeEndpoints,
+            endpoint => endpoint.RoutePattern.RawText == "/openapi/{documentName}.json");
+    }
+
+    [Fact]
+    public async Task RunnableWebApp_GeneratesDocumentTitleFromStartupContext()
+    {
+        using var document = await GetOpenApiDocumentAsync(endpoints =>
+        {
+            endpoints.MapGet("/health", () => Results.Ok(new { status = "ok" }));
+        });
+
+        Assert.Equal(
+            "OpenApiTestApp | v1",
+            document.RootElement.GetProperty("info").GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public async Task RunnableWebApp_RemovesRunnableWebDocumentTags()
+    {
+        using var document = await GetOpenApiDocumentAsync(endpoints =>
+        {
+            endpoints
+                .MapGet("/runnable", () => Results.Ok())
+                .WithTags("ForgeTrust.Runnable.Web", "DocumentApi");
+        });
+
+        var documentTags = GetDocumentTags(document.RootElement);
+
+        Assert.DoesNotContain("ForgeTrust.Runnable.Web", documentTags);
+        Assert.Contains("DocumentApi", documentTags);
+    }
+
+    [Fact]
+    public async Task RunnableWebApp_RemovesRunnableWebOperationTagsAndPreservesUnrelatedTags()
+    {
+        using var document = await GetOpenApiDocumentAsync(endpoints =>
+        {
+            endpoints
+                .MapGet("/mixed-tags", () => Results.Ok())
+                .WithTags("ForgeTrust.Runnable.Web", "PublicApi");
+        });
+
+        var operationTags = GetOperationTags(document.RootElement, "/mixed-tags", "get");
+
+        Assert.DoesNotContain("ForgeTrust.Runnable.Web", operationTags);
+        Assert.Contains("PublicApi", operationTags);
+    }
+
+    [Fact]
+    public async Task NoOpLifecycleMethods_AreSafeToCallWithNormalInputs()
+    {
+        var module = new RunnableWebOpenApiModule();
+        var context = CreateContext(module);
+        var hostBuilder = Host.CreateDefaultBuilder();
+        var appBuilder = WebApplication.CreateBuilder();
+        await using var app = appBuilder.Build();
+
+        var exception = Record.Exception(() =>
+        {
+            module.RegisterDependentModules(new ModuleDependencyBuilder());
+            module.ConfigureHostBeforeServices(context, hostBuilder);
+            module.ConfigureHostAfterServices(context, hostBuilder);
+            module.ConfigureWebApplication(context, app);
+        });
+
+        Assert.Null(exception);
+    }
+
+    private static StartupContext CreateContext(RunnableWebOpenApiModule module) =>
+        new([], module, "OpenApiTestApp");
+
+    private static async Task<JsonDocument> GetOpenApiDocumentAsync(Action<IEndpointRouteBuilder> mapEndpoints)
+    {
+        var startup = new TestOpenApiStartup();
+        startup.WithOptions(options => options.MapEndpoints = mapEndpoints);
+
+        var module = new RunnableWebOpenApiModule();
+        var context = CreateContext(module);
+        var builder = ((IRunnableStartup)startup).CreateHostBuilder(context);
+        builder.ConfigureWebHost(webHost => webHost.UseUrls("http://127.0.0.1:0"));
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        try
+        {
+            using var client = new HttpClient
+            {
+                BaseAddress = new Uri(GetBaseAddress(host))
+            };
+
+            using var response = await client.GetAsync("/openapi/v1.json");
+            var openApiJson = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            return JsonDocument.Parse(openApiJson);
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+
+    private static string GetBaseAddress(IHost host)
+    {
+        var addresses = host.Services
+            .GetRequiredService<IServer>()
+            .Features
+            .Get<IServerAddressesFeature>()
+            ?.Addresses;
+
+        return Assert.Single(addresses ?? []);
+    }
+
+    private static string[] GetDocumentTags(JsonElement document)
+    {
+        if (!document.TryGetProperty("tags", out var tags))
+        {
+            return [];
+        }
+
+        return tags
+            .EnumerateArray()
+            .Select(tag => tag.GetProperty("name").GetString())
+            .OfType<string>()
+            .ToArray();
+    }
+
+    private static string[] GetOperationTags(JsonElement document, string path, string method)
+    {
+        return document
+            .GetProperty("paths")
+            .GetProperty(path)
+            .GetProperty(method)
+            .GetProperty("tags")
+            .EnumerateArray()
+            .Select(tag => tag.GetString())
+            .OfType<string>()
+            .ToArray();
+    }
+
+    private sealed class TestOpenApiStartup : WebStartup<RunnableWebOpenApiModule>;
+}

--- a/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/packages.lock.json
+++ b/Web/ForgeTrust.Runnable.Web.OpenApi.Tests/packages.lock.json
@@ -1,0 +1,149 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.msbuild": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "Qa7Hg+wrOMDKpXVn2dw4Wlun490bIWsFW0fdNJQFJLZnbU27MCP0HJ2mPgS+3EQBQUb0zKlkwiQzP+j38Hc3Iw=="
+      },
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[2.4.1, )",
+        "resolved": "2.4.1",
+        "contentHash": "SH1ar/kg36CggzMqLUDRoUqR8SSjK/JiQ2JS8MYg8u0RCLDkkDEbPGIN91omOPx9f2GuDqsxxofSdgsQje3Xuw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.10.0"
+        }
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[6.1.0, )",
+        "resolved": "6.1.0",
+        "contentHash": "a3ciawoHOzqcry7yS5z9DerNyF9QZi6fEZZJPILSy6Noj6+r8Ydma+cENA6wvivXDCblpXxw72wWT9QApNy/0w=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "1.6.17",
+        "contentHash": "Le+kehlmrlQfuDFUt1zZ2dVwrhFQtKREdKBo+rexOwaCoYP0/qpgT9tLxCsZjsgR5Itk1UKPcbgO+FyaNid/bA=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "forgetrust.runnable.core": {
+        "type": "Project"
+      },
+      "forgetrust.runnable.web": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.Runnable.Core": "[1.0.0, )"
+        }
+      },
+      "forgetrust.runnable.web.openapi": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.Runnable.Web": "[1.0.0, )",
+          "Microsoft.AspNetCore.OpenApi": "[9.0.8, )"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "BwF9sQCKmvu93C/pmKxJjPhF5fFB23MEcgTsGL+7W3wKLYawS4lyFSL5/qh00IJzuADLf+1SmvxMaphbyZYqQQ==",
+        "dependencies": {
+          "Microsoft.OpenApi": "1.6.17"
+        }
+      }
+    }
+  }
+}

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -59,7 +59,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 ### Web host development defaults
 
 - Runnable web hosts now choose a deterministic localhost-only development URL when no endpoint is configured, while production, staging, container, and appsettings-based endpoint choices remain untouched.
-- OpenAPI's optional web package now has dedicated test coverage for service registration, endpoint mapping, generated document titles, and framework tag cleanup, so the public module contract is guarded independently of Scalar.
+- OpenAPI's optional web package now has dedicated test coverage for service registration, endpoint mapping, generated document titles, and transformer behavior that removes `ForgeTrust.Runnable.Web` tags at the document and operation levels while preserving unrelated tags, so the public module contract is guarded independently of Scalar.
 - Scalar's optional web package now has dedicated test coverage for OpenAPI dependency wiring, Scalar endpoint mapping, no-op lifecycle hooks, and minimal Runnable web host composition.
 - Tailwind development watch mode now treats a missing standalone CLI as a recoverable local-tooling gap: the app keeps serving existing CSS and logs a warning that points to the runtime package or `TailwindCliPath` override.
 - Runnable's conventional browser 404 page now prioritizes user recovery paths, including documentation search for missing `/docs/...` routes and a home link for other misses, while still documenting how app owners can override the default page.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -59,6 +59,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 ### Web host development defaults
 
 - Runnable web hosts now choose a deterministic localhost-only development URL when no endpoint is configured, while production, staging, container, and appsettings-based endpoint choices remain untouched.
+- OpenAPI's optional web package now has dedicated test coverage for service registration, endpoint mapping, generated document titles, and framework tag cleanup, so the public module contract is guarded independently of Scalar.
 - Scalar's optional web package now has dedicated test coverage for OpenAPI dependency wiring, Scalar endpoint mapping, no-op lifecycle hooks, and minimal Runnable web host composition.
 - Tailwind development watch mode now treats a missing standalone CLI as a recoverable local-tooling gap: the app keeps serving existing CSS and logs a warning that points to the runtime package or `TailwindCliPath` override.
 - Runnable's conventional browser 404 page now prioritizes user recovery paths, including documentation search for missing `/docs/...` routes and a home link for other misses, while still documenting how app owners can override the default page.


### PR DESCRIPTION
## Summary
- create a dedicated ForgeTrust.Runnable.Web.OpenApi.Tests project
- cover OpenAPI service registration, endpoint mapping, generated document title, and tag transformer behavior
- add the project to ForgeTrust.Runnable.slnx so solution coverage includes it

Fixes #209

## Validation
- dotnet test Web/ForgeTrust.Runnable.Web.OpenApi.Tests/ForgeTrust.Runnable.Web.OpenApi.Tests.csproj --no-restore
- dotnet format Web/ForgeTrust.Runnable.Web.OpenApi.Tests/ForgeTrust.Runnable.Web.OpenApi.Tests.csproj --no-restore
- ./scripts/coverage-solution.sh