### PR TITLE
feat(config): add scalar config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This changelog is the compact release ledger for Runnable. The monorepo ships in
 - RazorDocs now supports metadata-driven page wayfinding: harvested outlines, explicit proof-path previous/next links, related pages, and sidebar anchor navigation.
 - The root README now includes a single hello-world web quickstart with an explicit local port and a concrete expected response.
 - Runnable now ships GitHub issue templates for bug reports and documentation feedback.
+- Runnable Config now supports first-class scalar value validation on `Config<T>` and `ConfigStruct<T>` wrappers with `ConfigValueNotEmpty`, `ConfigValueRange`, `ConfigValueMinLength`, and a `ValidateValue` override for custom rules.
 
 ### Changed
 

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
@@ -345,6 +345,12 @@ public class ConfigTests
     {
     }
 
+    [ConfigValueNotEmpty]
+    private sealed class DefaultInvalidNotEmptyStringConfig : Config<string>
+    {
+        public override string DefaultValue => string.Empty;
+    }
+
     [ConfigValueMinLength(3)]
     private sealed class MinLengthStringConfig : Config<string>
     {
@@ -353,6 +359,12 @@ public class ConfigTests
     [ConfigValueRange(1, 5)]
     private sealed class RangedIntConfig : ConfigStruct<int>
     {
+    }
+
+    [ConfigValueRange(1, 5)]
+    private sealed class DefaultInvalidRangedIntConfig : ConfigStruct<int>
+    {
+        public override int? DefaultValue => 6;
     }
 
     [ConfigValueRange(1.5, 5.5)]
@@ -966,6 +978,20 @@ public class ConfigTests
     }
 
     [Fact]
+    public void Init_WithScalarClassDefaultValue_ValidatesDefault()
+    {
+        var config = new DefaultInvalidNotEmptyStringConfig();
+
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(config, null));
+
+        Assert.True(config.HasValue);
+        Assert.True(config.IsDefaultValue);
+        Assert.Equal(string.Empty, config.Value);
+        Assert.Contains("must not be empty", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Init_WithConfigValueMinLength_RejectsShortString()
     {
         var exception = Assert.Throws<ConfigurationValidationException>(() =>
@@ -984,6 +1010,20 @@ public class ConfigTests
 
         Assert.Contains("between 1 and 5", Assert.Single(intException.Failures).Message, StringComparison.Ordinal);
         Assert.Contains("between 1.5 and 5.5", Assert.Single(doubleException.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Struct_Init_WithScalarDefaultValue_ValidatesDefault()
+    {
+        var config = new DefaultInvalidRangedIntConfig();
+
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            InitStruct(config, null));
+
+        Assert.True(config.HasValue);
+        Assert.True(config.IsDefaultValue);
+        Assert.Equal(6, config.Value);
+        Assert.Contains("between 1 and 5", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
@@ -411,6 +411,21 @@ public class ConfigTests
         }
     }
 
+    private sealed class HookDefaultFailureConfig : Config<string>
+    {
+        public override string DefaultValue => "fallback";
+
+        protected override IEnumerable<ValidationResult> ValidateValue(
+            string value,
+            ValidationContext validationContext)
+        {
+            if (value == DefaultValue)
+            {
+                yield return new ValidationResult("Default hook failure.");
+            }
+        }
+    }
+
     private sealed class HookSuccessNoiseConfig : Config<string>
     {
         protected override IEnumerable<ValidationResult>? ValidateValue(
@@ -989,6 +1004,20 @@ public class ConfigTests
         Assert.True(config.IsDefaultValue);
         Assert.Equal(string.Empty, config.Value);
         Assert.Contains("must not be empty", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithScalarClassDefaultValue_RunsValidateValueHook()
+    {
+        var config = new HookDefaultFailureConfig();
+
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(config, null));
+
+        Assert.True(config.HasValue);
+        Assert.True(config.IsDefaultValue);
+        Assert.Equal("fallback", config.Value);
+        Assert.Contains("Default hook failure.", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
@@ -372,6 +372,11 @@ public class ConfigTests
     {
     }
 
+    [ConfigValueRange(1, 5)]
+    private sealed class RangedDoubleWithIntegerBoundsConfig : ConfigStruct<double>
+    {
+    }
+
     [ConfigValueNotEmpty]
     private sealed class NotEmptyGuidConfig : ConfigStruct<Guid>
     {
@@ -1066,6 +1071,16 @@ public class ConfigTests
 
         Assert.Equal(3, intConfig.Value);
         Assert.Equal(3.5, doubleConfig.Value);
+    }
+
+    [Fact]
+    public void Struct_Init_WithConfigValueRange_AcceptsDoubleWithIntegerLiteralBounds()
+    {
+        var config = new RangedDoubleWithIntegerBoundsConfig();
+
+        InitStruct(config, 3.5);
+
+        Assert.Equal(3.5, config.Value);
     }
 
     [Fact]

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
@@ -340,6 +340,152 @@ public class ConfigTests
     {
     }
 
+    [ConfigValueNotEmpty]
+    private sealed class NotEmptyStringConfig : Config<string>
+    {
+    }
+
+    [ConfigValueMinLength(3)]
+    private sealed class MinLengthStringConfig : Config<string>
+    {
+    }
+
+    [ConfigValueRange(1, 5)]
+    private sealed class RangedIntConfig : ConfigStruct<int>
+    {
+    }
+
+    [ConfigValueRange(1.5, 5.5)]
+    private sealed class RangedDoubleConfig : ConfigStruct<double>
+    {
+    }
+
+    [ConfigValueNotEmpty]
+    private sealed class NotEmptyGuidConfig : ConfigStruct<Guid>
+    {
+    }
+
+    [ConfigValueMinLength(3)]
+    private sealed class UnsupportedMinLengthIntConfig : ConfigStruct<int>
+    {
+    }
+
+    [RejectUnlessAllowed]
+    private class BaseInheritedScalarConfig : Config<string>
+    {
+    }
+
+    private sealed class DerivedInheritedScalarConfig : BaseInheritedScalarConfig
+    {
+    }
+
+    [RejectUnlessAllowed]
+    private sealed class CustomScalarAttributeConfig : Config<string>
+    {
+    }
+
+    [CaptureContext]
+    private sealed class ContextAwareScalarConfig : Config<string>
+    {
+    }
+
+    private sealed class HookFailureConfig : Config<string>
+    {
+        protected override IEnumerable<ValidationResult> ValidateValue(
+            string value,
+            ValidationContext validationContext)
+        {
+            yield return new ValidationResult("Hook failure.", ["HookMember"]);
+        }
+    }
+
+    private sealed class HookSuccessNoiseConfig : Config<string>
+    {
+        protected override IEnumerable<ValidationResult>? ValidateValue(
+            string value,
+            ValidationContext validationContext) =>
+            [null!, ValidationResult.Success!];
+    }
+
+    private sealed class HookNullEnumerableConfig : Config<string>
+    {
+        protected override IEnumerable<ValidationResult>? ValidateValue(
+            string value,
+            ValidationContext validationContext) =>
+            null;
+    }
+
+    private sealed class HookThrowsConfig : Config<string>
+    {
+        protected override IEnumerable<ValidationResult> ValidateValue(
+            string value,
+            ValidationContext validationContext) =>
+            throw new InvalidOperationException("Hook broke.");
+    }
+
+    [ConfigValueMinLength(5)]
+    private sealed class AttributeAndHookFailureConfig : Config<string>
+    {
+        protected override IEnumerable<ValidationResult> ValidateValue(
+            string value,
+            ValidationContext validationContext)
+        {
+            yield return new ValidationResult("Hook failure.");
+        }
+    }
+
+    [ConfigValueNotEmpty]
+    private sealed class ObjectConfigWithScalarValidation : Config<AnnotatedOptions>
+    {
+        public static bool HookRan { get; set; }
+
+        protected override IEnumerable<ValidationResult> ValidateValue(
+            AnnotatedOptions value,
+            ValidationContext validationContext)
+        {
+            HookRan = true;
+            yield return new ValidationResult("Object hook should not run.");
+        }
+    }
+
+    private sealed class HookStructConfig : ConfigStruct<int>
+    {
+        protected override IEnumerable<ValidationResult> ValidateValue(
+            int value,
+            ValidationContext validationContext)
+        {
+            yield return new ValidationResult("Struct hook failure.");
+        }
+    }
+
+    private sealed class RejectUnlessAllowedAttribute : ConfigValueValidationAttribute
+    {
+        protected override ValidationResult? IsValid(
+            object? value,
+            ValidationContext validationContext) =>
+            value as string == "allowed"
+                ? ValidationResult.Success
+                : new ValidationResult("Only 'allowed' is accepted.");
+    }
+
+    private sealed class CaptureContextAttribute : ConfigValueValidationAttribute
+    {
+        protected override ValidationResult? IsValid(
+            object? value,
+            ValidationContext validationContext)
+        {
+            var valid = validationContext.ObjectInstance is ContextAwareScalarConfig
+                        && validationContext.ObjectType == typeof(ContextAwareScalarConfig)
+                        && validationContext.DisplayName == "App.Settings"
+                        && validationContext.MemberName == null
+                        && validationContext.GetService(typeof(object)) == null;
+
+            return valid
+                ? ValidationResult.Success
+                : new ValidationResult("Unexpected validation context.");
+        }
+    }
+
     [Fact]
     public void Base_DefaultValue_ReturnsNull()
     {
@@ -777,6 +923,212 @@ public class ConfigTests
         Assert.Equal(string.Empty, config.Value);
     }
 
+    [Fact]
+    public void Init_WithConfigValueNotEmptyString_RejectsEmptyAndWhitespace()
+    {
+        var emptyException = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new NotEmptyStringConfig(), string.Empty));
+        var whitespaceException = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new NotEmptyStringConfig(), "   "));
+
+        Assert.Empty(Assert.Single(emptyException.Failures).MemberNames);
+        Assert.Contains("- <value>: The configuration value must not be empty.", emptyException.Message, StringComparison.Ordinal);
+        Assert.Contains("- <value>: The configuration value must not be empty.", whitespaceException.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("   ", whitespaceException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithConfigValueNotEmptyString_AcceptsNonEmptyValue()
+    {
+        var config = new NotEmptyStringConfig();
+
+        Init(config, "token");
+
+        Assert.True(config.HasValue);
+        Assert.Equal("token", config.Value);
+    }
+
+    [Fact]
+    public void Init_WithConfigValueNotEmptyAndMissingValue_DoesNotRequirePresence()
+    {
+        var config = new NotEmptyStringConfig();
+        var configManager = A.Fake<IConfigManager>();
+        var environmentProvider = A.Fake<IEnvironmentProvider>();
+
+        A.CallTo(() => environmentProvider.Environment).Returns("Production");
+        A.CallTo(() => configManager.GetValue<string>("Production", "App.Settings"))
+            .Returns(null);
+
+        ((IConfig)config).Init(configManager, environmentProvider, "App.Settings");
+
+        Assert.False(config.HasValue);
+        Assert.Null(config.Value);
+    }
+
+    [Fact]
+    public void Init_WithConfigValueMinLength_RejectsShortString()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new MinLengthStringConfig(), "ab"));
+
+        Assert.Contains("at least 3", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Struct_Init_WithConfigValueRange_RejectsOutOfRangeIntAndDouble()
+    {
+        var intException = Assert.Throws<ConfigurationValidationException>(() =>
+            InitStruct(new RangedIntConfig(), 6));
+        var doubleException = Assert.Throws<ConfigurationValidationException>(() =>
+            InitStruct(new RangedDoubleConfig(), 6.5));
+
+        Assert.Contains("between 1 and 5", Assert.Single(intException.Failures).Message, StringComparison.Ordinal);
+        Assert.Contains("between 1.5 and 5.5", Assert.Single(doubleException.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Struct_Init_WithConfigValueRange_AcceptsValidIntAndDouble()
+    {
+        var intConfig = new RangedIntConfig();
+        var doubleConfig = new RangedDoubleConfig();
+
+        InitStruct(intConfig, 3);
+        InitStruct(doubleConfig, 3.5);
+
+        Assert.Equal(3, intConfig.Value);
+        Assert.Equal(3.5, doubleConfig.Value);
+    }
+
+    [Fact]
+    public void Struct_Init_WithConfigValueNotEmptyGuid_RejectsEmptyGuid()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            InitStruct(new NotEmptyGuidConfig(), Guid.Empty));
+
+        Assert.Contains("must not be empty", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithUnsupportedBuiltInType_ThrowsStructuredValidationException()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            InitStruct(new UnsupportedMinLengthIntConfig(), 42));
+
+        var failure = Assert.Single(exception.Failures);
+        Assert.Empty(failure.MemberNames);
+        Assert.Contains("ConfigValueMinLengthAttribute supports String values", failure.Message, StringComparison.Ordinal);
+        Assert.IsType<ConfigurationValidationException>(exception);
+    }
+
+    [Fact]
+    public void Init_WithInheritedConfigValueValidationAttribute_AppliesRule()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new DerivedInheritedScalarConfig(), "denied"));
+
+        Assert.Contains("Only 'allowed' is accepted.", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithCustomConfigValueValidationAttribute_AppliesRule()
+    {
+        var config = new CustomScalarAttributeConfig();
+
+        Init(config, "allowed");
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new CustomScalarAttributeConfig(), "denied"));
+
+        Assert.Equal("allowed", config.Value);
+        Assert.Contains("Only 'allowed' is accepted.", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithContextAwareAttribute_ReceivesGuaranteedValidationContextValues()
+    {
+        var config = new ContextAwareScalarConfig();
+
+        Init(config, "value");
+
+        Assert.Equal("value", config.Value);
+    }
+
+    [Fact]
+    public void Init_WithValidateValueFailure_ThrowsStructuredValidationException()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new HookFailureConfig(), "value"));
+
+        var failure = Assert.Single(exception.Failures);
+        Assert.Equal(["HookMember"], failure.MemberNames);
+        Assert.Contains("Hook failure.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithValidateValueSuccessNoise_IgnoresNullSuccessAndNullEnumerable()
+    {
+        Init(new HookSuccessNoiseConfig(), "value");
+        Init(new HookNullEnumerableConfig(), "value");
+    }
+
+    [Fact]
+    public void Init_WithValidateValueException_BubblesOriginalException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            Init(new HookThrowsConfig(), "value"));
+
+        Assert.Equal("Hook broke.", exception.Message);
+    }
+
+    [Fact]
+    public void Init_WithAttributeAndHookFailures_CollectsAttributeFailuresFirst()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new AttributeAndHookFailureConfig(), "abc"));
+
+        Assert.Equal(2, exception.Failures.Count);
+        Assert.Contains("at least 5", exception.Failures[0].Message, StringComparison.Ordinal);
+        Assert.Equal("Hook failure.", exception.Failures[1].Message);
+    }
+
+    [Fact]
+    public void Struct_Init_WithValidateValueHook_RunsWithoutVirtualInit()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            InitStruct(new HookStructConfig(), 3));
+
+        Assert.Contains("Struct hook failure.", Assert.Single(exception.Failures).Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithObjectConfig_IgnoresWrapperScalarAttributesAndHook()
+    {
+        ObjectConfigWithScalarValidation.HookRan = false;
+        var config = new ObjectConfigWithScalarValidation();
+
+        Init(
+            config,
+            new AnnotatedOptions
+            {
+                Name = "payments",
+                RetryCount = 3
+            });
+
+        Assert.False(ObjectConfigWithScalarValidation.HookRan);
+        Assert.True(config.HasValue);
+    }
+
+    [Fact]
+    public void Init_WithScalarFailure_UsesValueFailureLabelWithoutChangingObjectLabel()
+    {
+        var scalarException = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new NotEmptyStringConfig(), string.Empty));
+        var objectException = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new ValidatableOptionsConfig(), new ValidatableOptions { Invalid = true }));
+
+        Assert.Contains("- <value>:", scalarException.Message, StringComparison.Ordinal);
+        Assert.Contains("- <object>:", objectException.Message, StringComparison.Ordinal);
+    }
+
     private static void Init<T>(Config<T> config, T? value)
         where T : class
     {
@@ -785,6 +1137,19 @@ public class ConfigTests
 
         A.CallTo(() => environmentProvider.Environment).Returns("Production");
         A.CallTo(() => configManager.GetValue<T>("Production", "App.Settings"))
+            .Returns(value);
+
+        ((IConfig)config).Init(configManager, environmentProvider, "App.Settings");
+    }
+
+    private static void InitStruct<T>(ConfigStruct<T> config, T? value)
+        where T : struct
+    {
+        var configManager = A.Fake<IConfigManager>();
+        var environmentProvider = A.Fake<IEnvironmentProvider>();
+
+        A.CallTo(() => environmentProvider.Environment).Returns("Production");
+        A.CallTo(() => configManager.GetValue<T?>("Production", "App.Settings"))
             .Returns(value);
 
         ((IConfig)config).Init(configManager, environmentProvider, "App.Settings");

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValidationExampleSmokeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValidationExampleSmokeTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using ForgeTrust.Runnable.Core;
 
 namespace ForgeTrust.Runnable.Config.Tests;
 
@@ -7,13 +8,13 @@ public sealed class ConfigValidationExampleSmokeTests
     [Fact]
     public async Task ConfigValidationExample_FailsWithScalarValidationMessage()
     {
-        var repositoryRoot = FindRepositoryRoot();
+        var repositoryRoot = PathUtils.FindRepositoryRoot(AppContext.BaseDirectory);
         using var process = new Process();
         process.StartInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
             Arguments = "run --project examples/config-validation -p:NodeReuse=false",
-            WorkingDirectory = repositoryRoot.FullName,
+            WorkingDirectory = repositoryRoot,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false
@@ -70,20 +71,4 @@ public sealed class ConfigValidationExampleSmokeTests
         Assert.DoesNotContain("70000", output);
     }
 
-    private static DirectoryInfo FindRepositoryRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-
-        while (directory != null)
-        {
-            if (File.Exists(Path.Combine(directory.FullName, "ForgeTrust.Runnable.slnx")))
-            {
-                return directory;
-            }
-
-            directory = directory.Parent;
-        }
-
-        throw new DirectoryNotFoundException("Could not find the repository root.");
-    }
 }

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValidationExampleSmokeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValidationExampleSmokeTests.cs
@@ -20,19 +20,34 @@ public sealed class ConfigValidationExampleSmokeTests
         };
         process.StartInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
         process.StartInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+        process.StartInfo.Environment["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1";
         process.StartInfo.Environment["DOTNET_NOLOGO"] = "1";
+        process.StartInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";
 
         process.Start();
 
         var stdout = process.StandardOutput.ReadToEndAsync();
         var stderr = process.StandardError.ReadToEndAsync();
-        var waitForExit = process.WaitForExitAsync();
-        var completed = await Task.WhenAny(waitForExit, Task.Delay(TimeSpan.FromSeconds(30)));
+        var timedOut = false;
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        if (completed != waitForExit)
+        try
         {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException("The config validation example did not finish within 30 seconds.");
+            await process.WaitForExitAsync(timeoutSource.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            timedOut = true;
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+                // The process can exit naturally between cancellation and kill.
+            }
+
+            await process.WaitForExitAsync();
         }
 
         var outputTask = Task.WhenAll(stdout, stderr);
@@ -43,6 +58,10 @@ public sealed class ConfigValidationExampleSmokeTests
         }
 
         var output = string.Concat(await stdout, await stderr);
+        if (timedOut)
+        {
+            throw new TimeoutException("The config validation example did not finish within 30 seconds.");
+        }
 
         Assert.NotEqual(0, process.ExitCode);
         Assert.Contains("Configuration validation failed for key 'PortConfig'", output);

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValidationExampleSmokeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValidationExampleSmokeTests.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+
+namespace ForgeTrust.Runnable.Config.Tests;
+
+public sealed class ConfigValidationExampleSmokeTests
+{
+    [Fact]
+    public async Task ConfigValidationExample_FailsWithScalarValidationMessage()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = "run --project examples/config-validation -p:NodeReuse=false",
+            WorkingDirectory = repositoryRoot.FullName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        process.StartInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+        process.StartInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+        process.StartInfo.Environment["DOTNET_NOLOGO"] = "1";
+
+        process.Start();
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        var waitForExit = process.WaitForExitAsync();
+        var completed = await Task.WhenAny(waitForExit, Task.Delay(TimeSpan.FromSeconds(30)));
+
+        if (completed != waitForExit)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("The config validation example did not finish within 30 seconds.");
+        }
+
+        var outputTask = Task.WhenAll(stdout, stderr);
+        var outputCompleted = await Task.WhenAny(outputTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        if (outputCompleted != outputTask)
+        {
+            throw new TimeoutException("The config validation example output streams did not close within 5 seconds.");
+        }
+
+        var output = string.Concat(await stdout, await stderr);
+
+        Assert.NotEqual(0, process.ExitCode);
+        Assert.Contains("Configuration validation failed for key 'PortConfig'", output);
+        Assert.Contains("- <value>: The configuration value must be between 1 and 65535.", output);
+        Assert.Contains("Fix the configured value or relax the scalar rule", output);
+        Assert.DoesNotContain("70000", output);
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "ForgeTrust.Runnable.slnx")))
+            {
+                return directory;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find the repository root.");
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
@@ -24,7 +24,7 @@ public class ConfigValueValidationAttributeTests
 
         AssertValid(attribute, "value");
         AssertValid(attribute, Guid.NewGuid());
-        AssertInvalid(attribute, null, "must not be empty");
+        AssertValid(attribute, null);
         AssertInvalid(attribute, string.Empty, "must not be empty");
         AssertInvalid(attribute, "   ", "must not be empty");
         AssertInvalid(attribute, Guid.Empty, "must not be empty");

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
@@ -81,6 +81,17 @@ public class ConfigValueValidationAttributeTests
     }
 
     [Fact]
+    public void Range_CustomErrorMessagePreservesDisplayNamePlaceholder()
+    {
+        var attribute = new ConfigValueRangeAttribute(1, 5)
+        {
+            ErrorMessage = "{0} must be between {1} and {2}."
+        };
+
+        AssertInvalid(attribute, 0, "Test must be between 1 and 5.");
+    }
+
+    [Fact]
     public void MinLength_ValidatesStringValues()
     {
         var attribute = new ConfigValueMinLengthAttribute(3);
@@ -96,6 +107,17 @@ public class ConfigValueValidationAttributeTests
     public void MinLength_RejectsNegativeLength()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigValueMinLengthAttribute(-1));
+    }
+
+    [Fact]
+    public void MinLength_CustomErrorMessagePreservesDisplayNamePlaceholder()
+    {
+        var attribute = new ConfigValueMinLengthAttribute(3)
+        {
+            ErrorMessage = "{0} must be at least {1} characters."
+        };
+
+        AssertInvalid(attribute, "ab", "Test must be at least 3 characters.");
     }
 
     private static void AssertValid(ValidationAttribute attribute, object? value)

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
@@ -39,7 +39,7 @@ public class ConfigValueValidationAttributeTests
     }
 
     [Fact]
-    public void Range_IntConstructor_ValidatesIntValues()
+    public void Range_IntConstructor_ValidatesIntAndDoubleValues()
     {
         var attribute = new ConfigValueRangeAttribute(1, 5);
 
@@ -48,14 +48,17 @@ public class ConfigValueValidationAttributeTests
         AssertValid(attribute, null);
         AssertValid(attribute, attribute.Minimum);
         AssertValid(attribute, 3);
+        AssertValid(attribute, 3.5);
         AssertValid(attribute, attribute.Maximum);
         AssertInvalid(attribute, 0, "between 1 and 5");
+        AssertInvalid(attribute, 0.5, "between 1 and 5");
         AssertInvalid(attribute, 6, "between 1 and 5");
-        AssertInvalid(attribute, 3.0, "configured for Int32 values");
+        AssertInvalid(attribute, 6.0, "between 1 and 5");
+        AssertInvalid(attribute, 3m, "supports Int32 and Double values");
     }
 
     [Fact]
-    public void Range_DoubleConstructor_ValidatesDoubleValues()
+    public void Range_DoubleConstructor_ValidatesIntAndDoubleValues()
     {
         var attribute = new ConfigValueRangeAttribute(1.5, 5.5);
 
@@ -63,11 +66,14 @@ public class ConfigValueValidationAttributeTests
         Assert.Equal(5.5, attribute.Maximum);
         AssertValid(attribute, null);
         AssertValid(attribute, attribute.Minimum);
+        AssertValid(attribute, 3);
         AssertValid(attribute, 3.5);
         AssertValid(attribute, attribute.Maximum);
+        AssertInvalid(attribute, 1, "between 1.5 and 5.5");
         AssertInvalid(attribute, 1.0, "between 1.5 and 5.5");
+        AssertInvalid(attribute, 6, "between 1.5 and 5.5");
         AssertInvalid(attribute, 6.0, "between 1.5 and 5.5");
-        AssertInvalid(attribute, 3, "configured for Double values");
+        AssertInvalid(attribute, 3m, "supports Int32 and Double values");
     }
 
     [Fact]

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
@@ -67,6 +67,13 @@ public class ConfigValueValidationAttributeTests
     }
 
     [Fact]
+    public void Range_ConstructorsRejectInvertedBounds()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigValueRangeAttribute(5, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigValueRangeAttribute(5.5, 1.5));
+    }
+
+    [Fact]
     public void MinLength_ValidatesStringValues()
     {
         var attribute = new ConfigValueMinLengthAttribute(3);

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
@@ -46,7 +46,9 @@ public class ConfigValueValidationAttributeTests
         Assert.Equal(1, attribute.Minimum);
         Assert.Equal(5, attribute.Maximum);
         AssertValid(attribute, null);
+        AssertValid(attribute, attribute.Minimum);
         AssertValid(attribute, 3);
+        AssertValid(attribute, attribute.Maximum);
         AssertInvalid(attribute, 0, "between 1 and 5");
         AssertInvalid(attribute, 6, "between 1 and 5");
         AssertInvalid(attribute, 3.0, "configured for Int32 values");
@@ -60,7 +62,9 @@ public class ConfigValueValidationAttributeTests
         Assert.Equal(1.5, attribute.Minimum);
         Assert.Equal(5.5, attribute.Maximum);
         AssertValid(attribute, null);
+        AssertValid(attribute, attribute.Minimum);
         AssertValid(attribute, 3.5);
+        AssertValid(attribute, attribute.Maximum);
         AssertInvalid(attribute, 1.0, "between 1.5 and 5.5");
         AssertInvalid(attribute, 6.0, "between 1.5 and 5.5");
         AssertInvalid(attribute, 3, "configured for Double values");

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
@@ -74,6 +74,13 @@ public class ConfigValueValidationAttributeTests
     }
 
     [Fact]
+    public void Range_DoubleConstructorRejectsNaNBounds()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigValueRangeAttribute(double.NaN, 1.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigValueRangeAttribute(1.5, double.NaN));
+    }
+
+    [Fact]
     public void MinLength_ValidatesStringValues()
     {
         var attribute = new ConfigValueMinLengthAttribute(3);

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigValueValidationAttributeTests.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace ForgeTrust.Runnable.Config.Tests;
+
+public class ConfigValueValidationAttributeTests
+{
+    [Fact]
+    public void BaseAttribute_AllowsMultipleInheritedClassUsage()
+    {
+        var usage = typeof(ConfigValueValidationAttribute)
+            .GetCustomAttribute<AttributeUsageAttribute>();
+
+        Assert.NotNull(usage);
+        Assert.Equal(AttributeTargets.Class, usage.ValidOn);
+        Assert.True(usage.AllowMultiple);
+        Assert.True(usage.Inherited);
+    }
+
+    [Fact]
+    public void NotEmpty_ValidatesStringsAndGuids()
+    {
+        var attribute = new ConfigValueNotEmptyAttribute();
+
+        AssertValid(attribute, "value");
+        AssertValid(attribute, Guid.NewGuid());
+        AssertInvalid(attribute, null, "must not be empty");
+        AssertInvalid(attribute, string.Empty, "must not be empty");
+        AssertInvalid(attribute, "   ", "must not be empty");
+        AssertInvalid(attribute, Guid.Empty, "must not be empty");
+    }
+
+    [Fact]
+    public void NotEmpty_UnsupportedTypeReturnsValidationFailure()
+    {
+        var attribute = new ConfigValueNotEmptyAttribute();
+
+        AssertInvalid(attribute, 1, "ConfigValueNotEmptyAttribute supports String and Guid values");
+    }
+
+    [Fact]
+    public void Range_IntConstructor_ValidatesIntValues()
+    {
+        var attribute = new ConfigValueRangeAttribute(1, 5);
+
+        Assert.Equal(1, attribute.Minimum);
+        Assert.Equal(5, attribute.Maximum);
+        AssertValid(attribute, null);
+        AssertValid(attribute, 3);
+        AssertInvalid(attribute, 0, "between 1 and 5");
+        AssertInvalid(attribute, 6, "between 1 and 5");
+        AssertInvalid(attribute, 3.0, "configured for Int32 values");
+    }
+
+    [Fact]
+    public void Range_DoubleConstructor_ValidatesDoubleValues()
+    {
+        var attribute = new ConfigValueRangeAttribute(1.5, 5.5);
+
+        Assert.Equal(1.5, attribute.Minimum);
+        Assert.Equal(5.5, attribute.Maximum);
+        AssertValid(attribute, null);
+        AssertValid(attribute, 3.5);
+        AssertInvalid(attribute, 1.0, "between 1.5 and 5.5");
+        AssertInvalid(attribute, 6.0, "between 1.5 and 5.5");
+        AssertInvalid(attribute, 3, "configured for Double values");
+    }
+
+    [Fact]
+    public void MinLength_ValidatesStringValues()
+    {
+        var attribute = new ConfigValueMinLengthAttribute(3);
+
+        Assert.Equal(3, attribute.Length);
+        AssertValid(attribute, null);
+        AssertValid(attribute, "abc");
+        AssertInvalid(attribute, "ab", "at least 3");
+        AssertInvalid(attribute, 3, "ConfigValueMinLengthAttribute supports String values");
+    }
+
+    [Fact]
+    public void MinLength_RejectsNegativeLength()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigValueMinLengthAttribute(-1));
+    }
+
+    private static void AssertValid(ValidationAttribute attribute, object? value)
+    {
+        var results = Validate(attribute, value);
+        Assert.Empty(results);
+    }
+
+    private static void AssertInvalid(ValidationAttribute attribute, object? value, string expectedMessage)
+    {
+        var result = Assert.Single(Validate(attribute, value));
+        Assert.Contains(expectedMessage, result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    private static List<ValidationResult> Validate(ValidationAttribute attribute, object? value)
+    {
+        var results = new List<ValidationResult>();
+        Validator.TryValidateValue(
+            value,
+            new ValidationContext(new object())
+            {
+                DisplayName = "Test"
+            },
+            results,
+            [attribute]);
+
+        return results;
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config.Tests/ForgeTrust.Runnable.Config.Tests.csproj
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ForgeTrust.Runnable.Config.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../ForgeTrust.Runnable.Core/ForgeTrust.Runnable.Core.csproj" />
     <ProjectReference Include="../ForgeTrust.Runnable.Config/ForgeTrust.Runnable.Config.csproj" />
   </ItemGroup>
 

--- a/Config/ForgeTrust.Runnable.Config/Config.cs
+++ b/Config/ForgeTrust.Runnable.Config/Config.cs
@@ -51,7 +51,7 @@ public class Config<T> : IConfig
     /// <param name="environmentProvider">The environment provider used to choose the active environment.</param>
     /// <param name="key">The configuration key to resolve.</param>
     /// <exception cref="ConfigurationValidationException">
-    /// Thrown when the provider value or default value violates DataAnnotations validation rules.
+    /// Thrown when the provider value or default value violates object DataAnnotations or scalar validation rules.
     /// </exception>
     internal virtual void Init(
         IConfigManager configManager,
@@ -81,7 +81,10 @@ public class Config<T> : IConfig
     /// </summary>
     /// <param name="value">The resolved provider or default scalar value.</param>
     /// <param name="validationContext">The validation context for the concrete configuration wrapper.</param>
-    /// <returns>The validation results for <paramref name="value"/>, or null when validation succeeds.</returns>
+    /// <returns>
+    /// The validation results for <paramref name="value"/>. Return <see langword="null"/>, an empty sequence,
+    /// <see cref="ValidationResult.Success"/>, or null entries when validation succeeds.
+    /// </returns>
     protected virtual IEnumerable<ValidationResult>? ValidateValue(
         T value,
         ValidationContext validationContext) =>

--- a/Config/ForgeTrust.Runnable.Config/Config.cs
+++ b/Config/ForgeTrust.Runnable.Config/Config.cs
@@ -1,11 +1,13 @@
-﻿using ForgeTrust.Runnable.Core;
+﻿using System.ComponentModel.DataAnnotations;
+using ForgeTrust.Runnable.Core;
 
 namespace ForgeTrust.Runnable.Config;
 
 /// <summary>
 /// A base class for strongly-typed configuration objects.
-/// Values are resolved during <see cref="IConfig.Init"/>, then any DataAnnotations on the
-/// resolved provider value or <see cref="DefaultValue"/> are validated before initialization completes.
+/// Values are resolved during <see cref="IConfig.Init"/>, then object-valued configuration models are
+/// validated with DataAnnotations and scalar values can be validated with Runnable scalar attributes or
+/// <see cref="ValidateValue"/>.
 /// Invalid provider values and invalid defaults fail fast by throwing
 /// <see cref="ConfigurationValidationException"/>, so callers that activate config wrappers can catch
 /// that exception and surface its structured failures. Ensure defaults satisfy the same validation
@@ -43,7 +45,7 @@ public class Config<T> : IConfig
 
     /// <summary>
     /// Resolves the configured value for <paramref name="key"/> and validates the resolved provider
-    /// value or <see cref="DefaultValue"/> with DataAnnotations before initialization completes.
+    /// value or <see cref="DefaultValue"/> before initialization completes.
     /// </summary>
     /// <param name="configManager">The configuration manager used to resolve the provider value.</param>
     /// <param name="environmentProvider">The environment provider used to choose the active environment.</param>
@@ -65,5 +67,23 @@ public class Config<T> : IConfig
             GetType(),
             typeof(T),
             Value);
+        ConfigScalarValueValidator.Validate(
+            key,
+            this,
+            typeof(T),
+            Value,
+            (value, validationContext) => ValidateValue((T)value, validationContext));
     }
+
+    /// <summary>
+    /// Validates a resolved non-null scalar configuration value.
+    /// Override this method when a scalar rule is too specific for the built-in Runnable scalar attributes.
+    /// </summary>
+    /// <param name="value">The resolved provider or default scalar value.</param>
+    /// <param name="validationContext">The validation context for the concrete configuration wrapper.</param>
+    /// <returns>The validation results for <paramref name="value"/>, or null when validation succeeds.</returns>
+    protected virtual IEnumerable<ValidationResult>? ValidateValue(
+        T value,
+        ValidationContext validationContext) =>
+        [];
 }

--- a/Config/ForgeTrust.Runnable.Config/ConfigDataAnnotationsValidator.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigDataAnnotationsValidator.cs
@@ -38,7 +38,7 @@ internal static class ConfigDataAnnotationsValidator
         Type valueType,
         object? value)
     {
-        if (value == null || IsScalar(value.GetType()))
+        if (value == null || ConfigScalarTypes.IsScalar(value.GetType()))
         {
             return;
         }
@@ -88,7 +88,7 @@ internal static class ConfigDataAnnotationsValidator
 
             foreach (var result in results)
             {
-                failures.Add(ToFailure(key, configType, valueType, path, result));
+                failures.Add(ConfigValidationFailureFactory.FromValidationResult(key, configType, valueType, path, result));
             }
 
             ValidateFieldAnnotations(key, configType, valueType, value, path, failures);
@@ -142,7 +142,13 @@ internal static class ConfigDataAnnotationsValidator
 
             foreach (var result in results)
             {
-                failures.Add(ToFailure(key, configType, valueType, parentPath, result, field.Name));
+                failures.Add(ConfigValidationFailureFactory.FromValidationResult(
+                    key,
+                    configType,
+                    valueType,
+                    parentPath,
+                    result,
+                    field.Name));
             }
         }
     }
@@ -247,7 +253,7 @@ internal static class ConfigDataAnnotationsValidator
             return;
         }
 
-        if (objectMembersAttribute != null && !IsScalar(memberValue.GetType()))
+        if (objectMembersAttribute != null && !ConfigScalarTypes.IsScalar(memberValue.GetType()))
         {
             ValidateNode(
                 key,
@@ -264,7 +270,7 @@ internal static class ConfigDataAnnotationsValidator
             var index = 0;
             foreach (var item in enumerable)
             {
-                if (item != null && !IsScalar(item.GetType()))
+                if (item != null && !ConfigScalarTypes.IsScalar(item.GetType()))
                 {
                     ValidateNode(
                         key,
@@ -279,38 +285,6 @@ internal static class ConfigDataAnnotationsValidator
                 index++;
             }
         }
-    }
-
-    private static ConfigurationValidationFailure ToFailure(
-        string key,
-        Type configType,
-        Type valueType,
-        string? path,
-        ValidationResult result,
-        string? defaultMemberName = null)
-    {
-        var resultMemberNames = result.MemberNames.ToList();
-        if (resultMemberNames.Count == 0 && defaultMemberName != null)
-        {
-            resultMemberNames.Add(defaultMemberName);
-        }
-
-        var memberNames = resultMemberNames
-            .Select(memberName => PrefixMemberName(path, memberName))
-            .Where(memberName => !string.IsNullOrWhiteSpace(memberName))
-            .ToList();
-
-        if (memberNames.Count == 0 && path != null)
-        {
-            memberNames.Add(path);
-        }
-
-        return new ConfigurationValidationFailure(
-            key,
-            configType,
-            valueType,
-            memberNames,
-            result.ErrorMessage ?? "The configuration value is invalid.");
     }
 
     private static ConfigurationValidationFailure CreateUnsupportedValidatorFailure(
@@ -348,33 +322,6 @@ internal static class ConfigDataAnnotationsValidator
         string.IsNullOrEmpty(prefix)
             ? memberName
             : $"{prefix}.{memberName}";
-
-    private static string PrefixMemberName(string? path, string memberName)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return memberName;
-        }
-
-        return string.IsNullOrWhiteSpace(memberName)
-            ? path
-            : $"{path}.{memberName}";
-    }
-
-    private static bool IsScalar(Type type)
-    {
-        type = Nullable.GetUnderlyingType(type) ?? type;
-
-        return type.IsPrimitive
-               || type.IsEnum
-               || type == typeof(string)
-               || type == typeof(decimal)
-               || type == typeof(DateTime)
-               || type == typeof(DateTimeOffset)
-               || type == typeof(TimeSpan)
-               || type == typeof(Guid)
-               || type == typeof(Uri);
-    }
 
     private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
     {

--- a/Config/ForgeTrust.Runnable.Config/ConfigScalarTypes.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigScalarTypes.cs
@@ -1,0 +1,19 @@
+namespace ForgeTrust.Runnable.Config;
+
+internal static class ConfigScalarTypes
+{
+    public static bool IsScalar(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        return type.IsPrimitive
+               || type.IsEnum
+               || type == typeof(string)
+               || type == typeof(decimal)
+               || type == typeof(DateTime)
+               || type == typeof(DateTimeOffset)
+               || type == typeof(TimeSpan)
+               || type == typeof(Guid)
+               || type == typeof(Uri);
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config/ConfigScalarTypes.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigScalarTypes.cs
@@ -1,7 +1,19 @@
 namespace ForgeTrust.Runnable.Config;
 
+/// <summary>
+/// Provides the canonical scalar-type classification shared by configuration validation paths.
+/// </summary>
 internal static class ConfigScalarTypes
 {
+    /// <summary>
+    /// Returns whether <paramref name="type"/> is treated as a scalar configuration value.
+    /// Nullable wrappers are unwrapped before inspection. Supported scalar types are primitives,
+    /// enums, <see cref="string"/>, <see cref="decimal"/>, <see cref="DateTime"/>,
+    /// <see cref="DateTimeOffset"/>, <see cref="TimeSpan"/>, <see cref="Guid"/>, and
+    /// <see cref="Uri"/>.
+    /// </summary>
+    /// <param name="type">The declared or runtime value type to inspect.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> is a supported scalar type.</returns>
     public static bool IsScalar(Type type)
     {
         type = Nullable.GetUnderlyingType(type) ?? type;

--- a/Config/ForgeTrust.Runnable.Config/ConfigScalarValueValidator.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigScalarValueValidator.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace ForgeTrust.Runnable.Config;
+
+internal static class ConfigScalarValueValidator
+{
+    public static void Validate(
+        string key,
+        object config,
+        Type valueType,
+        object? value,
+        Func<object, ValidationContext, IEnumerable<ValidationResult>?> validateValue)
+    {
+        if (value == null || !ConfigScalarTypes.IsScalar(valueType))
+        {
+            return;
+        }
+
+        var configType = config.GetType();
+        var failures = new List<ConfigurationValidationFailure>();
+        var validationContext = new ValidationContext(config)
+        {
+            DisplayName = key,
+            MemberName = null
+        };
+
+        ValidateAttributes(key, configType, valueType, value, validationContext, failures);
+        ValidateHook(key, configType, valueType, value, validationContext, validateValue, failures);
+
+        if (failures.Count > 0)
+        {
+            throw new ConfigurationValidationException(key, configType, valueType, failures);
+        }
+    }
+
+    private static void ValidateAttributes(
+        string key,
+        Type configType,
+        Type valueType,
+        object value,
+        ValidationContext validationContext,
+        List<ConfigurationValidationFailure> failures)
+    {
+        var attributes = configType
+            .GetCustomAttributes<ConfigValueValidationAttribute>(inherit: true)
+            .ToArray();
+        if (attributes.Length == 0)
+        {
+            return;
+        }
+
+        var results = new List<ValidationResult>();
+        Validator.TryValidateValue(value, validationContext, results, attributes);
+
+        foreach (var result in results)
+        {
+            failures.Add(ConfigValidationFailureFactory.FromValidationResult(
+                key,
+                configType,
+                valueType,
+                path: null,
+                result));
+        }
+    }
+
+    private static void ValidateHook(
+        string key,
+        Type configType,
+        Type valueType,
+        object value,
+        ValidationContext validationContext,
+        Func<object, ValidationContext, IEnumerable<ValidationResult>?> validateValue,
+        List<ConfigurationValidationFailure> failures)
+    {
+        var results = validateValue(value, validationContext);
+        if (results == null)
+        {
+            return;
+        }
+
+        foreach (var result in results)
+        {
+            if (result == null || result == ValidationResult.Success)
+            {
+                continue;
+            }
+
+            failures.Add(ConfigValidationFailureFactory.FromValidationResult(
+                key,
+                configType,
+                valueType,
+                path: null,
+                result));
+        }
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config/ConfigStruct.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigStruct.cs
@@ -1,11 +1,13 @@
+using System.ComponentModel.DataAnnotations;
 using ForgeTrust.Runnable.Core;
 
 namespace ForgeTrust.Runnable.Config;
 
 /// <summary>
 /// A base class for strongly-typed configuration objects where the value is a struct.
-/// Values are resolved during <see cref="IConfig.Init"/>, then any DataAnnotations on the
-/// resolved provider value or <see cref="DefaultValue"/> are validated before initialization completes.
+/// Values are resolved during <see cref="IConfig.Init"/>, then object-valued configuration models are
+/// validated with DataAnnotations and scalar values can be validated with Runnable scalar attributes or
+/// <see cref="ValidateValue"/>.
 /// Invalid provider values and invalid defaults fail fast by throwing
 /// <see cref="ConfigurationValidationException"/>, so callers that activate config wrappers can catch
 /// that exception and surface its structured failures. Ensure defaults satisfy the same validation
@@ -37,7 +39,7 @@ public class ConfigStruct<T> : IConfig
 
     /// <summary>
     /// Resolves the configured value for <paramref name="key"/> and validates the resolved provider
-    /// value or <see cref="DefaultValue"/> with DataAnnotations before initialization completes.
+    /// value or <see cref="DefaultValue"/> before initialization completes.
     /// </summary>
     /// <param name="configManager">The configuration manager used to resolve the provider value.</param>
     /// <param name="environmentProvider">The environment provider used to choose the active environment.</param>
@@ -59,5 +61,23 @@ public class ConfigStruct<T> : IConfig
             GetType(),
             typeof(T),
             Value);
+        ConfigScalarValueValidator.Validate(
+            key,
+            this,
+            typeof(T),
+            Value,
+            (value, validationContext) => ValidateValue((T)value, validationContext));
     }
+
+    /// <summary>
+    /// Validates a resolved non-null scalar configuration value.
+    /// Override this method when a scalar rule is too specific for the built-in Runnable scalar attributes.
+    /// </summary>
+    /// <param name="value">The resolved provider or default scalar value.</param>
+    /// <param name="validationContext">The validation context for the concrete configuration wrapper.</param>
+    /// <returns>The validation results for <paramref name="value"/>, or null when validation succeeds.</returns>
+    protected virtual IEnumerable<ValidationResult>? ValidateValue(
+        T value,
+        ValidationContext validationContext) =>
+        [];
 }

--- a/Config/ForgeTrust.Runnable.Config/ConfigStruct.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigStruct.cs
@@ -45,7 +45,7 @@ public class ConfigStruct<T> : IConfig
     /// <param name="environmentProvider">The environment provider used to choose the active environment.</param>
     /// <param name="key">The configuration key to resolve.</param>
     /// <exception cref="ConfigurationValidationException">
-    /// Thrown when the provider value or default value violates DataAnnotations validation rules.
+    /// Thrown when the provider value or default value violates object DataAnnotations or scalar validation rules.
     /// </exception>
     void IConfig.Init(
         IConfigManager configManager,
@@ -75,7 +75,10 @@ public class ConfigStruct<T> : IConfig
     /// </summary>
     /// <param name="value">The resolved provider or default scalar value.</param>
     /// <param name="validationContext">The validation context for the concrete configuration wrapper.</param>
-    /// <returns>The validation results for <paramref name="value"/>, or null when validation succeeds.</returns>
+    /// <returns>
+    /// The validation results for <paramref name="value"/>. Return <see langword="null"/>, an empty sequence,
+    /// <see cref="ValidationResult.Success"/>, or null entries when validation succeeds.
+    /// </returns>
     protected virtual IEnumerable<ValidationResult>? ValidateValue(
         T value,
         ValidationContext validationContext) =>

--- a/Config/ForgeTrust.Runnable.Config/ConfigValidationFailureFactory.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValidationFailureFactory.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ForgeTrust.Runnable.Config;
+
+internal static class ConfigValidationFailureFactory
+{
+    public static ConfigurationValidationFailure FromValidationResult(
+        string key,
+        Type configType,
+        Type valueType,
+        string? path,
+        ValidationResult result,
+        string? defaultMemberName = null)
+    {
+        var resultMemberNames = result.MemberNames.ToList();
+        if (resultMemberNames.Count == 0 && defaultMemberName != null)
+        {
+            resultMemberNames.Add(defaultMemberName);
+        }
+
+        var memberNames = resultMemberNames
+            .Select(memberName => PrefixMemberName(path, memberName))
+            .Where(memberName => !string.IsNullOrWhiteSpace(memberName))
+            .ToList();
+
+        if (memberNames.Count == 0 && path != null)
+        {
+            memberNames.Add(path);
+        }
+
+        return new ConfigurationValidationFailure(
+            key,
+            configType,
+            valueType,
+            memberNames,
+            result.ErrorMessage ?? "The configuration value is invalid.");
+    }
+
+    private static string PrefixMemberName(string? path, string memberName)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return memberName;
+        }
+
+        return string.IsNullOrWhiteSpace(memberName)
+            ? path
+            : $"{path}.{memberName}";
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config/ConfigValidationFailureFactory.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValidationFailureFactory.cs
@@ -2,8 +2,28 @@ using System.ComponentModel.DataAnnotations;
 
 namespace ForgeTrust.Runnable.Config;
 
+/// <summary>
+/// Creates <see cref="ConfigurationValidationFailure"/> instances from DataAnnotations results while
+/// preserving Runnable's member-path formatting contract.
+/// </summary>
 internal static class ConfigValidationFailureFactory
 {
+    /// <summary>
+    /// Converts a <see cref="ValidationResult"/> into a configuration-validation failure payload.
+    /// </summary>
+    /// <param name="key">The configuration key being validated.</param>
+    /// <param name="configType">The concrete configuration wrapper type.</param>
+    /// <param name="valueType">The resolved value type being validated.</param>
+    /// <param name="path">
+    /// Optional member path prefix. When present, validation-result member names are combined under this
+    /// path using dot notation, and the path itself is used when the result has no member names.
+    /// </param>
+    /// <param name="result">The validation result to convert.</param>
+    /// <param name="defaultMemberName">
+    /// Optional fallback member name used when <paramref name="result"/> has no member names, such as
+    /// field-level validation where DataAnnotations did not bind the member name itself.
+    /// </param>
+    /// <returns>A normalized <see cref="ConfigurationValidationFailure"/>.</returns>
     public static ConfigurationValidationFailure FromValidationResult(
         string key,
         Type configType,

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -7,6 +7,24 @@ namespace ForgeTrust.Runnable.Config;
 /// Apply derived attributes to concrete <see cref="Config{T}"/> or <see cref="ConfigStruct{T}"/> wrapper
 /// types to validate resolved scalar values during configuration initialization.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Scalar validation runs after provider/default resolution and only when the resolved value is non-null.
+/// These attributes validate the value itself; they do not make a missing configuration key required.
+/// Use a default value or an application startup presence check when absence should fail.
+/// </para>
+/// <para>
+/// Validation is intentionally strict about value types. Built-in scalar attributes return validation
+/// failures for unsupported runtime types instead of converting values. Use an options object with
+/// DataAnnotations when validation spans multiple members, needs nested object traversal, or should model
+/// required presence separately from value shape.
+/// </para>
+/// <para>
+/// The validation context object is the concrete config wrapper and does not provide application dependency
+/// injection services. Override <see cref="Config{T}.ValidateValue"/> or <see cref="ConfigStruct{T}.ValidateValue"/>
+/// for scalar rules that cannot be expressed as reusable attributes.
+/// </para>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
 public abstract class ConfigValueValidationAttribute : ValidationAttribute
 {
@@ -31,6 +49,19 @@ public abstract class ConfigValueValidationAttribute : ValidationAttribute
 /// Validates that a resolved scalar configuration value is not empty.
 /// Supported value types are <see cref="string"/> and <see cref="Guid"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A null value is treated as successful validation so optional or missing scalar values remain optional.
+/// Non-null strings must contain non-whitespace characters, and non-null <see cref="Guid"/> values must not
+/// be <see cref="Guid.Empty"/>.
+/// </para>
+/// <para>
+/// Runtime type matching is strict: only <see cref="string"/> and <see cref="Guid"/> are supported. Applying
+/// this attribute to a different scalar value type returns a validation failure rather than attempting a
+/// conversion. Use an options object with member-level DataAnnotations when required presence, cross-field
+/// rules, or richer object validation is part of the contract.
+/// </para>
+/// </remarks>
 public sealed class ConfigValueNotEmptyAttribute : ConfigValueValidationAttribute
 {
     /// <summary>
@@ -46,7 +77,7 @@ public sealed class ConfigValueNotEmptyAttribute : ConfigValueValidationAttribut
     {
         if (value is null)
         {
-            return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+            return ValidationResult.Success;
         }
 
         return value switch
@@ -68,6 +99,19 @@ public sealed class ConfigValueNotEmptyAttribute : ConfigValueValidationAttribut
 /// Validates that a resolved scalar numeric configuration value is inside an inclusive range.
 /// Supported value types are <see cref="int"/> and <see cref="double"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A null value is treated as successful validation so optional or missing scalar values remain optional.
+/// Non-null values are compared against the inclusive minimum and maximum supplied to the constructor.
+/// </para>
+/// <para>
+/// Runtime type matching is strict and follows the constructor overload. The <see cref="int"/> constructor
+/// validates only <see cref="int"/> values, and the <see cref="double"/> constructor validates only
+/// <see cref="double"/> values. Unsupported runtime types return validation failures instead of being
+/// converted. Use an options object when validation needs multiple numeric fields, required presence, or
+/// object-level DataAnnotations.
+/// </para>
+/// </remarks>
 public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
 {
     private readonly RangeKind _kind;
@@ -196,6 +240,18 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
 /// <summary>
 /// Validates that a resolved scalar string configuration value has at least the configured length.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A null value is treated as successful validation so optional or missing scalar values remain optional.
+/// Non-null strings must have a length greater than or equal to <see cref="Length"/>.
+/// </para>
+/// <para>
+/// Runtime type matching is strict: only <see cref="string"/> values are supported. Applying this attribute
+/// to another scalar value type returns a validation failure rather than converting the value. Use an options
+/// object with DataAnnotations when string length is only one part of a larger model contract or when
+/// required presence should be represented separately.
+/// </para>
+/// </remarks>
 public sealed class ConfigValueMinLengthAttribute : ConfigValueValidationAttribute
 {
     /// <summary>

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -1,0 +1,229 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ForgeTrust.Runnable.Config;
+
+/// <summary>
+/// Base class for Runnable scalar configuration value validation attributes.
+/// Apply derived attributes to concrete <see cref="Config{T}"/> or <see cref="ConfigStruct{T}"/> wrapper
+/// types to validate resolved scalar values during configuration initialization.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public abstract class ConfigValueValidationAttribute : ValidationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigValueValidationAttribute"/> class.
+    /// </summary>
+    protected ConfigValueValidationAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigValueValidationAttribute"/> class with an error message.
+    /// </summary>
+    /// <param name="errorMessage">The validation error message.</param>
+    protected ConfigValueValidationAttribute(string errorMessage)
+        : base(errorMessage)
+    {
+    }
+}
+
+/// <summary>
+/// Validates that a resolved scalar configuration value is not empty.
+/// Supported value types are <see cref="string"/> and <see cref="Guid"/>.
+/// </summary>
+public sealed class ConfigValueNotEmptyAttribute : ConfigValueValidationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigValueNotEmptyAttribute"/> class.
+    /// </summary>
+    public ConfigValueNotEmptyAttribute()
+        : base("The configuration value must not be empty.")
+    {
+    }
+
+    /// <inheritdoc />
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is null)
+        {
+            return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+        }
+
+        return value switch
+        {
+            string text when !string.IsNullOrWhiteSpace(text) => ValidationResult.Success,
+            string => new ValidationResult(FormatErrorMessage(validationContext.DisplayName)),
+            Guid guid when guid != Guid.Empty => ValidationResult.Success,
+            Guid => new ValidationResult(FormatErrorMessage(validationContext.DisplayName)),
+            _ => new ValidationResult(CreateUnsupportedTypeMessage(value.GetType()))
+        };
+    }
+
+    private static string CreateUnsupportedTypeMessage(Type type) =>
+        $"{nameof(ConfigValueNotEmptyAttribute)} supports String and Guid values. "
+        + $"Config value type '{type.Name}' is not supported.";
+}
+
+/// <summary>
+/// Validates that a resolved scalar numeric configuration value is inside an inclusive range.
+/// Supported value types are <see cref="int"/> and <see cref="double"/>.
+/// </summary>
+public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
+{
+    private readonly RangeKind _kind;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigValueRangeAttribute"/> class for <see cref="int"/> values.
+    /// </summary>
+    /// <param name="minimum">The inclusive minimum allowed value.</param>
+    /// <param name="maximum">The inclusive maximum allowed value.</param>
+    public ConfigValueRangeAttribute(int minimum, int maximum)
+        : base("The configuration value must be between {0} and {1}.")
+    {
+        _kind = RangeKind.Int32;
+        Minimum = minimum;
+        Maximum = maximum;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigValueRangeAttribute"/> class for <see cref="double"/> values.
+    /// </summary>
+    /// <param name="minimum">The inclusive minimum allowed value.</param>
+    /// <param name="maximum">The inclusive maximum allowed value.</param>
+    public ConfigValueRangeAttribute(double minimum, double maximum)
+        : base("The configuration value must be between {0} and {1}.")
+    {
+        _kind = RangeKind.Double;
+        Minimum = minimum;
+        Maximum = maximum;
+    }
+
+    /// <summary>
+    /// Gets the inclusive minimum allowed value.
+    /// </summary>
+    public object Minimum { get; }
+
+    /// <summary>
+    /// Gets the inclusive maximum allowed value.
+    /// </summary>
+    public object Maximum { get; }
+
+    /// <inheritdoc />
+    public override string FormatErrorMessage(string name) =>
+        string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            ErrorMessageString,
+            Minimum,
+            Maximum);
+
+    /// <inheritdoc />
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is null)
+        {
+            return ValidationResult.Success;
+        }
+
+        return _kind switch
+        {
+            RangeKind.Int32 => ValidateInt32(value),
+            RangeKind.Double => ValidateDouble(value),
+            _ => ValidationResult.Success
+        };
+    }
+
+    private ValidationResult? ValidateInt32(object value)
+    {
+        if (value is not int typedValue)
+        {
+            return new ValidationResult(CreateUnsupportedTypeMessage(value.GetType(), "Int32"));
+        }
+
+        var minimum = (int)Minimum;
+        var maximum = (int)Maximum;
+
+        return typedValue >= minimum && typedValue <= maximum
+            ? ValidationResult.Success
+            : new ValidationResult(FormatErrorMessage(string.Empty));
+    }
+
+    private ValidationResult? ValidateDouble(object value)
+    {
+        if (value is not double typedValue)
+        {
+            return new ValidationResult(CreateUnsupportedTypeMessage(value.GetType(), "Double"));
+        }
+
+        var minimum = (double)Minimum;
+        var maximum = (double)Maximum;
+
+        return typedValue >= minimum && typedValue <= maximum
+            ? ValidationResult.Success
+            : new ValidationResult(FormatErrorMessage(string.Empty));
+    }
+
+    private static string CreateUnsupportedTypeMessage(Type type, string supportedType) =>
+        $"{nameof(ConfigValueRangeAttribute)} configured for {supportedType} values cannot validate "
+        + $"config value type '{type.Name}'.";
+
+    private enum RangeKind
+    {
+        Int32,
+        Double
+    }
+}
+
+/// <summary>
+/// Validates that a resolved scalar string configuration value has at least the configured length.
+/// </summary>
+public sealed class ConfigValueMinLengthAttribute : ConfigValueValidationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigValueMinLengthAttribute"/> class.
+    /// </summary>
+    /// <param name="length">The minimum allowed string length.</param>
+    public ConfigValueMinLengthAttribute(int length)
+        : base("The configuration value must be at least {0} character(s) long.")
+    {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be greater than or equal to zero.");
+        }
+
+        Length = length;
+    }
+
+    /// <summary>
+    /// Gets the minimum allowed string length.
+    /// </summary>
+    public int Length { get; }
+
+    /// <inheritdoc />
+    public override string FormatErrorMessage(string name) =>
+        string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            ErrorMessageString,
+            Length);
+
+    /// <inheritdoc />
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is null)
+        {
+            return ValidationResult.Success;
+        }
+
+        if (value is not string text)
+        {
+            return new ValidationResult(CreateUnsupportedTypeMessage(value.GetType()));
+        }
+
+        return text.Length >= Length
+            ? ValidationResult.Success
+            : new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+    }
+
+    private static string CreateUnsupportedTypeMessage(Type type) =>
+        $"{nameof(ConfigValueMinLengthAttribute)} supports String values. "
+        + $"Config value type '{type.Name}' is not supported.";
+}

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -202,6 +202,9 @@ public sealed class ConfigValueMinLengthAttribute : ConfigValueValidationAttribu
     /// Initializes a new instance of the <see cref="ConfigValueMinLengthAttribute"/> class.
     /// </summary>
     /// <param name="length">The minimum allowed string length.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="length"/> is less than zero.
+    /// </exception>
     public ConfigValueMinLengthAttribute(int length)
         : base("The configuration value must be at least {0} character(s) long.")
     {

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -145,11 +145,22 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     /// <param name="minimum">The inclusive minimum allowed value.</param>
     /// <param name="maximum">The inclusive maximum allowed value.</param>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="minimum"/> is greater than <paramref name="maximum"/>.
+    /// Thrown when either bound is <see cref="double.NaN"/> or <paramref name="minimum"/>
+    /// is greater than <paramref name="maximum"/>.
     /// </exception>
     public ConfigValueRangeAttribute(double minimum, double maximum)
         : base("The configuration value must be between {0} and {1}.")
     {
+        if (double.IsNaN(minimum))
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be a valid number.");
+        }
+
+        if (double.IsNaN(maximum))
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximum), "Maximum must be a valid number.");
+        }
+
         if (minimum > maximum)
         {
             throw new ArgumentOutOfRangeException(

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -125,7 +125,7 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     /// Thrown when <paramref name="minimum"/> is greater than <paramref name="maximum"/>.
     /// </exception>
     public ConfigValueRangeAttribute(int minimum, int maximum)
-        : base("The configuration value must be between {0} and {1}.")
+        : base("The configuration value must be between {1} and {2}.")
     {
         if (minimum > maximum)
         {
@@ -149,7 +149,7 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     /// is greater than <paramref name="maximum"/>.
     /// </exception>
     public ConfigValueRangeAttribute(double minimum, double maximum)
-        : base("The configuration value must be between {0} and {1}.")
+        : base("The configuration value must be between {1} and {2}.")
     {
         if (double.IsNaN(minimum))
         {
@@ -188,6 +188,7 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
         string.Format(
             System.Globalization.CultureInfo.InvariantCulture,
             ErrorMessageString,
+            name,
             Minimum,
             Maximum);
 
@@ -201,13 +202,13 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
 
         return _kind switch
         {
-            RangeKind.Int32 => ValidateInt32(value),
-            RangeKind.Double => ValidateDouble(value),
+            RangeKind.Int32 => ValidateInt32(value, validationContext.DisplayName),
+            RangeKind.Double => ValidateDouble(value, validationContext.DisplayName),
             _ => ValidationResult.Success
         };
     }
 
-    private ValidationResult? ValidateInt32(object value)
+    private ValidationResult? ValidateInt32(object value, string displayName)
     {
         if (value is not int typedValue)
         {
@@ -219,10 +220,10 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
 
         return typedValue >= minimum && typedValue <= maximum
             ? ValidationResult.Success
-            : new ValidationResult(FormatErrorMessage(string.Empty));
+            : new ValidationResult(FormatErrorMessage(displayName));
     }
 
-    private ValidationResult? ValidateDouble(object value)
+    private ValidationResult? ValidateDouble(object value, string displayName)
     {
         if (value is not double typedValue)
         {
@@ -234,7 +235,7 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
 
         return typedValue >= minimum && typedValue <= maximum
             ? ValidationResult.Success
-            : new ValidationResult(FormatErrorMessage(string.Empty));
+            : new ValidationResult(FormatErrorMessage(displayName));
     }
 
     private static string CreateUnsupportedTypeMessage(Type type, string supportedType) =>
@@ -273,7 +274,7 @@ public sealed class ConfigValueMinLengthAttribute : ConfigValueValidationAttribu
     /// Thrown when <paramref name="length"/> is less than zero.
     /// </exception>
     public ConfigValueMinLengthAttribute(int length)
-        : base("The configuration value must be at least {0} character(s) long.")
+        : base("The configuration value must be at least {1} character(s) long.")
     {
         if (length < 0)
         {
@@ -293,6 +294,7 @@ public sealed class ConfigValueMinLengthAttribute : ConfigValueValidationAttribu
         string.Format(
             System.Globalization.CultureInfo.InvariantCulture,
             ErrorMessageString,
+            name,
             Length);
 
     /// <inheritdoc />

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -105,11 +105,11 @@ public sealed class ConfigValueNotEmptyAttribute : ConfigValueValidationAttribut
 /// Non-null values are compared against the inclusive minimum and maximum supplied to the constructor.
 /// </para>
 /// <para>
-/// Runtime type matching is strict and follows the constructor overload. The <see cref="int"/> constructor
-/// validates only <see cref="int"/> values, and the <see cref="double"/> constructor validates only
-/// <see cref="double"/> values. Unsupported runtime types return validation failures instead of being
-/// converted. Use an options object when validation needs multiple numeric fields, required presence, or
-/// object-level DataAnnotations.
+/// Range validation accepts resolved <see cref="int"/> and <see cref="double"/> values. Integer bounds are
+/// widened when validating a <see cref="double"/> value, so attribute arguments such as
+/// <c>[ConfigValueRange(1, 5)]</c> work for <c>ConfigStruct&lt;double&gt;</c> wrappers. Unsupported runtime
+/// types return validation failures instead of being converted. Use an options object when validation needs
+/// multiple numeric fields, required presence, or object-level DataAnnotations.
 /// </para>
 /// </remarks>
 public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
@@ -180,7 +180,7 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     /// <remarks>
     /// The integer constructor stores a boxed <see cref="int"/>, and the double constructor stores a boxed
     /// <see cref="double"/>. Callers should unbox this value according to the constructor overload they used.
-    /// The attribute also compares values using that same numeric type and treats the bound as inclusive.
+    /// The attribute treats the bound as inclusive and may widen integer bounds when validating double values.
     /// </remarks>
     public object Minimum { get; }
 
@@ -191,7 +191,7 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     /// <remarks>
     /// The integer constructor stores a boxed <see cref="int"/>, and the double constructor stores a boxed
     /// <see cref="double"/>. Callers should unbox this value according to the constructor overload they used.
-    /// The attribute also compares values using that same numeric type and treats the bound as inclusive.
+    /// The attribute treats the bound as inclusive and may widen integer bounds when validating double values.
     /// </remarks>
     public object Maximum { get; }
 
@@ -222,37 +222,40 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
 
     private ValidationResult? ValidateInt32(object value, string displayName)
     {
-        if (value is not int typedValue)
-        {
-            return new ValidationResult(CreateUnsupportedTypeMessage(value.GetType(), "Int32"));
-        }
-
-        var minimum = (int)Minimum;
-        var maximum = (int)Maximum;
-
-        return typedValue >= minimum && typedValue <= maximum
-            ? ValidationResult.Success
-            : new ValidationResult(FormatErrorMessage(displayName));
+        return ValidateNumber(value, displayName, (int)Minimum, (int)Maximum);
     }
 
     private ValidationResult? ValidateDouble(object value, string displayName)
     {
-        if (value is not double typedValue)
-        {
-            return new ValidationResult(CreateUnsupportedTypeMessage(value.GetType(), "Double"));
-        }
+        return ValidateNumber(value, displayName, (double)Minimum, (double)Maximum);
+    }
 
-        var minimum = (double)Minimum;
-        var maximum = (double)Maximum;
+    private ValidationResult? ValidateNumber(
+        object value,
+        string displayName,
+        double minimum,
+        double maximum)
+    {
+        var typedValue = value switch
+        {
+            int intValue => intValue,
+            double doubleValue => doubleValue,
+            _ => (double?)null
+        };
+
+        if (typedValue is null)
+        {
+            return new ValidationResult(CreateUnsupportedTypeMessage(value.GetType()));
+        }
 
         return typedValue >= minimum && typedValue <= maximum
             ? ValidationResult.Success
             : new ValidationResult(FormatErrorMessage(displayName));
     }
 
-    private static string CreateUnsupportedTypeMessage(Type type, string supportedType) =>
-        $"{nameof(ConfigValueRangeAttribute)} configured for {supportedType} values cannot validate "
-        + $"config value type '{type.Name}'.";
+    private static string CreateUnsupportedTypeMessage(Type type) =>
+        $"{nameof(ConfigValueRangeAttribute)} supports Int32 and Double values. "
+        + $"Config value type '{type.Name}' is not supported.";
 
     private enum RangeKind
     {

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -77,9 +77,19 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     /// </summary>
     /// <param name="minimum">The inclusive minimum allowed value.</param>
     /// <param name="maximum">The inclusive maximum allowed value.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="minimum"/> is greater than <paramref name="maximum"/>.
+    /// </exception>
     public ConfigValueRangeAttribute(int minimum, int maximum)
         : base("The configuration value must be between {0} and {1}.")
     {
+        if (minimum > maximum)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(minimum),
+                "Minimum must be less than or equal to maximum.");
+        }
+
         _kind = RangeKind.Int32;
         Minimum = minimum;
         Maximum = maximum;
@@ -90,9 +100,19 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     /// </summary>
     /// <param name="minimum">The inclusive minimum allowed value.</param>
     /// <param name="maximum">The inclusive maximum allowed value.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="minimum"/> is greater than <paramref name="maximum"/>.
+    /// </exception>
     public ConfigValueRangeAttribute(double minimum, double maximum)
         : base("The configuration value must be between {0} and {1}.")
     {
+        if (minimum > maximum)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(minimum),
+                "Minimum must be less than or equal to maximum.");
+        }
+
         _kind = RangeKind.Double;
         Minimum = minimum;
         Maximum = maximum;

--- a/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigValueValidationAttribute.cs
@@ -174,13 +174,25 @@ public sealed class ConfigValueRangeAttribute : ConfigValueValidationAttribute
     }
 
     /// <summary>
-    /// Gets the inclusive minimum allowed value.
+    /// Gets the inclusive minimum allowed value as a boxed <see cref="int"/> or <see cref="double"/>,
+    /// matching the constructor overload used to create the attribute.
     /// </summary>
+    /// <remarks>
+    /// The integer constructor stores a boxed <see cref="int"/>, and the double constructor stores a boxed
+    /// <see cref="double"/>. Callers should unbox this value according to the constructor overload they used.
+    /// The attribute also compares values using that same numeric type and treats the bound as inclusive.
+    /// </remarks>
     public object Minimum { get; }
 
     /// <summary>
-    /// Gets the inclusive maximum allowed value.
+    /// Gets the inclusive maximum allowed value as a boxed <see cref="int"/> or <see cref="double"/>,
+    /// matching the constructor overload used to create the attribute.
     /// </summary>
+    /// <remarks>
+    /// The integer constructor stores a boxed <see cref="int"/>, and the double constructor stores a boxed
+    /// <see cref="double"/>. Callers should unbox this value according to the constructor overload they used.
+    /// The attribute also compares values using that same numeric type and treats the bound as inclusive.
+    /// </remarks>
     public object Maximum { get; }
 
     /// <inheritdoc />

--- a/Config/ForgeTrust.Runnable.Config/ConfigurationValidationException.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigurationValidationException.cs
@@ -68,7 +68,7 @@ public sealed class ConfigurationValidationException : Exception
         IReadOnlyList<ConfigurationValidationFailure> failures)
     {
         var orderedFailures = failures
-            .OrderBy(GetMemberLabel, StringComparer.Ordinal)
+            .OrderBy(failure => GetMemberLabel(failure, valueType), StringComparer.Ordinal)
             .ThenBy(failure => failure.Message, StringComparer.Ordinal)
             .ToList();
 
@@ -87,7 +87,7 @@ public sealed class ConfigurationValidationException : Exception
         {
             builder.Append(Environment.NewLine)
                 .Append("- ")
-                .Append(GetMemberLabel(failure))
+                .Append(GetMemberLabel(failure, valueType))
                 .Append(": ")
                 .Append(failure.Message);
         }
@@ -95,11 +95,11 @@ public sealed class ConfigurationValidationException : Exception
         return builder.ToString();
     }
 
-    private static string GetMemberLabel(ConfigurationValidationFailure failure)
+    private static string GetMemberLabel(ConfigurationValidationFailure failure, Type valueType)
     {
         if (failure.MemberNames.Count == 0)
         {
-            return "<object>";
+            return ConfigScalarTypes.IsScalar(valueType) ? "<value>" : "<object>";
         }
 
         return string.Join(

--- a/Config/ForgeTrust.Runnable.Config/EnvironmentConfigProvider.cs
+++ b/Config/ForgeTrust.Runnable.Config/EnvironmentConfigProvider.cs
@@ -1,5 +1,5 @@
-﻿using System.Globalization;
-using System.Collections;
+﻿using System.Collections;
+using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 using ForgeTrust.Runnable.Core;

--- a/Config/ForgeTrust.Runnable.Config/IConfig.cs
+++ b/Config/ForgeTrust.Runnable.Config/IConfig.cs
@@ -10,7 +10,7 @@ public interface IConfig
     /// <summary>
     /// Initializes the configuration object, resolving its provider or default value and failing fast
     /// with <see cref="ConfigurationValidationException"/> when the resolved value violates
-    /// DataAnnotations validation rules.
+    /// object DataAnnotations rules or scalar value validation rules.
     /// </summary>
     /// <param name="configManager">The configuration manager to use for retrieving values.</param>
     /// <param name="environmentProvider">The environment provider.</param>

--- a/Config/ForgeTrust.Runnable.Config/IConfig.cs
+++ b/Config/ForgeTrust.Runnable.Config/IConfig.cs
@@ -11,10 +11,20 @@ public interface IConfig
     /// Initializes the configuration object, resolving its provider or default value and failing fast
     /// with <see cref="ConfigurationValidationException"/> when the resolved value violates
     /// object DataAnnotations rules or scalar value validation rules.
+    /// Exceptions thrown by scalar <see cref="Config{T}.ValidateValue"/> or
+    /// <see cref="ConfigStruct{T}.ValidateValue"/> overrides are not wrapped, so callers that activate
+    /// config wrappers during startup should let unexpected programming errors fail the startup path.
     /// </summary>
     /// <param name="configManager">The configuration manager to use for retrieving values.</param>
     /// <param name="environmentProvider">The environment provider.</param>
     /// <param name="key">The root configuration key for this object.</param>
+    /// <exception cref="ConfigurationValidationException">
+    /// Thrown when the resolved provider value or default value violates object DataAnnotations or scalar
+    /// validation rules.
+    /// </exception>
+    /// <exception cref="Exception">
+    /// Thrown when a concrete scalar validation override throws; override exceptions are not wrapped.
+    /// </exception>
     void Init(
         IConfigManager configManager,
         IEnvironmentProvider environmentProvider,

--- a/Config/ForgeTrust.Runnable.Config/README.md
+++ b/Config/ForgeTrust.Runnable.Config/README.md
@@ -17,7 +17,7 @@ This package provides the configuration layer for Runnable modules. It combines 
 - **`ConfigValueNotEmptyAttribute`**: Validates that a resolved scalar `string` or `Guid` value is not empty.
 - **`ConfigValueRangeAttribute`**: Validates that a resolved scalar `int` or `double` value is within an inclusive range.
 - **`ConfigValueMinLengthAttribute`**: Validates that a resolved scalar `string` value meets a minimum length.
-- **`ConfigurationValidationException`**: Startup-time exception that reports DataAnnotations failures for a resolved config value.
+- **`ConfigurationValidationException`**: Startup-time exception that reports object DataAnnotations and scalar validation failures for a resolved config value.
 - **`ConfigurationValidationFailure`**: Structured validation failure details for logging and tests.
 
 ## Usage

--- a/Config/ForgeTrust.Runnable.Config/README.md
+++ b/Config/ForgeTrust.Runnable.Config/README.md
@@ -14,6 +14,9 @@ This package provides the configuration layer for Runnable modules. It combines 
 - **`FileBasedConfigProvider`**: Loads configuration from files.
 - **`Config<T>` / `ConfigStruct<T>`**: Base types for strongly typed configuration values.
 - **`ConfigKeyAttribute`**: Associates a configuration type or property with a specific key.
+- **`ConfigValueNotEmptyAttribute`**: Validates that a resolved scalar `string` or `Guid` value is not empty.
+- **`ConfigValueRangeAttribute`**: Validates that a resolved scalar `int` or `double` value is within an inclusive range.
+- **`ConfigValueMinLengthAttribute`**: Validates that a resolved scalar `string` value meets a minimum length.
 - **`ConfigurationValidationException`**: Startup-time exception that reports DataAnnotations failures for a resolved config value.
 - **`ConfigurationValidationFailure`**: Structured validation failure details for logging and tests.
 
@@ -37,9 +40,20 @@ public sealed class DocsPathConfig : Config<string>
 
 Resolve them through the configuration services used by your module or application startup flow.
 
-## DataAnnotations Validation
+Install the package from an application project with:
+
+```bash
+dotnet add package ForgeTrust.Runnable.Config --project <path-to-your-app.csproj>
+```
+
+## Validation
 
 `Config<T>` and `ConfigStruct<T>` validate the resolved value during initialization when the value is present. Validation runs after provider/default resolution, so defaults are held to the same rules as provider-supplied values. Optional `ConfigStruct<T>` values resolve through nullable `T?` provider lookups so a missing struct value is not confused with a configured zero-initialized value.
+
+Runnable has two validation paths:
+
+- object-valued config models use ordinary DataAnnotations on the model and its members
+- scalar config wrappers use Runnable scalar attributes or a `ValidateValue` override on the wrapper
 
 Use ordinary DataAnnotations on object-valued config models:
 
@@ -65,6 +79,61 @@ Configuration validation failed for key 'RetryConfig' (RetryConfig -> RetryOptio
 ```
 
 The exception also exposes structured failures through `Failures`. Each failure includes the config key, wrapper type, value type, member names, and validation message. Attempted values are not exposed because config values often include secrets.
+
+### Scalar Value Validation
+
+Scalar wrappers such as `Config<string>` and `ConfigStruct<int>` validate the resolved value from attributes placed on the wrapper class. This keeps simple configuration as a primitive while still giving startup-time validation:
+
+```csharp
+using ForgeTrust.Runnable.Config;
+
+[ConfigValueRange(1, 65535)]
+public sealed class PortConfig : ConfigStruct<int>
+{
+}
+
+[ConfigValueNotEmpty]
+public sealed class ApiKeyConfig : Config<string>
+{
+}
+```
+
+Built-in scalar attributes are intentionally small:
+
+| Attribute | Supported values | Behavior |
+| --- | --- | --- |
+| `ConfigValueNotEmptyAttribute` | `string`, `Guid` | Rejects empty or whitespace-only strings and `Guid.Empty`. |
+| `ConfigValueRangeAttribute(int minimum, int maximum)` | `int` | Rejects values outside the inclusive integer range. |
+| `ConfigValueRangeAttribute(double minimum, double maximum)` | `double` | Rejects values outside the inclusive double range. |
+| `ConfigValueMinLengthAttribute(int length)` | `string` | Rejects strings shorter than the configured length. |
+
+An unsupported built-in attribute and value-type pairing fails as a structured `ConfigurationValidationException`. For example, `[ConfigValueMinLength(3)]` on `ConfigStruct<int>` reports that the attribute supports `String` values instead of silently passing or throwing a cast exception.
+
+Use `ValidateValue` when the scalar rule is specific to your domain:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using ForgeTrust.Runnable.Config;
+
+public sealed class TenantSlugConfig : Config<string>
+{
+    protected override IEnumerable<ValidationResult>? ValidateValue(
+        string value,
+        ValidationContext validationContext)
+    {
+        if (value.Contains("..", StringComparison.Ordinal))
+        {
+            return [new ValidationResult("Tenant slugs cannot contain '..'.")];
+        }
+
+        return null;
+    }
+}
+```
+
+Scalar validation runs only for non-null resolved scalar values. `[ConfigValueNotEmpty]` rejects an empty value that was supplied by a provider or default, but it does not make a missing config value required. Use a default, application startup policy, or a dedicated presence check when the key itself must exist.
+
+When both wrapper attributes and `ValidateValue` fail, attribute failures are reported first. Hook exceptions are not wrapped; they bubble to the caller so programming errors remain visible.
 
 ### Recursive Validation
 
@@ -106,10 +175,22 @@ Runnable uses the Microsoft marker attributes as the public authoring contract, 
 
 ### Pitfalls
 
-- Scalar primitive configs such as `Config<string>` and `ConfigStruct<int>` are not meaningful DataAnnotations targets. Wrap scalar values in an options object when validation matters.
+- DataAnnotations attributes such as `[Range]` on the wrapper class are not scalar validation attributes. Use Runnable `ConfigValue*` attributes on scalar wrappers, or wrap related settings in an options object and use ordinary DataAnnotations on that object.
+- Scalar validation validates values that exist after provider/default resolution. It is not a required-presence contract for missing keys.
+- Built-in scalar attributes support only the value types documented above. Use `ValidateValue` for decimal, date/time, URI, domain-specific, or cross-cutting scalar rules.
 - DataAnnotations can short-circuit. For example, object-level `IValidatableObject` validation may not run when property validation already failed.
 - Recursive validation is opt-in. A nested object without `[ValidateObjectMembers]` and a collection without `[ValidateEnumeratedItems]` is not traversed.
 - The `Validator` constructor overloads on Microsoft Options validation attributes are not supported by Runnable Config validation.
+
+## Example
+
+Run the scalar validation sample from the repository root:
+
+```bash
+dotnet run --project examples/config-validation
+```
+
+It intentionally exits non-zero and prints the validation failure shape without echoing the invalid value.
 
 ## Notes
 

--- a/Config/ForgeTrust.Runnable.Config/README.md
+++ b/Config/ForgeTrust.Runnable.Config/README.md
@@ -155,8 +155,8 @@ Built-in scalar attributes are intentionally small:
 | Attribute | Supported values | Behavior |
 | --- | --- | --- |
 | `ConfigValueNotEmptyAttribute` | `string`, `Guid` | Rejects empty or whitespace-only strings and `Guid.Empty`. |
-| `ConfigValueRangeAttribute(int minimum, int maximum)` | `int` | Rejects values outside the inclusive integer range. |
-| `ConfigValueRangeAttribute(double minimum, double maximum)` | `double` | Rejects values outside the inclusive double range. |
+| `ConfigValueRangeAttribute(int minimum, int maximum)` | `int`, `double` | Rejects values outside the inclusive range. Integer bounds are widened for double values, so `[ConfigValueRange(1, 5)]` works on `ConfigStruct<double>`. |
+| `ConfigValueRangeAttribute(double minimum, double maximum)` | `int`, `double` | Rejects values outside the inclusive range using double comparisons. |
 | `ConfigValueMinLengthAttribute(int length)` | `string` | Rejects strings shorter than the configured length. |
 
 An unsupported built-in attribute and value-type pairing fails as a structured `ConfigurationValidationException`. For example, `[ConfigValueMinLength(3)]` on `ConfigStruct<int>` reports that the attribute supports `String` values instead of silently passing or throwing a cast exception.

--- a/ForgeTrust.Runnable.slnx
+++ b/ForgeTrust.Runnable.slnx
@@ -26,6 +26,7 @@
     <Project Path="Dependency/ForgeTrust.Runnable.Dependency.Autofac/ForgeTrust.Runnable.Dependency.Autofac.csproj" />
   </Folder>
   <Folder Name="/Examples/">
+    <Project Path="examples/config-validation/ConfigValidationExample.csproj" />
     <Project Path="examples/console-app/ConsoleAppExample.csproj" />
     <Project Path="examples/web-app/WebAppExample.csproj" />
   </Folder>

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ dotnet run --project examples/console-app
 dotnet run --project examples/web-app
 ```
 
+For the intentional validation-failure shape, run `dotnet run --project examples/config-validation`.
+
 ## Release notes and upgrade policy
 
 Runnable is preparing to release the entire monorepo in unison. The public release contract now lives in the repository so teams can see what is queued for the next version, how pre-1.0 changes are handled, and where future migration notes will live.
@@ -153,6 +155,8 @@ how to use this project.
   definitions.
 - [Web app example](examples/web-app) – shows a minimal ASP.NET Core app that
   composes middleware and endpoints from modules.
+- [Config validation example](examples/config-validation) – shows scalar
+  validation on a strongly typed config wrapper and the startup failure shape.
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ This directory contains sample applications that use **ForgeTrust.Runnable**.
 
 - [Console app example](console-app) – shows how to build a simple console application using [CliFx](https://github.com/Tyrrrz/CliFx) for command definitions.
 - [Web app example](web-app) – demonstrates starting a minimal ASP.NET Core web application.
+- [Config validation example](config-validation) – shows scalar validation on a strongly typed config wrapper and the startup failure shape.
 
 ---
 [🏠 Back to Root](../README.md)

--- a/examples/config-validation/ConfigValidationExample.csproj
+++ b/examples/config-validation/ConfigValidationExample.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Config/ForgeTrust.Runnable.Config/ForgeTrust.Runnable.Config.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/config-validation/Program.cs
+++ b/examples/config-validation/Program.cs
@@ -1,0 +1,50 @@
+using ForgeTrust.Runnable.Config;
+using ForgeTrust.Runnable.Core;
+
+var config = new PortConfig();
+
+try
+{
+    ((IConfig)config).Init(new ExampleConfigManager(), new ExampleEnvironmentProvider(), "PortConfig");
+    Console.WriteLine("Configuration validation unexpectedly passed.");
+
+    return 0;
+}
+catch (ConfigurationValidationException exception)
+{
+    Console.Error.WriteLine(exception.Message);
+    Console.Error.WriteLine("Fix the configured value or relax the scalar rule on the config wrapper.");
+
+    return 1;
+}
+
+[ConfigValueRange(1, 65535)]
+internal sealed class PortConfig : ConfigStruct<int>
+{
+}
+
+internal sealed class ExampleConfigManager : IConfigManager
+{
+    public int Priority => 0;
+
+    public string Name => nameof(ExampleConfigManager);
+
+    public T? GetValue<T>(string environment, string key)
+    {
+        if (key == "PortConfig" && typeof(T) == typeof(int?))
+        {
+            return (T)(object)70000;
+        }
+
+        return default;
+    }
+}
+
+internal sealed class ExampleEnvironmentProvider : IEnvironmentProvider
+{
+    public string Environment => "Development";
+
+    public bool IsDevelopment => true;
+
+    public string? GetEnvironmentVariable(string name, string? defaultValue = null) => defaultValue;
+}

--- a/examples/config-validation/README.md
+++ b/examples/config-validation/README.md
@@ -1,0 +1,19 @@
+# Config validation example
+
+This sample shows scalar validation on a strongly typed Runnable config wrapper.
+
+Run it from the repository root:
+
+```bash
+dotnet run --project examples/config-validation
+```
+
+The sample intentionally exits with a non-zero status so you can see the startup failure shape:
+
+```text
+Configuration validation failed for key 'PortConfig' (PortConfig -> Int32): 1 error(s).
+- <value>: The configuration value must be between 1 and 65535.
+Fix the configured value or relax the scalar rule on the config wrapper.
+```
+
+The failed value is not printed. Configuration values often include secrets, so validation output names the key and rule without echoing the attempted value.

--- a/examples/config-validation/packages.lock.json
+++ b/examples/config-validation/packages.lock.json
@@ -1,0 +1,307 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "VWB5jdkxHsRiuoniTqwOL32R4OWyp5If/bAucLjRJczRVNcwb8iCXKLjn3Inv8fv+jHMVMnvQLg7xhSys+y5PA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "3GgMIi2jP8g1fBW93Z9b9Unamc0SIsgyhiCmC91gq4loTixK9vQMuxxUsfJ1kRGwn+/FqLKwOHqmn0oYWn3Fvw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "Opl/7SIrwDy9WjHn/vU2thQ8CUtrIWHLr+89I7/0VYNEJQvpL24zvqYrh83cH38RzNKHji0WGVkCVP6HJChVVw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "DC5I4Y1nK35jY4piDqQCzWjDXzT6ECMctBAxgAJoc6pn0k6uyxcDeOuVDRooFui/N65ptn9xT5mk9eO4mSTj/g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "RGYG2JBak9lf2rIPiZUVmWjUqoxaHPy3XPhPsJyIQ8QqK47rKvJz7jxVYefTnYdM5LTEiGFBdC7v3+SiosvmkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "pCEueasI5JhJ24KYzMFxtG40zyLnWpcQYawpARh9FNq9XbWozuWgexmdkPa8p8YoVNlpi3ecKfcjfoRMkKAufw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "N0dgOYQ9tDzJouL9Tyx2dgMCcHV2pBaY8yVtorbDqYYwiDRS2zd1TbhTA2FMHqXF3SMjBoO+gONZcDoA79gdSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.FileExtensions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0ZZMzdvNwIS0f09S0IcaEbKFm+Xc41vRROsA/soeKEpzRISTDdiVwGlzdldbXEsuPjNVvNHyvIP8YW2hfIig0w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Json": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "vS65HMo5RS10DD543fknsyVDxihMcVxVn3/hNaILgBxWYnOLxWIeCIO9X0QFuCvPRNjClvXe9Aj8KaQNx7vFkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0Zn6nR/6g+90MxskZyOOMPQvnPnrrGu6bytPwkV+azDcTtCSuQ1+GJUrg8Klmnrjk1i6zMpw2lXijl+tw7Q3kA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "mIqCzZseDK9SqTRy4LxtjLwjlUu6aH5UdA6j0vgVER14yki9oRqLF+SmBiF6OlwsBSeL6dMQ8dmq02JMeE2puQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "GIoXX7VDcTEsNM6yvffTBaOwnPQELGI5dzExR7L2O7AUkDsHBYIZawUbuwfq3cYzz8dIAAJotQYJMzH7qy27Ng==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "q9FPkSGVA9ipI255p3PBAvWNXas5Tzjyp/DwYSwT+46mIFw9fWZahsF6vHpoxLt5/vtANotH2sAm7HunuFIx9g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "l+dFA0NRl90vSIiJNy5d7V0kpTEOWHTqbgoWYzlTwF5uiM5sWJ953haaELKE05jkyJdnemVTnqjrlgo4wo7oyg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileSystemGlobbing": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "1HJCAbwukNEoYbHgHbKHmenU0V/0huw8+i7Qtf5rLUG1E+3kEwRJQxpwD3wbTEagIgPSQisNgJTvmUX9yYVc6g=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "G9T95JbcG/wQpeVIzg0IMwxI+uTywDmbxWUWN2P0mdna35rmuTqgTrZ4SU5rcfUT3EJfbI9N4K8UyCAAc6QK8Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "XBzjitTFaQhF8EbJ645vblZezV1p52ePTxKHoVkRidHF11Xkjxg94qr0Rvp2qyxK2vBJ4OIZ41NB15YUyxTGMQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "LFnyBNK7WtFmKdnHu3v0HOYQ8BcjYuy0jdC9pgCJ/rbLKoJEG9/dBzSKMEeeWDbDeoWS0TIxOC8a9CM5ufca3A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lCgpxE5r6v43SB40/yUVnSWZUUqUZF5iUWizhkx4gqvq0L0rMw5g8adWKGO7sfIaSbCiU0et85sDQWswhLcceg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "u21euQdOjaEwmlnnB1Zd4XGqOmWI8FkoGeUleV7n4BZ8HPQC/jrYzX/B5Cz3uI/FXjd//W88clPfkGIbSif7Jw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "IyyGy7xNJAjdlFYXc7SZ7kS3CWd3Ma4hing9QGtzXi+LXm8RWCEXdKA1cPx5AeFmdg3rVG+ADGIn44K14O+vFA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "System.Diagnostics.EventLog": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "ayCRr/8ON3aINH81ak9l3vLAF/0pV/xrfChCbIlT2YnHAd4TYBWLcWhzbJWwPFV4XmJFrx/z8oq+gZzIc/74OA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "2lnp8nrvfzyp+5zvfeULm/hkZsDsKkl2ziBt5T8EZKoON5q+XRpRLoWcSPo8mP7GNZXpxKMBVjFNIZNbBIcnRw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "BHniU24QV67qp1pJknqYSofAPYGmijGI8D+ci9yfw33iuFdyOeB9lWTg78ThyYLyQwZw3s0vZ36VMb0MqbUuLw=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lum+Dv+8S4gqN5H1C576UcQe0M2buoRjEUVs4TctXRSWjBH3ay3w2KyQrOo1yPdRs1I+xK69STz+4mjIisFI5w=="
+      },
+      "forgetrust.runnable.config": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.Runnable.Core": "[1.0.0, )",
+          "Microsoft.Extensions.Options": "[9.0.6, )"
+        }
+      },
+      "forgetrust.runnable.core": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting": "[9.0.6, )",
+          "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
+        }
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "Iu1UyXUnjMhoOwThKM0kCyjgWqqQnuujsbPMnF44ITUbmETT7RAVlozNgev2L/damwNoPZKpmwArRKBy2IOAZg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.Configuration.CommandLine": "9.0.6",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "9.0.6",
+          "Microsoft.Extensions.Configuration.FileExtensions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Json": "9.0.6",
+          "Microsoft.Extensions.Configuration.UserSecrets": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.Logging.Console": "9.0.6",
+          "Microsoft.Extensions.Logging.Debug": "9.0.6",
+          "Microsoft.Extensions.Logging.EventLog": "9.0.6",
+          "Microsoft.Extensions.Logging.EventSource": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "L1O0M3MrqGlkrPYMLzcCphQpCG0lSHfTSPrm1otALNBzTPiO8rxxkjhBIIa2onKv92UP30Y4QaiigVMTx8YcxQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "wUPhNM1zsI58Dy10xRdF2+pnsisiUuETg5ZBncyAEEUm/CQ9Q1vmivyUWH8RDbAlqyixf2dJNQ2XZb7HsKUEQw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      }
+    }
+  }
+}

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -50,6 +50,8 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 
 - Strongly typed config wrappers now validate resolved object values with DataAnnotations during startup, including defaults, and report operator-friendly `ConfigurationValidationException` failures without echoing attempted values.
 - Nested config validation can now opt into Microsoft Options `[ValidateObjectMembers]` and `[ValidateEnumeratedItems]` markers while Runnable owns traversal, path formatting, and cycle protection.
+- Scalar config wrappers can now validate resolved primitive values directly with `ConfigValueNotEmpty`, `ConfigValueRange`, and `ConfigValueMinLength` attributes, while wrapper-specific scalar rules can override `ValidateValue`.
+- The new `examples/config-validation` sample demonstrates an intentional startup validation failure for a scalar `ConfigStruct<int>` without printing the invalid configured value.
 
 ### Web host development defaults
 


### PR DESCRIPTION
## Summary

Fixes #194.

Adds first-class scalar validation for Runnable Config primitive wrappers while preserving object-valued DataAnnotations validation:

- adds `ConfigValueValidationAttribute`, `ConfigValueNotEmptyAttribute`, `ConfigValueRangeAttribute`, and `ConfigValueMinLengthAttribute`
- adds protected `ValidateValue` hooks on `Config<T>` and `ConfigStruct<T>` for custom scalar rules
- keeps missing optional scalar values non-required, with true required-presence work tracked separately in #204
- reports scalar root failures as `<value>` while preserving object root `<object>` labels
- adds `examples/config-validation` plus docs, changelog, release notes, and smoke coverage

## Developer impact

Package users can now keep simple settings as scalar config wrappers instead of wrapping every primitive in an options object just to get startup-time validation. Built-in attributes cover the common cases, and `ValidateValue` keeps domain-specific rules available without forcing a new attribute type.

## Validation

- `dotnet test Config/ForgeTrust.Runnable.Config.Tests/ForgeTrust.Runnable.Config.Tests.csproj` passed, 119/119
- `dotnet format --verify-no-changes` passed
- `dotnet run --project examples/config-validation` produced the expected intentional non-zero safe validation failure
- `./scripts/coverage-solution.sh` passed
- solution coverage: 95.85% line / 93.77% branch
- Config coverage: 99.56% line / 97.13% branch / 100% method
- /qa browser smoke found 0 issues, health score 100 -> 100

## QA artifact

- `.gstack/qa-reports/qa-report-127-0-0-1-5055-2026-05-03.md`
