### PR TITLE
docs: add contributor feature request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+name: Feature request
+description: Propose a focused product capability, API shape, workflow, or example.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a change. Focused feature requests are easiest to evaluate when they name the current limitation, the user job, and the smallest useful outcome. Use the docs/DX form instead when the main problem is confusing guidance, broken links, missing explanations, or first-run friction.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem should this solve?
+      description: Describe the developer task, product gap, or repeated workaround that motivated the request.
+      placeholder: "I am trying to ..., but today I have to ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape
+      description: Describe the API, command, package behavior, example, or workflow you expected.
+      placeholder: "It would help if Runnable provided ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Pick the closest package or repo surface.
+      options:
+        - Core startup pipeline
+        - Console
+        - Web
+        - RazorWire
+        - RazorDocs
+        - Caching
+        - Config
+        - Dependency injection
+        - Aspire
+        - Examples
+        - Release tooling
+        - Repository workflow
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Share current workarounds, other libraries, or narrower designs that might solve the same job.
+      placeholder: "I can work around this by ..., but ..."
+    validations:
+      required: false
+  - type: textarea
+    id: usage
+    attributes:
+      label: Expected usage
+      description: Include a small code sample, command, page outline, or workflow sketch when that would clarify the request.
+      placeholder: |
+        ```csharp
+        // Example shape, if relevant.
+        ```
+    validations:
+      required: false
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints or pitfalls
+      description: Name compatibility, security, performance, hosting, documentation, or migration concerns that should shape the design.
+      placeholder: "This should preserve ..., avoid ..., and document ..."
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Filing checklist
+      options:
+        - label: I described the user job or limitation instead of only naming an implementation.
+          required: true
+        - label: I checked the relevant package README, examples, or release notes for existing guidance.
+          required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,24 @@ Runnable treats docs and onboarding feedback as product input, not as a second-c
 For quick access, use GitHub's issue template chooser: [choose an issue template](https://github.com/forge-trust/Runnable/issues/new/choose).
 
 - Use the [**Bug report** issue form](https://github.com/forge-trust/Runnable/issues/new?template=bug_report.yml) when behavior is broken or surprising.
+- Use the [**Feature request** issue form](https://github.com/forge-trust/Runnable/issues/new?template=feature_request.yml) when you can name a focused product capability, API shape, workflow, or example that would remove friction.
 - Use the [**Docs or developer experience feedback** issue form](https://github.com/forge-trust/Runnable/issues/new?template=docs_dx_feedback.yml) when the code may work, but the route to understanding it is unclear.
 - Do not use public issue forms for suspected vulnerabilities, leaked secrets, or exploit details. Use the [security policy](./SECURITY.md) and report sensitive findings privately.
 - Include the command, page, example, package, or API where the confusion started. The sharpest reports name the exact step that failed and the next thing you expected to see.
-- If you are unsure whether something is a bug or a docs gap, file the docs/DX form and explain the behavior you expected.
+- If you are unsure whether something is a bug, feature request, or docs gap, file the docs/DX form and explain the behavior you expected.
 
 Avoid broad requests such as "improve the docs" without a concrete page, task, or decision point. Narrow feedback is easier to verify and much more likely to turn into a useful change.
+
+## Local setup
+
+Use a current .NET SDK supported by this repository, then restore and build from the repository root before opening a pull request:
+
+```bash
+dotnet restore
+dotnet build
+```
+
+Run the sample or package-specific command you changed, and include that command in your pull request notes. For broad changes, also run the full test suite and coverage command listed in [Local verification](#local-verification).
 
 ## Working on docs
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ Runnable is preparing to release the entire monorepo in unison. The public relea
 
 ## Feedback and contributing
 
-Runnable uses GitHub issue forms to keep bug reports and docs/developer-experience feedback concrete enough to reproduce. If an example, README, quickstart, or package API leaves you stuck, start with the [contribution guide](./CONTRIBUTING.md), [choose an issue template](https://github.com/forge-trust/Runnable/issues/new/choose), and file the form that matches the problem.
+Runnable uses GitHub issue forms to keep bug reports, feature requests, and docs/developer-experience feedback concrete enough to reproduce or evaluate. If an example, README, quickstart, or package API leaves you stuck, start with the [contribution guide](./CONTRIBUTING.md), [choose an issue template](https://github.com/forge-trust/Runnable/issues/new/choose), and file the form that matches the problem.
 
-Use docs/DX feedback for confusing guidance, missing concepts, broken links, snippet drift, or first-run friction. Use bug reports when runtime behavior, generated output, or package APIs do something unexpected.
+Use docs/DX feedback for confusing guidance, missing concepts, broken links, snippet drift, or first-run friction. Use feature requests for focused product capabilities, API shapes, workflows, or examples. Use bug reports when runtime behavior, generated output, or package APIs do something unexpected.
 Do not file suspected vulnerabilities, leaked secrets, or exploit details in public issues; follow the [security policy](./SECURITY.md) instead.
 
 ## Examples

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -27,7 +27,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Pull request titles are now expected to follow Conventional Commits so the merge history is machine-readable for future automation.
 - Pull requests are expected to update this page unless maintainers explicitly mark the change as outside the public release story.
 - Markdown-only changes on `main` now republish the docs surface, so release-note and policy edits are treated as first-class product updates.
-- Runnable now exposes focused GitHub issue forms for bug reports and docs/developer-experience feedback, with the root README and contribution guide pointing developers to that feedback path.
+- Runnable now exposes focused GitHub issue forms for bug reports, feature requests, and docs/developer-experience feedback, with the root README and contribution guide pointing developers to that feedback path.
 - Public contribution surfaces now steer suspected vulnerabilities away from issue forms and into a private security reporting path.
 - GitHub issue template support links now point first-time adopters to the package chooser and release/upgrade contract when they are evaluating install path or migration risk.
 


### PR DESCRIPTION
## Summary

- add a first-party feature request issue form with required problem, proposal, and area fields
- clarify the split between bug reports, feature requests, and docs/DX feedback in the README and contributor guide
- add lightweight local setup guidance for contributors
- update unreleased notes for the expanded issue intake surface

Fixes #122

## Validation

- ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].each { |path| YAML.load_file(path); puts "ok #{path}" }'\n- git diff --cached --check