### PR TITLE
feat(config): require config key presence

### DIFF
--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigKeyRequiredAttributeTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigKeyRequiredAttributeTests.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+namespace ForgeTrust.Runnable.Config.Tests;
+
+public class ConfigKeyRequiredAttributeTests
+{
+    [Fact]
+    public void AttributeUsage_TargetsInheritedSingleClassUsage()
+    {
+        var usage = typeof(ConfigKeyRequiredAttribute)
+            .GetCustomAttribute<AttributeUsageAttribute>();
+
+        Assert.NotNull(usage);
+        Assert.Equal(AttributeTargets.Class, usage.ValidOn);
+        Assert.False(usage.AllowMultiple);
+        Assert.True(usage.Inherited);
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
+++ b/Config/ForgeTrust.Runnable.Config.Tests/ConfigTests.cs
@@ -340,8 +340,51 @@ public class ConfigTests
     {
     }
 
+    [ConfigKeyRequired]
+    private sealed class RequiredStringConfig : Config<string>
+    {
+    }
+
+    [ConfigKeyRequired]
+    private sealed class DefaultRequiredStringConfig : Config<string>
+    {
+        public override string DefaultValue => "fallback";
+    }
+
+    [ConfigKeyRequired]
+    private sealed class RequiredIntConfig : ConfigStruct<int>
+    {
+    }
+
+    [ConfigKeyRequired]
+    private sealed class DefaultRequiredIntConfig : ConfigStruct<int>
+    {
+        public override int? DefaultValue => 42;
+    }
+
+    [ConfigKeyRequired]
+    private sealed class RequiredAnnotatedOptionsConfig : Config<AnnotatedOptions>
+    {
+    }
+
+    [ConfigKey("Base.Required", root: true)]
+    [ConfigKeyRequired]
+    private class BaseRequiredStringConfig : Config<string>
+    {
+    }
+
+    private sealed class DerivedRequiredStringConfig : BaseRequiredStringConfig
+    {
+    }
+
     [ConfigValueNotEmpty]
     private sealed class NotEmptyStringConfig : Config<string>
+    {
+    }
+
+    [ConfigKeyRequired]
+    [ConfigValueNotEmpty]
+    private sealed class RequiredNotEmptyStringConfig : Config<string>
     {
     }
 
@@ -998,6 +1041,163 @@ public class ConfigTests
     }
 
     [Fact]
+    public void Init_WithRequiredClassConfigAndMissingValue_ThrowsStructuredValidationException()
+    {
+        var config = new RequiredStringConfig();
+
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(config, null));
+
+        var failure = Assert.Single(exception.Failures);
+        Assert.Equal("App.Settings", failure.Key);
+        Assert.Equal(typeof(RequiredStringConfig), failure.ConfigType);
+        Assert.Equal(typeof(string), failure.ValueType);
+        Assert.Empty(failure.MemberNames);
+        Assert.Equal("A value is required for this configuration key.", failure.Message);
+        Assert.Contains("- <value>: A value is required for this configuration key.", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Production", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Struct_Init_WithRequiredConfigAndMissingValue_ThrowsStructuredValidationException()
+    {
+        var config = new RequiredIntConfig();
+
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            InitStruct(config, null));
+
+        var failure = Assert.Single(exception.Failures);
+        Assert.Equal("App.Settings", failure.Key);
+        Assert.Equal(typeof(RequiredIntConfig), failure.ConfigType);
+        Assert.Equal(typeof(int), failure.ValueType);
+        Assert.Empty(failure.MemberNames);
+        Assert.Equal("A value is required for this configuration key.", failure.Message);
+        Assert.Contains("- <value>: A value is required for this configuration key.", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Production", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithRequiredClassConfig_AcceptsProviderValue()
+    {
+        var config = new RequiredStringConfig();
+
+        Init(config, "token");
+
+        Assert.True(config.HasValue);
+        Assert.False(config.IsDefaultValue);
+        Assert.Equal("token", config.Value);
+    }
+
+    [Fact]
+    public void Struct_Init_WithRequiredConfig_AcceptsProviderValueIncludingZero()
+    {
+        var config = new RequiredIntConfig();
+
+        InitStruct(config, 0);
+
+        Assert.True(config.HasValue);
+        Assert.False(config.IsDefaultValue);
+        Assert.Equal(0, config.Value);
+    }
+
+    [Fact]
+    public void Init_WithRequiredClassDefaultValue_SatisfiesPresence()
+    {
+        var config = new DefaultRequiredStringConfig();
+
+        Init(config, null);
+
+        Assert.True(config.HasValue);
+        Assert.True(config.IsDefaultValue);
+        Assert.Equal("fallback", config.Value);
+    }
+
+    [Fact]
+    public void Struct_Init_WithRequiredDefaultValue_SatisfiesPresence()
+    {
+        var config = new DefaultRequiredIntConfig();
+
+        InitStruct(config, null);
+
+        Assert.True(config.HasValue);
+        Assert.True(config.IsDefaultValue);
+        Assert.Equal(42, config.Value);
+    }
+
+    [Fact]
+    public void Init_WithRequiredAndNotEmptyMissingValue_ReportsOnlyPresenceFailure()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new RequiredNotEmptyStringConfig(), null));
+
+        var failure = Assert.Single(exception.Failures);
+        Assert.Contains("required", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("empty", failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Init_WithRequiredAndNotEmptyEmptyValue_ReportsOnlyValueFailure()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new RequiredNotEmptyStringConfig(), string.Empty));
+
+        var failure = Assert.Single(exception.Failures);
+        Assert.Contains("must not be empty", failure.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("required", failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Init_WithInheritedRequiredAttribute_UsesDerivedConfigKeySemantics()
+    {
+        var config = new DerivedRequiredStringConfig();
+        var key = ConfigKeyAttribute.GetKeyPath(config.GetType());
+
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(config, null, key));
+
+        Assert.Equal($"{nameof(ConfigTests)}.{nameof(DerivedRequiredStringConfig)}", key);
+        Assert.Equal($"{nameof(ConfigTests)}.{nameof(DerivedRequiredStringConfig)}", exception.Key);
+        Assert.NotEqual("Base.Required", exception.Key);
+        Assert.Equal(typeof(DerivedRequiredStringConfig), exception.ConfigType);
+        Assert.Equal("A value is required for this configuration key.", Assert.Single(exception.Failures).Message);
+    }
+
+    [Fact]
+    public void Init_WithRequiredObjectConfigAndMissingValue_ThrowsPresenceFailure()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(new RequiredAnnotatedOptionsConfig(), null));
+
+        var failure = Assert.Single(exception.Failures);
+        Assert.Equal(typeof(RequiredAnnotatedOptionsConfig), failure.ConfigType);
+        Assert.Equal(typeof(AnnotatedOptions), failure.ValueType);
+        Assert.Empty(failure.MemberNames);
+        Assert.Equal("A value is required for this configuration key.", failure.Message);
+        Assert.Contains("- <object>: A value is required for this configuration key.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Init_WithRequiredObjectConfigAndInvalidValue_RunsDataAnnotations()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Init(
+                new RequiredAnnotatedOptionsConfig(),
+                new AnnotatedOptions
+                {
+                    Name = null,
+                    RetryCount = 0
+                }));
+
+        Assert.DoesNotContain(
+            exception.Failures,
+            failure => failure.Message.Contains("required for this configuration key", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            exception.Failures,
+            failure => failure.MemberNames.SequenceEqual(["Name"])
+                       && failure.Message.Contains("required", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Init_WithScalarClassDefaultValue_ValidatesDefault()
     {
         var config = new DefaultInvalidNotEmptyStringConfig();
@@ -1216,14 +1416,20 @@ public class ConfigTests
     private static void Init<T>(Config<T> config, T? value)
         where T : class
     {
+        Init(config, value, "App.Settings");
+    }
+
+    private static void Init<T>(Config<T> config, T? value, string key)
+        where T : class
+    {
         var configManager = A.Fake<IConfigManager>();
         var environmentProvider = A.Fake<IEnvironmentProvider>();
 
         A.CallTo(() => environmentProvider.Environment).Returns("Production");
-        A.CallTo(() => configManager.GetValue<T>("Production", "App.Settings"))
+        A.CallTo(() => configManager.GetValue<T>("Production", key))
             .Returns(value);
 
-        ((IConfig)config).Init(configManager, environmentProvider, "App.Settings");
+        ((IConfig)config).Init(configManager, environmentProvider, key);
     }
 
     private static void InitStruct<T>(ConfigStruct<T> config, T? value)

--- a/Config/ForgeTrust.Runnable.Config/Config.cs
+++ b/Config/ForgeTrust.Runnable.Config/Config.cs
@@ -12,6 +12,7 @@ namespace ForgeTrust.Runnable.Config;
 /// <see cref="ConfigurationValidationException"/>, so callers that activate config wrappers can catch
 /// that exception and surface its structured failures. Ensure defaults satisfy the same validation
 /// rules as configured values; an invalid default prevents initialization when no provider value exists.
+/// Apply <see cref="ConfigKeyRequiredAttribute"/> to require resolved provider/default presence.
 /// </summary>
 /// <typeparam name="T">The type of the configuration value.</typeparam>
 public class Config<T> : IConfig
@@ -51,7 +52,8 @@ public class Config<T> : IConfig
     /// <param name="environmentProvider">The environment provider used to choose the active environment.</param>
     /// <param name="key">The configuration key to resolve.</param>
     /// <exception cref="ConfigurationValidationException">
-    /// Thrown when the provider value or default value violates object DataAnnotations or scalar validation rules.
+    /// Thrown when the wrapper requires a value and no provider/default value resolves, or when the provider value
+    /// or default value violates object DataAnnotations or scalar validation rules.
     /// </exception>
     internal virtual void Init(
         IConfigManager configManager,
@@ -62,6 +64,11 @@ public class Config<T> : IConfig
         Value = rawValue ?? DefaultValue;
         IsDefaultValue = rawValue == null || Equals(Value, DefaultValue);
         HasValue = Value != null;
+        ConfigPresenceValidator.Validate(
+            key,
+            GetType(),
+            typeof(T),
+            HasValue);
         ConfigDataAnnotationsValidator.Validate(
             key,
             GetType(),

--- a/Config/ForgeTrust.Runnable.Config/ConfigKeyRequiredAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigKeyRequiredAttribute.cs
@@ -1,0 +1,24 @@
+namespace ForgeTrust.Runnable.Config;
+
+/// <summary>
+/// Requires a strongly typed configuration wrapper to resolve a value during initialization.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply this attribute to a concrete <see cref="Config{T}"/> or <see cref="ConfigStruct{T}"/>
+/// wrapper when startup should fail if provider/default resolution leaves the wrapper without a
+/// value. A <see cref="Config{T}.DefaultValue"/> or <see cref="ConfigStruct{T}.DefaultValue"/>
+/// satisfies the requirement because the requirement is resolved presence, not provider-source
+/// auditing.
+/// </para>
+/// <para>
+/// This attribute is intentionally separate from scalar value validation attributes such as
+/// <see cref="ConfigValueNotEmptyAttribute"/>. Use <see cref="ConfigKeyRequiredAttribute"/> when
+/// absence should fail, and use value validation when a resolved value must satisfy shape or range
+/// rules.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class ConfigKeyRequiredAttribute : Attribute
+{
+}

--- a/Config/ForgeTrust.Runnable.Config/ConfigPresenceValidator.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigPresenceValidator.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+
+namespace ForgeTrust.Runnable.Config;
+
+/// <summary>
+/// Validates required resolved presence for strongly typed configuration wrappers.
+/// </summary>
+internal static class ConfigPresenceValidator
+{
+    private const string RequiredPresenceMessage = "A value is required for this configuration key.";
+
+    /// <summary>
+    /// Throws <see cref="ConfigurationValidationException"/> when a wrapper marked with
+    /// <see cref="ConfigKeyRequiredAttribute"/> has no resolved provider or default value.
+    /// </summary>
+    /// <param name="key">The configuration key being initialized.</param>
+    /// <param name="configType">The concrete configuration wrapper type being initialized.</param>
+    /// <param name="valueType">The declared configuration value type.</param>
+    /// <param name="hasValue">Whether provider/default resolution produced a value.</param>
+    public static void Validate(
+        string key,
+        Type configType,
+        Type valueType,
+        bool hasValue)
+    {
+        if (hasValue || configType.GetCustomAttribute<ConfigKeyRequiredAttribute>(inherit: true) == null)
+        {
+            return;
+        }
+
+        var failure = new ConfigurationValidationFailure(
+            key,
+            configType,
+            valueType,
+            Array.Empty<string>(),
+            RequiredPresenceMessage);
+
+        throw new ConfigurationValidationException(key, configType, valueType, [failure]);
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config/ConfigStruct.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigStruct.cs
@@ -12,6 +12,7 @@ namespace ForgeTrust.Runnable.Config;
 /// <see cref="ConfigurationValidationException"/>, so callers that activate config wrappers can catch
 /// that exception and surface its structured failures. Ensure defaults satisfy the same validation
 /// rules as configured values; an invalid default prevents initialization when no provider value exists.
+/// Apply <see cref="ConfigKeyRequiredAttribute"/> to require resolved provider/default presence.
 /// </summary>
 /// <typeparam name="T">The struct type of the configuration value.</typeparam>
 public class ConfigStruct<T> : IConfig
@@ -45,7 +46,8 @@ public class ConfigStruct<T> : IConfig
     /// <param name="environmentProvider">The environment provider used to choose the active environment.</param>
     /// <param name="key">The configuration key to resolve.</param>
     /// <exception cref="ConfigurationValidationException">
-    /// Thrown when the provider value or default value violates object DataAnnotations or scalar validation rules.
+    /// Thrown when the wrapper requires a value and no provider/default value resolves, or when the provider value
+    /// or default value violates object DataAnnotations or scalar validation rules.
     /// </exception>
     void IConfig.Init(
         IConfigManager configManager,
@@ -56,6 +58,11 @@ public class ConfigStruct<T> : IConfig
         Value = rawValue ?? DefaultValue;
         IsDefaultValue = rawValue == null || Equals(Value, DefaultValue);
         HasValue = Value != null;
+        ConfigPresenceValidator.Validate(
+            key,
+            GetType(),
+            typeof(T),
+            HasValue);
         ConfigDataAnnotationsValidator.Validate(
             key,
             GetType(),

--- a/Config/ForgeTrust.Runnable.Config/IConfig.cs
+++ b/Config/ForgeTrust.Runnable.Config/IConfig.cs
@@ -9,8 +9,8 @@ public interface IConfig
 {
     /// <summary>
     /// Initializes the configuration object, resolving its provider or default value and failing fast
-    /// with <see cref="ConfigurationValidationException"/> when the resolved value violates
-    /// object DataAnnotations rules or scalar value validation rules.
+    /// with <see cref="ConfigurationValidationException"/> when required presence is not satisfied
+    /// or when the resolved value violates object DataAnnotations rules or scalar value validation rules.
     /// Exceptions thrown by scalar <see cref="Config{T}.ValidateValue"/> or
     /// <see cref="ConfigStruct{T}.ValidateValue"/> overrides are not wrapped, so callers that activate
     /// config wrappers during startup should let unexpected programming errors fail the startup path.
@@ -19,8 +19,8 @@ public interface IConfig
     /// <param name="environmentProvider">The environment provider.</param>
     /// <param name="key">The root configuration key for this object.</param>
     /// <exception cref="ConfigurationValidationException">
-    /// Thrown when the resolved provider value or default value violates object DataAnnotations or scalar
-    /// validation rules.
+    /// Thrown when the wrapper requires a value and no provider/default value resolves, or when the resolved
+    /// provider value or default value violates object DataAnnotations or scalar validation rules.
     /// </exception>
     /// <exception cref="Exception">
     /// Thrown when a concrete scalar validation override throws; override exceptions are not wrapped.

--- a/Config/ForgeTrust.Runnable.Config/README.md
+++ b/Config/ForgeTrust.Runnable.Config/README.md
@@ -14,6 +14,7 @@ This package provides the configuration layer for Runnable modules. It combines 
 - **`FileBasedConfigProvider`**: Loads configuration from files.
 - **`Config<T>` / `ConfigStruct<T>`**: Base types for strongly typed configuration values.
 - **`ConfigKeyAttribute`**: Associates a configuration type or property with a specific key.
+- **`ConfigKeyRequiredAttribute`**: Requires a config wrapper to resolve a provider or default value during startup.
 - **`ConfigValueNotEmptyAttribute`**: Validates that a resolved scalar `string` or `Guid` value is not empty.
 - **`ConfigValueRangeAttribute`**: Validates that a resolved scalar `int` or `double` value is within an inclusive range.
 - **`ConfigValueMinLengthAttribute`**: Validates that a resolved scalar `string` value meets a minimum length.
@@ -132,6 +133,48 @@ Configuration validation failed for key 'RetryConfig' (RetryConfig -> RetryOptio
 
 The exception also exposes structured failures through `Failures`. Each failure includes the config key, wrapper type, value type, member names, and validation message. Attempted values are not exposed because config values often include secrets.
 
+### Required Key Presence
+
+Config wrappers are optional by default. A missing provider value with no default leaves `HasValue` false and skips value validation. Use `[ConfigKeyRequired]` when the key itself must resolve a value during startup:
+
+```csharp
+using ForgeTrust.Runnable.Config;
+
+[ConfigKeyRequired]
+public sealed class ApiKeyConfig : Config<string>
+{
+}
+```
+
+Required presence runs after provider/default resolution. A provider value satisfies the requirement, and a `DefaultValue` also satisfies it because the requirement is resolved presence, not provider-source auditing:
+
+```csharp
+[ConfigKeyRequired]
+public sealed class RegionConfig : Config<string>
+{
+    public override string? DefaultValue => "us-east-1";
+}
+```
+
+When a required wrapper has no provider value and no default, Runnable throws `ConfigurationValidationException` through the same startup failure family used by object and scalar validation:
+
+```text
+Configuration validation failed for key 'ApiKeyConfig' (ApiKeyConfig -> String): 1 error(s).
+- <value>: A value is required for this configuration key.
+```
+
+Combine presence and value validation when both contracts matter:
+
+```csharp
+[ConfigKeyRequired]
+[ConfigValueNotEmpty]
+public sealed class ApiKeyConfig : Config<string>
+{
+}
+```
+
+In that example, a missing key reports the required-presence failure. A supplied empty string reports the `ConfigValueNotEmpty` value failure. The two attributes are intentionally separate so operators can distinguish "nothing resolved" from "a resolved value was invalid."
+
 ### Scalar Value Validation
 
 Scalar wrappers such as `Config<string>` and `ConfigStruct<int>` validate the resolved value from attributes placed on the wrapper class. This keeps simple configuration as a primitive while still giving startup-time validation:
@@ -183,7 +226,7 @@ public sealed class TenantSlugConfig : Config<string>
 }
 ```
 
-Scalar validation runs only for non-null resolved scalar values. `[ConfigValueNotEmpty]` rejects an empty value that was supplied by a provider or default, but it does not make a missing config value required. Use a default, application startup policy, or a dedicated presence check when the key itself must exist.
+Scalar validation runs only for non-null resolved scalar values. `[ConfigValueNotEmpty]` rejects an empty value that was supplied by a provider or default, but it does not make a missing config value required. Use `[ConfigKeyRequired]` when the key itself must exist.
 
 When both wrapper attributes and `ValidateValue` fail, attribute failures are reported first. Hook exceptions are not wrapped; they bubble to the caller so programming errors remain visible.
 
@@ -228,7 +271,9 @@ Runnable uses the Microsoft marker attributes as the public authoring contract, 
 ### Pitfalls
 
 - DataAnnotations attributes such as `[Range]` on the wrapper class are not scalar validation attributes. Use Runnable `ConfigValue*` attributes on scalar wrappers, or wrap related settings in an options object and use ordinary DataAnnotations on that object.
+- `[ConfigKeyRequired]` on a wrapper and `[Required]` on an options property solve different problems. The wrapper attribute requires a config key to resolve; the DataAnnotations attribute validates a member on an object value that already resolved.
 - Scalar validation validates values that exist after provider/default resolution. It is not a required-presence contract for missing keys.
+- Required key presence does not report which provider did or did not supply a value. It only reports that provider/default resolution ended without a value.
 - Built-in scalar attributes support only the value types documented above. Use `ValidateValue` for decimal, date/time, URI, domain-specific, or cross-cutting scalar rules.
 - DataAnnotations can short-circuit. For example, object-level `IValidatableObject` validation may not run when property validation already failed.
 - Recursive validation is opt-in. A nested object without `[ValidateObjectMembers]` and a collection without `[ValidateEnumeratedItems]` is not traversed.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -57,6 +57,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Strongly typed config wrappers now validate resolved object values with DataAnnotations during startup, including defaults, and report operator-friendly `ConfigurationValidationException` failures without echoing attempted values.
 - Nested config validation can now opt into Microsoft Options `[ValidateObjectMembers]` and `[ValidateEnumeratedItems]` markers while Runnable owns traversal, path formatting, and cycle protection.
 - Scalar config wrappers can now validate resolved primitive values directly with `ConfigValueNotEmpty`, `ConfigValueRange`, and `ConfigValueMinLength` attributes, while wrapper-specific scalar rules can override `ValidateValue`.
+- Config wrappers can now opt into required resolved presence with `ConfigKeyRequired`, so startup fails when no provider value and no default are available while defaults and supplied zero values still count as present.
 - The new `examples/config-validation` sample demonstrates an intentional startup validation failure for a scalar `ConfigStruct<int>` without printing the invalid configured value.
 - Environment variables can now patch individual members of object-valued config loaded from lower-priority providers, so `APP__SETTINGS__DATABASE__PORT` can override one nested value without replacing the rest of the JSON-backed options object.
 


### PR DESCRIPTION
Fixes #204

## Summary
- Add `ConfigKeyRequiredAttribute` for required resolved config presence on `Config<T>` and `ConfigStruct<T>` wrappers.
- Validate required presence after provider/default resolution and before existing object/scalar validation.
- Document required key presence in the config README, XML API docs, and unreleased notes.

## Verification
- `dotnet test Config/ForgeTrust.Runnable.Config.Tests/ForgeTrust.Runnable.Config.Tests.csproj` passed, 167/167.
- `./scripts/coverage-solution.sh` passed all 15 test projects.
- Solution line coverage: 96.38%, branch coverage: 93.71%.
- `ForgeTrust.Runnable.Config` coverage: 99.21% line, 97.44% branch, 100% method.
- /qa browser smoke on isolated RazorDocs host verified `/docs`, config README, and config API reference loaded with HTTP 200 and no console errors.

## QA
- Report: `.gstack/qa-reports/qa-report-localhost-5197-2026-05-05.md`
- QA found 0 issues and applied 0 fixes.