### PR TITLE
docs(razordocs): document namespace README merge contract

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -1123,6 +1123,26 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task DetailsView_ShouldRenderNonCSharpTitleWithMobileWrappingClasses()
+    {
+        var doc = new DocNode(
+            "ForgeTrust.Runnable.Web.RazorDocs",
+            "Web/ForgeTrust.Runnable.Web.RazorDocs/README.md",
+            "<p>Guide body</p>");
+
+        var html = await RenderDetailsViewAsync(doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        var title = document.QuerySelector("h1");
+
+        Assert.NotNull(title);
+        Assert.Equal("ForgeTrust.Runnable.Web.RazorDocs", title!.TextContent.Trim());
+        Assert.Contains("max-w-full", title.ClassList);
+        Assert.Contains("break-words", title.ClassList);
+        Assert.Contains("leading-tight", title.ClassList);
+    }
+
+    [Fact]
     public async Task DetailsView_ShouldFallbackToPathBreadcrumbLabels_WhenMetadataTargetsCannotBeVerified()
     {
         var doc = new DocNode(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -237,6 +237,7 @@ Negative examples:
 - The standalone README node is removed after a successful merge so readers do not see duplicate pages.
 - README metadata can override the namespace page metadata, but derived Markdown defaults are ignored when they would accidentally replace API-reference classification.
 - README-relative links are resolved from the README source path before the standalone README page is removed.
+- Links that target the removed README page itself are not rewritten to a published page. Avoid self-links such as `./README.md` inside namespace intros because the standalone README route disappears after merge.
 - Contributor provenance points at the README source, while symbol-level source links still point at the generated API declarations.
 
 ### Decision guidance
@@ -245,13 +246,14 @@ Use a namespace README when the content is specifically about the namespace API 
 
 Use a package README when the content is about package adoption: installation, package-level configuration, examples, compatibility, and links to broader guides. Package READMEs such as `Web/ForgeTrust.Runnable.Web/README.md` and `src/ForgeTrust.Runnable.Web/README.md` do not automatically become namespace intros, even when the folder name matches a namespace. That boundary is intentional so package docs do not disappear into API pages by folder-name coincidence.
 
-Future dual-use package and namespace docs should use an explicit opt-in contract instead of reopening implicit path matching. Reasonable shapes include a front matter flag that names the target namespace, a paired sidecar mapping a README to `Namespaces/{Dotted.Namespace}`, or a resolver extension point that receives an explicit namespace target. Any future design should require the namespace name to be authored directly, preserve predictable package-doc behavior, and fail closed when the target namespace page does not exist.
+Future dual-use package and namespace docs should use an explicit opt-in contract instead of reopening implicit path matching. At the product-contract level, a future design could use a front matter flag that names the target namespace, a paired sidecar mapping a README to `Namespaces/{Dotted.Namespace}`, or a resolver extension point that receives an explicit namespace target. This repository should still prefer sidecar or resolver-based opt-in for authored `README.md` files because repository and package READMEs are expected to stay portable and free of inline front matter. Any future design should require the namespace name to be authored directly, preserve predictable package-doc behavior, and fail closed when the target namespace page does not exist.
 
 ### Pitfalls
 
 - Do not move package READMEs under package folders expecting them to merge into namespace pages.
 - Do not rely on the final folder name alone. A path needs a docs-owned prefix before the namespace directory.
 - Do not expect a README to create a namespace API page. It only merges into a namespace page produced by the C# harvester.
+- Do not include README self-links such as `./README.md` in a namespace intro. Link to surviving guide pages, generated namespace anchors, or package docs instead.
 - Do not use namespace README merging as a general redirect or alias mechanism. Use explicit metadata and link authoring for those behaviors.
 
 ## Usage

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -200,6 +200,60 @@ This keeps RazorDocs from inventing fake precision for pages that do not have on
 - Do not invent additional `SymbolSourceUrlTemplate` tokens. RazorDocs rejects unsupported placeholders such as `{commit}` or `{linen}` instead of rendering silently broken links.
 - Do not expect automatic edit links on namespace-synthetic API pages. Symbol links point to source browsing locations, while README-authored namespace intros keep the page-level edit link.
 
+## Namespace README Intros
+
+RazorDocs can merge an authored `README.md` into a generated namespace API page so teams can explain a namespace in prose without replacing the generated symbol list.
+
+### Authoring contract
+
+A README qualifies as a namespace intro only when all of these are true:
+
+- The C# API harvester generated a namespace page at `Namespaces/{Dotted.Namespace}`.
+- The authored file is named `README.md`.
+- The README is harvested as a root documentation node, not as a child fragment.
+- The README directory resolves to the same dotted namespace as the generated page.
+- The path has an explicit docs-owned prefix before the namespace directory, currently a `docs/` segment or a `Namespaces/` segment.
+
+Positive examples:
+
+| README path | Merged target |
+| --- | --- |
+| `docs/ForgeTrust.Runnable.Web/README.md` | `Namespaces/ForgeTrust.Runnable.Web` |
+| `Namespaces/ForgeTrust.Runnable.Web/README.md` | `Namespaces/ForgeTrust.Runnable.Web` |
+
+Negative examples:
+
+| README path | Behavior |
+| --- | --- |
+| `Web/ForgeTrust.Runnable.Web/README.md` | Stays a package README page. |
+| `src/ForgeTrust.Runnable.Web/README.md` | Stays a source-adjacent README page if harvested. |
+| `README.md` | Stays the repository-root docs landing source. |
+| `docs/Unknown.Namespace/README.md` | Stays a normal README page unless a generated `Namespaces/Unknown.Namespace` page exists. |
+
+### Merge behavior
+
+- The generated namespace page keeps its `Namespaces/{Dotted.Namespace}` route.
+- README HTML is inserted into the namespace page as the namespace intro.
+- The standalone README node is removed after a successful merge so readers do not see duplicate pages.
+- README metadata can override the namespace page metadata, but derived Markdown defaults are ignored when they would accidentally replace API-reference classification.
+- README-relative links are resolved from the README source path before the standalone README page is removed.
+- Contributor provenance points at the README source, while symbol-level source links still point at the generated API declarations.
+
+### Decision guidance
+
+Use a namespace README when the content is specifically about the namespace API surface: concepts, intended usage, lifecycle notes, or cross-type orientation for that namespace.
+
+Use a package README when the content is about package adoption: installation, package-level configuration, examples, compatibility, and links to broader guides. Package READMEs such as `Web/ForgeTrust.Runnable.Web/README.md` and `src/ForgeTrust.Runnable.Web/README.md` do not automatically become namespace intros, even when the folder name matches a namespace. That boundary is intentional so package docs do not disappear into API pages by folder-name coincidence.
+
+Future dual-use package and namespace docs should use an explicit opt-in contract instead of reopening implicit path matching. Reasonable shapes include a front matter flag that names the target namespace, a paired sidecar mapping a README to `Namespaces/{Dotted.Namespace}`, or a resolver extension point that receives an explicit namespace target. Any future design should require the namespace name to be authored directly, preserve predictable package-doc behavior, and fail closed when the target namespace page does not exist.
+
+### Pitfalls
+
+- Do not move package READMEs under package folders expecting them to merge into namespace pages.
+- Do not rely on the final folder name alone. A path needs a docs-owned prefix before the namespace directory.
+- Do not expect a README to create a namespace API page. It only merges into a namespace page produced by the C# harvester.
+- Do not use namespace README merging as a general redirect or alias mechanism. Use explicit metadata and link authoring for those behaviors.
+
 ## Usage
 
 Reference the package and add the module to your Runnable web application:

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
@@ -146,7 +146,7 @@
 
     @if (!Model.IsCSharpApiDoc)
     {
-        <h1 class="text-3xl font-bold tracking-tight text-white">@Model.Title</h1>
+        <h1 class="max-w-full break-words text-3xl font-bold leading-tight tracking-tight text-white">@Model.Title</h1>
         @if (Model.ShowSummary && !string.IsNullOrWhiteSpace(Model.Summary))
         {
             <p class="mt-3 max-w-3xl text-base text-slate-400">@Model.Summary</p>

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -87,6 +87,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - The primary RazorDocs Pages deployment now configures commit-pinned symbol source links, so generated C# API `Source` chips resolve to the exact file and line from the CI build revision.
 - Shared RazorDocs badges, metadata chips, provenance strips, and trust bars now live in the shared package stylesheet while `search.css` stays focused on search-specific UI.
 - RazorDocs search now keeps failure recovery markup out of the active search shell until the index actually fails to load, so successful searches no longer expose hidden failure copy to text extraction tools.
+- RazorDocs now documents the namespace README merge contract with positive and negative examples, while detail-page titles wrap on narrow screens so long package names do not clip on mobile.
 - RazorDocs now treats `Releases` as a first-class public section and suppresses breadcrumb links to generated parent routes that do not correspond to published docs pages, keeping static export warnings focused on actionable broken links.
 - RazorDocs wayfinding coverage now waits for docs content replacement before asserting sequence-link destinations, keeping the details-page proof path deterministic in CI.
 


### PR DESCRIPTION
## Summary

- Documents the namespace README merge contract for RazorDocs, including eligible paths, positive and negative examples, merge behavior, and pitfalls.
- Captures the future explicit opt-in direction for intentional package README plus namespace intro dual-use docs.
- Fixes a QA-found mobile visual issue where long docs detail titles clipped on narrow viewports.

Fixes #207.

## Validation

- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj`
- Diff-aware QA against `http://localhost:5189/docs/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md.html`
  - HTTP 200
  - no browser console errors
  - namespace README section rendered after contributor provenance and before usage
  - mobile title wraps instead of clipping

## Notes

QA report and screenshots were generated under `.gstack/qa-reports/`, which is ignored by the repository.
