### PR TITLE
refactor(razordocs): share docs path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This changelog is the compact release ledger for Runnable. The monorepo ships in
 - Tailwind development watch mode now logs a warning, not a startup error, when the standalone CLI is unavailable and the app can continue serving existing CSS.
 - RazorDocs search now keeps failure recovery markup out of the active search shell until the index actually fails to load.
 - The RazorWire MVC sample counter button now has an accessible name while preserving the compact icon-only UI.
+- RazorDocs source-path, canonical-path, fragment, and docs-root-prefixed lookups now share one resolver across page details, landing curation, related-page links, and search fallback links.
 - RazorDocs landing curation now renders reader-intent `featured_page_groups` instead of one flat featured list.
 - The PackageIndex generator now has a successful `--help`/`-h` path with command and option guidance instead of a bare usage failure.
 - The conventional browser 404 page now favors user recovery, including documentation search for missing docs routes and a home link for other missing pages.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -1203,6 +1203,54 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDocDetailsAsync_ShouldResolveRelatedPagesWithCurrentDocsRootPrefixedCanonicalPaths()
+    {
+        var harvestedDocs = new List<DocNode>
+        {
+            new(
+                "Current",
+                "guides/current.md",
+                "<p>Current</p>",
+                Metadata: new DocMetadata
+                {
+                    RelatedPages = ["/docs/next/guides/related.md.html"]
+                }),
+            new(
+                "Related",
+                "guides/related.md",
+                "<p>Related</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "Follow the next preview step."
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        using var memo = new Memo(cache);
+        var aggregator = new DocAggregator(
+            [_harvesterFake],
+            new RazorDocsOptions
+            {
+                Routing = new RazorDocsRoutingOptions
+                {
+                    DocsRootPath = "/docs/next"
+                }
+            },
+            _envFake,
+            memo,
+            _sanitizerFake,
+            _loggerFake);
+
+        var details = await aggregator.GetDocDetailsAsync("guides/current.md");
+
+        var relatedPage = Assert.Single(details!.RelatedPages);
+        Assert.Equal("Related", relatedPage.Title);
+        Assert.Equal("/docs/next/guides/related.md.html", relatedPage.Href);
+        Assert.Equal("Follow the next preview step.", relatedPage.Summary);
+    }
+
+    [Fact]
     public async Task GetDocDetailsAsync_ShouldResolveRelatedPagesWithMissingMetadata()
     {
         var harvestedDocs = new List<DocNode>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -1171,6 +1171,38 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDocDetailsAsync_ShouldResolveRelatedPagesWithDocsRootPrefixedCanonicalPaths()
+    {
+        var harvestedDocs = new List<DocNode>
+        {
+            new(
+                "Current",
+                "guides/current.md",
+                "<p>Current</p>",
+                Metadata: new DocMetadata
+                {
+                    RelatedPages = ["/docs/guides/related.md.html"]
+                }),
+            new(
+                "Related",
+                "guides/related.md",
+                "<p>Related</p>",
+                Metadata: new DocMetadata
+                {
+                    Summary = "Follow the next step."
+                })
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        var details = await _aggregator.GetDocDetailsAsync("guides/current.md");
+
+        var relatedPage = Assert.Single(details!.RelatedPages);
+        Assert.Equal("Related", relatedPage.Title);
+        Assert.Equal("/docs/guides/related.md.html", relatedPage.Href);
+        Assert.Equal("Follow the next step.", relatedPage.Summary);
+    }
+
+    [Fact]
     public async Task GetDocDetailsAsync_ShouldResolveRelatedPagesWithMissingMetadata()
     {
         var harvestedDocs = new List<DocNode>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocPathResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocPathResolverTests.cs
@@ -1,0 +1,202 @@
+using ForgeTrust.Runnable.Web.RazorDocs.Models;
+using ForgeTrust.Runnable.Web.RazorDocs.Services;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
+
+public sealed class DocPathResolverTests
+{
+    [Fact]
+    public void Create_ShouldThrow_WhenDocsIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => DocPathResolver.Create(null!));
+    }
+
+    [Fact]
+    public void Resolve_ShouldThrow_WhenPathIsNull()
+    {
+        var resolver = DocPathResolver.Create([]);
+
+        Assert.Throws<ArgumentNullException>(() => resolver.Resolve(null!));
+    }
+
+    [Fact]
+    public void Resolve_ShouldMatchSourceAndCanonicalPaths_WithNormalizedSeparators()
+    {
+        var doc = Doc("Install", "guides/install.md", canonicalPath: "guides/install.md.html");
+        var resolver = DocPathResolver.Create([doc]);
+
+        var bySource = resolver.Resolve(" /guides\\install.md/ ");
+        var byCanonical = resolver.Resolve("\\guides\\install.md.html");
+
+        Assert.Same(doc, bySource);
+        Assert.Same(doc, byCanonical);
+    }
+
+    [Fact]
+    public void Resolve_ShouldPreserveExactFragmentMatches_AndFallbackToBasePage()
+    {
+        var fragment = Doc(
+            "Foo Type",
+            "Namespaces/Foo#Foo-Type",
+            content: string.Empty,
+            canonicalPath: "Namespaces/Foo.html#Foo-Type");
+        var basePage = Doc("Foo", "Namespaces/Foo", canonicalPath: "Namespaces/Foo.html");
+        var resolver = DocPathResolver.Create([fragment, basePage]);
+
+        var exactFragment = resolver.Resolve("Namespaces/Foo.html#Foo-Type");
+        var missingFragment = resolver.Resolve("Namespaces/Foo.html#Missing");
+        var sourceBase = resolver.Resolve("Namespaces/Foo");
+
+        Assert.Same(fragment, exactFragment);
+        Assert.Same(basePage, missingFragment);
+        Assert.Same(basePage, sourceBase);
+    }
+
+    [Fact]
+    public void Resolve_ShouldPreferNonEmptyCandidate_WhenOnlyFragmentPagesMatch()
+    {
+        var emptyFragment = Doc(
+            "Empty Fragment",
+            "guides/advanced.md#details",
+            content: "   ",
+            canonicalPath: "guides/advanced.md.html#details");
+        var richFragment = Doc(
+            "Rich Fragment",
+            "guides/advanced.md#setup",
+            canonicalPath: "guides/advanced.md.html#setup");
+        var resolver = DocPathResolver.Create([emptyFragment, richFragment]);
+
+        var resolved = resolver.Resolve("guides/advanced.md.html#missing-fragment");
+
+        Assert.Same(richFragment, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShouldPreferNonEmptyCandidate_WhenFallbackCandidateHasNoCanonicalPath()
+    {
+        var emptyFragment = Doc("Empty Fragment", "guides/advanced.md#details", content: "   ");
+        var richFragment = Doc("Rich Fragment", "guides/advanced.md#setup");
+        var resolver = DocPathResolver.Create([emptyFragment, richFragment]);
+
+        var resolved = resolver.Resolve("guides/advanced.md#missing-fragment");
+
+        Assert.Same(richFragment, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShouldStripConfiguredAndStableRouteRoots()
+    {
+        var doc = Doc("Composition", "guides/composition.md", canonicalPath: "guides/composition.md.html");
+        var resolver = DocPathResolver.Create([doc]);
+
+        var currentRootMatch = resolver.Resolve("/preview/docs/guides/composition.md.html", "/preview/docs", "/docs");
+        var stableRootMatch = resolver.Resolve("/docs/guides/composition.md.html", "/preview/docs", "/docs");
+
+        Assert.Same(doc, currentRootMatch);
+        Assert.Same(doc, stableRootMatch);
+    }
+
+    [Fact]
+    public void Resolve_ShouldPreferRouteRelativeMatch_BeforeRawPathMatch()
+    {
+        var routeRelative = Doc("Route Relative", "guide.html", canonicalPath: "guide.html");
+        var rawShadow = Doc("Raw Shadow", "docs/guide.html", canonicalPath: "docs/guide.html");
+        var resolver = DocPathResolver.Create([rawShadow, routeRelative]);
+
+        var resolved = resolver.Resolve("/docs/guide.html", "/docs");
+
+        Assert.Same(routeRelative, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShouldNotStripRouteRoots_FromSourceRelativePaths()
+    {
+        var sourceRelative = Doc("Source Relative", "docs/guide.html", canonicalPath: "docs/guide.html");
+        var routeRelative = Doc("Route Relative", "guide.html", canonicalPath: "guide.html");
+        var resolver = DocPathResolver.Create([routeRelative, sourceRelative]);
+
+        var resolved = resolver.Resolve("docs/guide.html", "/docs");
+
+        Assert.Same(sourceRelative, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShouldIgnoreBlankRouteRoots_AndContinueToUsableRoots()
+    {
+        var doc = Doc("Composition", "guides/composition.md", canonicalPath: "guides/composition.md.html");
+        var resolver = DocPathResolver.Create([doc]);
+
+        var resolved = resolver.Resolve("/docs/guides/composition.md.html", "   ", "/docs");
+
+        Assert.Same(doc, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShouldMatchEmptyRelativePath_WhenInputEqualsRouteRoot()
+    {
+        var doc = Doc("Index", string.Empty, canonicalPath: "index.html");
+        var resolver = DocPathResolver.Create([doc]);
+
+        var resolved = resolver.Resolve("/docs", "/docs");
+
+        Assert.Same(doc, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShouldReturnNull_WhenPathAndRouteRootsAreBlank()
+    {
+        var resolver = DocPathResolver.Create([]);
+
+        var resolved = resolver.Resolve("   ", "   ");
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShouldThrow_WhenRouteRootsArrayIsNull()
+    {
+        var resolver = DocPathResolver.Create([]);
+
+        Assert.Throws<ArgumentNullException>(() => resolver.Resolve("guides/intro.md", null!));
+    }
+
+    [Theory]
+    [InlineData("docs/service.cs.html#MethodId", "docs/service.cs.html#MethodId")]
+    [InlineData(" \\docs\\service.cs.html#MethodId/ ", "docs/service.cs.html#MethodId")]
+    public void NormalizeCanonicalPath_ShouldPreserveFragments(string path, string expected)
+    {
+        var normalized = DocPathResolver.NormalizeCanonicalPath(path);
+
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData("docs/service.cs.html#MethodId", "docs/service.cs.html")]
+    [InlineData(" \\docs\\service.cs.html#MethodId/ ", "docs/service.cs.html")]
+    public void NormalizeLookupPath_ShouldRemoveFragments(string path, string expected)
+    {
+        var normalized = DocPathResolver.NormalizeLookupPath(path);
+
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData("docs/service.cs.html#MethodId", "MethodId")]
+    [InlineData("docs/service.cs.html#", null)]
+    [InlineData("docs/service.cs.html", null)]
+    public void GetFragment_ShouldReturnOnlyNonEmptyFragments(string path, string? expected)
+    {
+        var fragment = DocPathResolver.GetFragment(path);
+
+        Assert.Equal(expected, fragment);
+    }
+
+    private static DocNode Doc(
+        string title,
+        string path,
+        string content = "<p>Content</p>",
+        string? canonicalPath = null)
+    {
+        return new DocNode(title, path, content, CanonicalPath: canonicalPath);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocPathResolverTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocPathResolverTests.cs
@@ -46,10 +46,16 @@ public sealed class DocPathResolverTests
         var exactFragment = resolver.Resolve("Namespaces/Foo.html#Foo-Type");
         var missingFragment = resolver.Resolve("Namespaces/Foo.html#Missing");
         var sourceBase = resolver.Resolve("Namespaces/Foo");
+        var rootedExactFragment = resolver.Resolve("/docs/Namespaces/Foo.html#Foo-Type", "/docs");
+        var rootedMissingFragment = resolver.Resolve("/docs/Namespaces/Foo.html#Missing", "/docs");
+        var rootedBase = resolver.Resolve("/docs/Namespaces/Foo", "/docs");
 
         Assert.Same(fragment, exactFragment);
         Assert.Same(basePage, missingFragment);
         Assert.Same(basePage, sourceBase);
+        Assert.Same(fragment, rootedExactFragment);
+        Assert.Same(basePage, rootedMissingFragment);
+        Assert.Same(basePage, rootedBase);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsViewsTests.cs
@@ -1459,6 +1459,26 @@ public class RazorDocsViewsTests
     }
 
     [Fact]
+    public async Task DetailsView_ShouldRenderNonCSharpTitleWithMobileWrappingClasses()
+    {
+        var doc = new DocNode(
+            "ForgeTrust.Runnable.Web.RazorDocs",
+            "Web/ForgeTrust.Runnable.Web.RazorDocs/README.md",
+            "<p>Guide body</p>");
+
+        var html = await RenderDetailsViewAsync(doc);
+        var document = new AngleSharp.Html.Parser.HtmlParser().ParseDocument(html);
+
+        var title = document.QuerySelector("h1");
+
+        Assert.NotNull(title);
+        Assert.Equal("ForgeTrust.Runnable.Web.RazorDocs", title!.TextContent.Trim());
+        Assert.Contains("max-w-full", title.ClassList);
+        Assert.Contains("break-words", title.ClassList);
+        Assert.Contains("leading-tight", title.ClassList);
+    }
+
+    [Fact]
     public async Task DetailsView_ShouldFallbackToPathBreadcrumbLabels_WhenMetadataTargetsCannotBeVerified()
     {
         var doc = new DocNode(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -667,8 +667,8 @@ public class DocsController : Controller
         IReadOnlyList<DocNode> docs,
         IReadOnlyList<DocSectionSnapshot> sections)
     {
-        var lookup = BuildDocLookup(docs);
         var doc = details.Document;
+        var pathResolver = DocPathResolver.Create(docs);
         var pathBaseAwareDoc = doc with
         {
             Content = DocContentLinkRewriter.PrefixPathBaseForDocsUrls(
@@ -731,9 +731,9 @@ public class DocsController : Controller
             PublicSectionLabel = currentSectionSnapshot?.Label,
             PublicSectionHref = currentSectionSnapshot is null ? null : _docsUrlBuilder.BuildSectionUrl(currentSectionSnapshot.Section),
             PublicSectionPurpose = currentSectionSnapshot is null ? null : DocPublicSectionCatalog.GetPurpose(currentSectionSnapshot.Section),
-            ContributorSourceUsesTurbo = ShouldUseDocsFrame(details.ContributorProvenance?.SourceHref, lookup),
-            ContributorEditUsesTurbo = ShouldUseDocsFrame(details.ContributorProvenance?.EditHref, lookup),
-            TrustMigrationUsesTurbo = ShouldUseDocsFrame(metadata?.Trust?.Migration?.Href, lookup),
+            ContributorSourceUsesTurbo = ShouldUseDocsFrame(details.ContributorProvenance?.SourceHref, pathResolver),
+            ContributorEditUsesTurbo = ShouldUseDocsFrame(details.ContributorProvenance?.EditHref, pathResolver),
+            TrustMigrationUsesTurbo = ShouldUseDocsFrame(metadata?.Trust?.Migration?.Href, pathResolver),
             IsSectionLanding = isSectionLanding,
             FeaturedPageGroups = featuredPageGroups,
             SectionGroups = sectionGroups
@@ -973,75 +973,6 @@ public class DocsController : Controller
         return false;
     }
 
-    private sealed class DocLookupBucket
-    {
-        public List<DocNode> OrderedDocs { get; } = [];
-
-        public HashSet<DocNode> SeenDocs { get; } = [];
-    }
-
-    private static Dictionary<string, DocLookupBucket> BuildDocLookup(IEnumerable<DocNode> docs)
-    {
-        var lookup = new Dictionary<string, DocLookupBucket>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var doc in docs)
-        {
-            AddLookupEntry(lookup, NormalizeLookupPath(doc.Path), doc);
-            AddLookupEntry(lookup, NormalizeLookupPath(GetSnapshotCanonicalPath(doc)), doc);
-        }
-
-        return lookup;
-    }
-
-    private static void AddLookupEntry(Dictionary<string, DocLookupBucket> lookup, string key, DocNode doc)
-    {
-        if (!lookup.TryGetValue(key, out var bucket))
-        {
-            bucket = new DocLookupBucket();
-            lookup[key] = bucket;
-        }
-
-        if (bucket.SeenDocs.Add(doc))
-        {
-            bucket.OrderedDocs.Add(doc);
-        }
-    }
-
-    private static DocNode? ResolveDocByPath(
-        string path,
-        IReadOnlyDictionary<string, DocLookupBucket> lookup)
-    {
-        var lookupPath = NormalizeLookupPath(path);
-        var lookupCanonicalPath = NormalizeCanonicalPath(path);
-
-        if (!lookup.TryGetValue(lookupPath, out var bucket) || bucket.OrderedDocs.Count == 0)
-        {
-            return null;
-        }
-
-        var candidates = bucket.OrderedDocs;
-
-        var exactCanonicalMatch = candidates.FirstOrDefault(
-            doc => string.Equals(
-                       NormalizeCanonicalPath(GetSnapshotCanonicalPath(doc)),
-                       lookupCanonicalPath,
-                       StringComparison.OrdinalIgnoreCase)
-                   || string.Equals(
-                       NormalizeCanonicalPath(doc.Path),
-                       lookupCanonicalPath,
-                       StringComparison.OrdinalIgnoreCase));
-        if (exactCanonicalMatch is not null)
-        {
-            return exactCanonicalMatch;
-        }
-
-        return candidates
-            .OrderBy(doc => string.IsNullOrWhiteSpace(GetFragment(GetSnapshotCanonicalPath(doc))) ? 0 : 1)
-            .ThenBy(doc => string.IsNullOrWhiteSpace(doc.Content) ? 1 : 0)
-            .ThenBy(doc => doc.Path, StringComparer.OrdinalIgnoreCase)
-            .FirstOrDefault();
-    }
-
     private SearchPageViewModel BuildSearchPageViewModel(IReadOnlyList<DocNode> docs)
     {
         return new SearchPageViewModel(
@@ -1093,12 +1024,12 @@ public class DocsController : Controller
 
     private IReadOnlyList<SearchPageFallbackLink> BuildSearchFallbackLinks(IReadOnlyList<DocNode> docs)
     {
-        var lookup = BuildDocLookup(docs);
+        var pathResolver = DocPathResolver.Create(docs);
         var links = new List<SearchPageFallbackLink>();
 
         TryAddFallbackLink(
             links,
-            lookup,
+            pathResolver,
             SelectFallbackDoc(
                 docs,
                 doc => HasPageType(doc, "guide", "concept", "tutorial", "troubleshooting")
@@ -1108,7 +1039,7 @@ public class DocsController : Controller
 
         TryAddFallbackLink(
             links,
-            lookup,
+            pathResolver,
             SelectFallbackDoc(
                 docs,
                 doc => HasPageType(doc, "example")
@@ -1118,7 +1049,7 @@ public class DocsController : Controller
 
         TryAddFallbackLink(
             links,
-            lookup,
+            pathResolver,
             SelectFallbackDoc(
                 docs,
                 doc => HasPageType(doc, "api-reference", "api")
@@ -1133,7 +1064,7 @@ public class DocsController : Controller
                 doc => string.Equals(doc.Path, "Namespaces", StringComparison.OrdinalIgnoreCase));
             TryAddFallbackLink(
                 links,
-                lookup,
+                pathResolver,
                 namespacesRoot,
                 "Browse namespaces",
                 "Use the namespace index when you need the reference map.");
@@ -1154,7 +1085,7 @@ public class DocsController : Controller
 
     private void TryAddFallbackLink(
         ICollection<SearchPageFallbackLink> links,
-        IReadOnlyDictionary<string, DocLookupBucket> lookup,
+        DocPathResolver pathResolver,
         DocNode? doc,
         string title,
         string description)
@@ -1175,10 +1106,10 @@ public class DocsController : Controller
                 title,
                 href,
                 description,
-                UsesDocsFrame: ShouldUseDocsFrame(href, lookup)));
+                UsesDocsFrame: ShouldUseDocsFrame(href, pathResolver)));
     }
 
-    private bool ShouldUseDocsFrame(string? href, IReadOnlyDictionary<string, DocLookupBucket> lookup)
+    private bool ShouldUseDocsFrame(string? href, DocPathResolver pathResolver)
     {
         if (string.IsNullOrWhiteSpace(href))
         {
@@ -1203,7 +1134,7 @@ public class DocsController : Controller
             return false;
         }
 
-        return ResolveDocByPath(hrefPath.TrimStart('/'), lookup) is not null;
+        return pathResolver.Resolve(hrefPath.TrimStart('/')) is not null;
     }
 
     private static DocNode? SelectFallbackDoc(
@@ -1245,39 +1176,11 @@ public class DocsController : Controller
         };
     }
 
-    private static string NormalizeLookupPath(string path)
-    {
-        var sanitized = path.Trim().Replace('\\', '/').Trim('/');
-        var hashIndex = sanitized.IndexOf('#');
-        if (hashIndex >= 0)
-        {
-            sanitized = sanitized[..hashIndex];
-        }
-
-        return sanitized;
-    }
-
-    private static string NormalizeCanonicalPath(string path)
-    {
-        return path.Trim().Replace('\\', '/').Trim('/');
-    }
     private static string GetSnapshotCanonicalPath(DocNode doc)
     {
         return doc.CanonicalPath
                ?? throw new InvalidOperationException(
                    $"DocsController requires snapshot canonical paths. Doc '{doc.Path}' was missing CanonicalPath.");
-    }
-
-    private static string? GetFragment(string path)
-    {
-        var canonical = NormalizeCanonicalPath(path);
-        var hashIndex = canonical.IndexOf('#');
-        if (hashIndex < 0 || hashIndex == canonical.Length - 1)
-        {
-            return null;
-        }
-
-        return canonical[(hashIndex + 1)..];
     }
 
     private static string ExtractHrefPath(string href)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -346,6 +346,62 @@ This keeps RazorDocs from inventing fake precision for pages that do not have on
 - Do not invent additional `SymbolSourceUrlTemplate` tokens. RazorDocs rejects unsupported placeholders such as `{commit}` or `{linen}` instead of rendering silently broken links.
 - Do not expect automatic edit links on namespace-synthetic API pages. Symbol links point to source browsing locations, while README-authored namespace intros keep the page-level edit link.
 
+## Namespace README Intros
+
+RazorDocs can merge an authored `README.md` into a generated namespace API page so teams can explain a namespace in prose without replacing the generated symbol list.
+
+### Authoring contract
+
+A README qualifies as a namespace intro only when all of these are true:
+
+- The C# API harvester generated a namespace page at `Namespaces/{Dotted.Namespace}`.
+- The authored file is named `README.md`.
+- The README is harvested as a root documentation node, not as a child fragment.
+- The README directory resolves to the same dotted namespace as the generated page.
+- The path has an explicit docs-owned prefix before the namespace directory, currently a `docs/` segment or a `Namespaces/` segment.
+
+Positive examples:
+
+| README path | Merged target |
+| --- | --- |
+| `docs/ForgeTrust.Runnable.Web/README.md` | `Namespaces/ForgeTrust.Runnable.Web` |
+| `Namespaces/ForgeTrust.Runnable.Web/README.md` | `Namespaces/ForgeTrust.Runnable.Web` |
+
+Negative examples:
+
+| README path | Behavior |
+| --- | --- |
+| `Web/ForgeTrust.Runnable.Web/README.md` | Stays a package README page. |
+| `src/ForgeTrust.Runnable.Web/README.md` | Stays a source-adjacent README page if harvested. |
+| `README.md` | Stays the repository-root docs landing source. |
+| `docs/Unknown.Namespace/README.md` | Stays a normal README page unless a generated `Namespaces/Unknown.Namespace` page exists. |
+
+### Merge behavior
+
+- The generated namespace page keeps its `Namespaces/{Dotted.Namespace}` route.
+- README HTML is inserted into the namespace page as the namespace intro.
+- The standalone README node is removed after a successful merge so readers do not see duplicate pages.
+- README metadata can override the namespace page metadata, but derived Markdown defaults are ignored when they would accidentally replace API-reference classification.
+- README-relative links are resolved from the README source path before the standalone README page is removed.
+- Links that target the removed README page itself are not rewritten to a published page. Avoid self-links such as `./README.md` inside namespace intros because the standalone README route disappears after merge.
+- Contributor provenance points at the README source, while symbol-level source links still point at the generated API declarations.
+
+### Decision guidance
+
+Use a namespace README when the content is specifically about the namespace API surface: concepts, intended usage, lifecycle notes, or cross-type orientation for that namespace.
+
+Use a package README when the content is about package adoption: installation, package-level configuration, examples, compatibility, and links to broader guides. Package READMEs such as `Web/ForgeTrust.Runnable.Web/README.md` and `src/ForgeTrust.Runnable.Web/README.md` do not automatically become namespace intros, even when the folder name matches a namespace. That boundary is intentional so package docs do not disappear into API pages by folder-name coincidence.
+
+Future dual-use package and namespace docs should use an explicit opt-in contract instead of reopening implicit path matching. At the product-contract level, a future design could use a front matter flag that names the target namespace, a paired sidecar mapping a README to `Namespaces/{Dotted.Namespace}`, or a resolver extension point that receives an explicit namespace target. This repository should still prefer sidecar or resolver-based opt-in for authored `README.md` files because repository and package READMEs are expected to stay portable and free of inline front matter. Any future design should require the namespace name to be authored directly, preserve predictable package-doc behavior, and fail closed when the target namespace page does not exist.
+
+### Pitfalls
+
+- Do not move package READMEs under package folders expecting them to merge into namespace pages.
+- Do not rely on the final folder name alone. A path needs a docs-owned prefix before the namespace directory.
+- Do not expect a README to create a namespace API page. It only merges into a namespace page produced by the C# harvester.
+- Do not include README self-links such as `./README.md` in a namespace intro. Link to surviving guide pages, generated namespace anchors, or package docs instead.
+- Do not use namespace README merging as a general redirect or alias mechanism. Use explicit metadata and link authoring for those behaviors.
+
 ## Usage
 
 Reference the package and add the module to your Runnable web application:
@@ -482,7 +538,7 @@ featured_page_groups:
 - `order` is optional on groups and pages. Lower values sort first, and ties preserve authored order.
 - `pages` must contain the featured destinations for the group. Empty page lists are skipped.
 - `question` is the reader-facing label shown on a row. If omitted, RazorDocs falls back to the destination page title.
-- `path` accepts either the source path or canonical docs path for the destination page. RazorDocs normalizes forward-slash and backslash separators during resolution.
+- `path` accepts either the source path or canonical docs path for the destination page. RazorDocs normalizes forward-slash and backslash separators during resolution, and the same resolver used by page details handles configured docs-root prefixes such as `/docs` or a custom live docs root.
 - `supporting_copy` is optional landing-only text. If omitted, RazorDocs falls back to the destination page summary.
 
 Author three to five groups for a broad landing page, and one to three pages per group. Prefer plain reader intents such as `understand`, `choose-package`, `see-it-working`, `release-risk`, and `api-reference`. Use custom intents when your product has domain-specific decisions that those defaults do not capture.
@@ -514,6 +570,7 @@ Diagnostics include the source file, field path when available, problem, cause, 
 - Do not create both `.yml` and `.yaml` sidecars for the same Markdown file. RazorDocs treats that as an authoring error and ignores both.
 - Do not use a sidecar as a second secret metadata system. It supports the same `DocMetadata` schema as inline front matter, and it is best reserved for files whose Markdown needs to stay portable on other surfaces.
 - Do not put `path` or `question` directly under a group. Page fields belong under `pages`.
+- Prefer source-relative paths for authored curation when the docs may be exported or mounted under more than one route. Canonical `/docs/...html` paths are accepted for parity with browser links, but source paths stay easier to review and move with the file.
 - README portability matters most at the repository and package level. In this repo, authored `README.md` files should stay free of inline front matter so GitHub renders them cleanly.
 
 ## Metadata-Driven Wayfinding

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -538,7 +538,7 @@ featured_page_groups:
 - `order` is optional on groups and pages. Lower values sort first, and ties preserve authored order.
 - `pages` must contain the featured destinations for the group. Empty page lists are skipped.
 - `question` is the reader-facing label shown on a row. If omitted, RazorDocs falls back to the destination page title.
-- `path` accepts either the source path or canonical docs path for the destination page. RazorDocs normalizes forward-slash and backslash separators during resolution, and the same resolver used by page details handles configured docs-root prefixes such as `/docs` or a custom live docs root.
+- `path` accepts either the source path or canonical docs path for the destination page, including an exact `#fragment` suffix when the card should land on a specific section. RazorDocs normalizes forward-slash and backslash separators during resolution while preserving fragment identifiers, and the same resolver used by page details handles configured docs-root prefixes such as `/docs` or a custom live docs root.
 - `supporting_copy` is optional landing-only text. If omitted, RazorDocs falls back to the destination page summary.
 
 Author three to five groups for a broad landing page, and one to three pages per group. Prefer plain reader intents such as `understand`, `choose-package`, `see-it-working`, `release-risk`, and `api-reference`. Use custom intents when your product has domain-specific decisions that those defaults do not capture.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -136,17 +136,10 @@ public class DocAggregator
 
     private sealed record CachedDocsSnapshot(
         Dictionary<string, DocNode> DocsByPath,
-        Dictionary<string, DocLookupBucket> Lookup,
+        DocPathResolver PathResolver,
         IReadOnlyList<DocSectionSnapshot> PublicSections,
         DocsSearchIndexPayload SearchIndexPayload,
         Dictionary<string, DocContributorProvenanceViewModel> ContributorProvenanceByPath);
-
-    private sealed class DocLookupBucket
-    {
-        public List<DocNode> OrderedDocs { get; } = [];
-
-        public HashSet<DocNode> SeenDocs { get; } = [];
-    }
 
     /// <summary>
     /// Initializes a new instance of <see cref="DocAggregator"/> with the provided dependencies and determines the repository root.
@@ -363,17 +356,22 @@ public class DocAggregator
     }
 
     /// <summary>
-    /// Retrieves a specific documentation node for the specified repository path.
+    /// Retrieves a documentation node for a source path or canonical docs path.
     /// </summary>
-    /// <param name="path">The documentation path to look up.</param>
-    /// <param name="cancellationToken">An optional token to observe for cancellation requests.</param>
-    /// <returns>The <see cref="DocNode"/> if found, or <c>null</c> if no node exists for the given path.</returns>
+    /// <remarks>
+    /// The lookup awaits the cached docs snapshot, then delegates to the snapshot's <see cref="DocPathResolver"/> so
+    /// legacy source paths, generated canonical <c>.html</c> paths, fragments, separators, and casing follow the same
+    /// matching rules used by details pages and curated links.
+    /// </remarks>
+    /// <param name="path">The source or canonical documentation path to look up.</param>
+    /// <param name="cancellationToken">An optional token to observe while waiting for the cached snapshot.</param>
+    /// <returns>The matching <see cref="DocNode"/>, or <c>null</c> if no node exists for the given path.</returns>
     public async Task<DocNode?> GetDocByPathAsync(string path, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(path);
 
         var snapshot = await GetCachedDocsSnapshotAsync().WaitAsync(cancellationToken);
-        return ResolveDocByPath(path, snapshot.Lookup, snapshot.DocsByPath);
+        return snapshot.PathResolver.Resolve(path);
     }
 
     /// <summary>
@@ -390,7 +388,7 @@ public class DocAggregator
         ArgumentNullException.ThrowIfNull(path);
 
         var snapshot = await GetCachedDocsSnapshotAsync().WaitAsync(cancellationToken);
-        var doc = ResolveDocByPath(path, snapshot.Lookup, snapshot.DocsByPath);
+        var doc = snapshot.PathResolver.Resolve(path);
         if (doc is null)
         {
             return null;
@@ -401,7 +399,7 @@ public class DocAggregator
             .ToList();
         var previousPage = ResolveSequenceNeighbor(doc, orderedDocs, direction: -1);
         var nextPage = ResolveSequenceNeighbor(doc, orderedDocs, direction: 1);
-        var relatedPages = ResolveRelatedPages(doc, orderedDocs, snapshot.Lookup, snapshot.DocsByPath, previousPage, nextPage);
+        var relatedPages = ResolveRelatedPages(doc, orderedDocs, snapshot.PathResolver, previousPage, nextPage);
         snapshot.ContributorProvenanceByPath.TryGetValue(doc.Path, out var contributorProvenance);
 
         return new DocDetailsViewModel
@@ -605,7 +603,7 @@ public class DocAggregator
                                return first;
                            })
                            .ToDictionary(n => n.Path, n => n);
-                       var lookup = BuildDocLookup(docsByPath.Values);
+                       var pathResolver = DocPathResolver.Create(docsByPath.Values);
 
                        var publicSections = BuildPublicSections(docsByPath.Values, logger);
                        var contributorProvenanceByPath = await BuildContributorProvenanceByPathAsync(
@@ -623,7 +621,7 @@ public class DocAggregator
 
                        return new CachedDocsSnapshot(
                            docsByPath,
-                           lookup,
+                           pathResolver,
                            publicSections,
                            searchIndexPayload,
                            contributorProvenanceByPath);
@@ -1397,73 +1395,6 @@ public class DocAggregator
         return text[..boundary].TrimEnd() + "...";
     }
 
-    private static Dictionary<string, DocLookupBucket> BuildDocLookup(IEnumerable<DocNode> docs)
-    {
-        var lookup = new Dictionary<string, DocLookupBucket>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var doc in docs)
-        {
-            AddLookupEntry(lookup, NormalizeLookupPath(doc.Path), doc);
-            AddLookupEntry(lookup, NormalizeLookupPath(GetSnapshotCanonicalPath(doc)), doc);
-        }
-
-        return lookup;
-    }
-
-    private static void AddLookupEntry(Dictionary<string, DocLookupBucket> lookup, string key, DocNode doc)
-    {
-        if (!lookup.TryGetValue(key, out var bucket))
-        {
-            bucket = new DocLookupBucket();
-            lookup[key] = bucket;
-        }
-
-        if (bucket.SeenDocs.Add(doc))
-        {
-            bucket.OrderedDocs.Add(doc);
-        }
-    }
-
-    private static DocNode? ResolveDocByPath(
-        string path,
-        IReadOnlyDictionary<string, DocLookupBucket> lookup,
-        IReadOnlyDictionary<string, DocNode> docsByPath)
-    {
-        var lookupPath = NormalizeLookupPath(path);
-        var lookupCanonicalPath = NormalizeCanonicalPath(path);
-
-        if (!lookup.TryGetValue(lookupPath, out var bucket) || bucket.OrderedDocs.Count == 0)
-        {
-            return null;
-        }
-
-        var candidates = bucket.OrderedDocs;
-        var exactCanonicalMatch = candidates.FirstOrDefault(
-            doc => string.Equals(
-                       NormalizeCanonicalPath(GetSnapshotCanonicalPath(doc)),
-                       lookupCanonicalPath,
-                       StringComparison.OrdinalIgnoreCase)
-                   || string.Equals(
-                       NormalizeCanonicalPath(doc.Path),
-                       lookupCanonicalPath,
-                       StringComparison.OrdinalIgnoreCase));
-        if (exactCanonicalMatch is not null)
-        {
-            return exactCanonicalMatch;
-        }
-
-        if (docsByPath.TryGetValue(lookupPath, out var directMatch))
-        {
-            return directMatch;
-        }
-
-        return candidates
-            .OrderBy(doc => string.IsNullOrWhiteSpace(GetFragment(GetSnapshotCanonicalPath(doc))) ? 0 : 1)
-            .ThenBy(doc => string.IsNullOrWhiteSpace(doc.Content) ? 1 : 0)
-            .ThenBy(doc => doc.Path, StringComparer.OrdinalIgnoreCase)
-            .FirstOrDefault();
-    }
-
     private DocPageLinkViewModel? ResolveSequenceNeighbor(
         DocNode currentDoc,
         IReadOnlyList<DocNode> docs,
@@ -1550,8 +1481,7 @@ public class DocAggregator
     private IReadOnlyList<DocPageLinkViewModel> ResolveRelatedPages(
         DocNode currentDoc,
         IReadOnlyList<DocNode> docs,
-        IReadOnlyDictionary<string, DocLookupBucket> lookup,
-        IReadOnlyDictionary<string, DocNode> docsByPath,
+        DocPathResolver pathResolver,
         DocPageLinkViewModel? previousPage,
         DocPageLinkViewModel? nextPage)
     {
@@ -1584,7 +1514,10 @@ public class DocAggregator
                 continue;
             }
 
-            var relatedDoc = ResolveDocByPath(normalizedEntry, lookup, docsByPath)
+            var relatedDoc = pathResolver.Resolve(
+                                 normalizedEntry,
+                                 _docsUrlBuilder.CurrentDocsRootPath,
+                                 DocsUrlBuilder.DocsEntryPath)
                              ?? ResolveDocByTitle(normalizedEntry, docs);
             if (relatedDoc is null || relatedDoc.Metadata?.HideFromPublicNav == true)
             {
@@ -1975,24 +1908,7 @@ public class DocAggregator
     /// <returns>The normalized lookup path.</returns>
     private static string NormalizeLookupPath(string path)
     {
-        var sanitized = path.Trim().Replace('\\', '/').Trim('/');
-        var hashIndex = sanitized.IndexOf('#');
-        if (hashIndex >= 0)
-        {
-            sanitized = sanitized[..hashIndex];
-        }
-
-        return sanitized;
-    }
-
-    /// <summary>
-    /// Normalizes a documentation path for canonicalization by trimming slashes and normalizing separators.
-    /// </summary>
-    /// <param name="path">The path to normalize.</param>
-    /// <returns>The normalized canonical path.</returns>
-    private static string NormalizeCanonicalPath(string path)
-    {
-        return path.Trim().Replace('\\', '/').Trim('/');
+        return DocPathResolver.NormalizeLookupPath(path);
     }
 
     private static string GetSnapshotCanonicalPath(DocNode doc) => doc.CanonicalPath!;
@@ -2004,14 +1920,7 @@ public class DocAggregator
     /// <returns>The fragment string, or <c>null</c> if no fragment is present.</returns>
     private static string? GetFragment(string path)
     {
-        var canonical = NormalizeCanonicalPath(path);
-        var hashIndex = canonical.IndexOf('#');
-        if (hashIndex < 0 || hashIndex == canonical.Length - 1)
-        {
-            return null;
-        }
-
-        return canonical[(hashIndex + 1)..];
+        return DocPathResolver.GetFragment(path);
     }
 
 }

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocFeaturedPageResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocFeaturedPageResolver.cs
@@ -76,7 +76,7 @@ public sealed class DocFeaturedPageResolver
             return [];
         }
 
-        var lookup = BuildDocLookup(docs);
+        var pathResolver = DocPathResolver.Create(docs);
         var resolvedGroups = new List<DocLandingFeaturedPageGroupViewModel>();
         var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -133,7 +133,7 @@ public sealed class DocFeaturedPageResolver
                          .ThenBy(item => item.Index))
             {
                 var fieldPath = definition.SourceFieldPath ?? $"{groupPath}.pages[{pageIndex}]";
-                var resolvedPage = ResolvePage(landingDoc, definition, fieldPath, lookup, seenPaths);
+                var resolvedPage = ResolvePage(landingDoc, definition, fieldPath, pathResolver, seenPaths);
                 if (resolvedPage is not null)
                 {
                     resolvedPages.Add(resolvedPage);
@@ -171,7 +171,7 @@ public sealed class DocFeaturedPageResolver
         DocNode landingDoc,
         DocFeaturedPageDefinition definition,
         string fieldPath,
-        IReadOnlyDictionary<string, DocLookupBucket> lookup,
+        DocPathResolver pathResolver,
         HashSet<string> seenPaths)
     {
         if (string.IsNullOrWhiteSpace(definition.Path))
@@ -183,7 +183,10 @@ public sealed class DocFeaturedPageResolver
             return null;
         }
 
-        var destination = ResolveDocByPath(definition.Path!, lookup);
+        var destination = pathResolver.Resolve(
+            definition.Path!,
+            _docsUrlBuilder.CurrentDocsRootPath,
+            DocsUrlBuilder.DocsEntryPath);
         if (destination is null)
         {
             _logger.LogWarning(
@@ -231,180 +234,11 @@ public sealed class DocFeaturedPageResolver
         };
     }
 
-    private sealed class DocLookupBucket
-    {
-        public List<DocNode> OrderedDocs { get; } = [];
-
-        public HashSet<DocNode> SeenDocs { get; } = new(ReferenceEqualityComparer.Instance);
-    }
-
-    private static Dictionary<string, DocLookupBucket> BuildDocLookup(IEnumerable<DocNode> docs)
-    {
-        var lookup = new Dictionary<string, DocLookupBucket>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var doc in docs)
-        {
-            AddLookupEntry(lookup, NormalizeLookupPath(doc.Path), doc);
-            if (!string.IsNullOrWhiteSpace(doc.CanonicalPath))
-            {
-                AddLookupEntry(lookup, NormalizeLookupPath(doc.CanonicalPath), doc);
-            }
-        }
-
-        return lookup;
-    }
-
-    private static void AddLookupEntry(Dictionary<string, DocLookupBucket> lookup, string key, DocNode doc)
-    {
-        if (!lookup.TryGetValue(key, out var bucket))
-        {
-            bucket = new DocLookupBucket();
-            lookup[key] = bucket;
-        }
-
-        if (bucket.SeenDocs.Add(doc))
-        {
-            bucket.OrderedDocs.Add(doc);
-        }
-    }
-
-    private DocNode? ResolveDocByPath(
-        string path,
-        IReadOnlyDictionary<string, DocLookupBucket> lookup)
-    {
-        var resolved = ResolveDocByNormalizedPath(path, lookup);
-        if (resolved is not null)
-        {
-            return resolved;
-        }
-
-        foreach (var routeRelativePath in GetRouteRelativePaths(path))
-        {
-            resolved = ResolveDocByNormalizedPath(routeRelativePath, lookup);
-            if (resolved is not null)
-            {
-                return resolved;
-            }
-        }
-
-        return null;
-    }
-
-    private static DocNode? ResolveDocByNormalizedPath(
-        string path,
-        IReadOnlyDictionary<string, DocLookupBucket> lookup)
-    {
-        var lookupPath = NormalizeLookupPath(path);
-        var lookupCanonicalPath = NormalizeCanonicalPath(path);
-
-        if (!lookup.TryGetValue(lookupPath, out var bucket) || bucket.OrderedDocs.Count == 0)
-        {
-            return null;
-        }
-
-        var candidates = bucket.OrderedDocs;
-        var exactCanonicalMatch = candidates.FirstOrDefault(
-            doc => (!string.IsNullOrWhiteSpace(doc.CanonicalPath)
-                    && string.Equals(
-                        NormalizeCanonicalPath(doc.CanonicalPath),
-                        lookupCanonicalPath,
-                        StringComparison.OrdinalIgnoreCase))
-                   || string.Equals(
-                       NormalizeCanonicalPath(doc.Path),
-                       lookupCanonicalPath,
-                       StringComparison.OrdinalIgnoreCase));
-        if (exactCanonicalMatch is not null)
-        {
-            return exactCanonicalMatch;
-        }
-
-        return candidates
-            .OrderBy(doc => string.IsNullOrWhiteSpace(GetFragment(doc.CanonicalPath ?? doc.Path)) ? 0 : 1)
-            .ThenBy(doc => string.IsNullOrWhiteSpace(doc.Content) ? 1 : 0)
-            .ThenBy(doc => doc.Path, StringComparer.OrdinalIgnoreCase)
-            .FirstOrDefault();
-    }
-
-    private IEnumerable<string> GetRouteRelativePaths(string path)
-    {
-        if (TryStripRouteRoot(path, _docsUrlBuilder.CurrentDocsRootPath, out var currentRootRelativePath))
-        {
-            yield return currentRootRelativePath;
-        }
-
-        if (TryStripRouteRoot(path, DocsUrlBuilder.DocsEntryPath, out var stableRootRelativePath)
-            && !string.Equals(currentRootRelativePath, stableRootRelativePath, StringComparison.OrdinalIgnoreCase))
-        {
-            yield return stableRootRelativePath;
-        }
-    }
-
-    private static bool TryStripRouteRoot(string path, string routeRootPath, out string routeRelativePath)
-    {
-        routeRelativePath = path;
-
-        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(routeRootPath))
-        {
-            return false;
-        }
-
-        var normalizedPath = path.Trim().Replace('\\', '/').TrimStart('/');
-        var normalizedRouteRoot = routeRootPath.Trim().Replace('\\', '/').Trim('/');
-        if (normalizedRouteRoot.Length == 0)
-        {
-            return false;
-        }
-
-        if (string.Equals(normalizedPath, normalizedRouteRoot, StringComparison.OrdinalIgnoreCase))
-        {
-            routeRelativePath = string.Empty;
-            return true;
-        }
-
-        var routePrefix = normalizedRouteRoot + "/";
-        if (normalizedPath.StartsWith(routePrefix, StringComparison.OrdinalIgnoreCase))
-        {
-            routeRelativePath = normalizedPath[routePrefix.Length..];
-            return true;
-        }
-
-        return false;
-    }
-
-    private static string NormalizeLookupPath(string path)
-    {
-        var sanitized = path.Trim().Replace('\\', '/').Trim('/');
-        var hashIndex = sanitized.IndexOf('#');
-        if (hashIndex >= 0)
-        {
-            sanitized = sanitized[..hashIndex];
-        }
-
-        return sanitized;
-    }
-
-    private static string NormalizeCanonicalPath(string path)
-    {
-        return path.Trim().Replace('\\', '/').Trim('/');
-    }
-
     private static string GetSnapshotCanonicalPath(DocNode doc)
     {
         return doc.CanonicalPath
                ?? throw new InvalidOperationException(
                    $"DocFeaturedPageResolver requires snapshot canonical paths. Doc '{doc.Path}' was missing CanonicalPath.");
-    }
-
-    private static string? GetFragment(string path)
-    {
-        var canonical = NormalizeCanonicalPath(path);
-        var hashIndex = canonical.IndexOf('#');
-        if (hashIndex < 0 || hashIndex == canonical.Length - 1)
-        {
-            return null;
-        }
-
-        return canonical[(hashIndex + 1)..];
     }
 
     private static string? GetSupportingText(DocFeaturedPageDefinition definition, DocNode destination)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocPathResolver.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocPathResolver.cs
@@ -1,0 +1,241 @@
+using ForgeTrust.Runnable.Web.RazorDocs.Models;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Services;
+
+/// <summary>
+/// Resolves authored, source, and canonical RazorDocs paths against a harvested documentation corpus.
+/// </summary>
+/// <remarks>
+/// RazorDocs accepts paths from several authoring surfaces: browser routes, source-relative Markdown metadata, generated
+/// canonical paths, and route-prefixed links. This resolver is the shared source of truth for trimming route separators,
+/// ignoring lookup fragments when selecting candidate buckets, preserving exact fragment matches when available, and
+/// ranking fallback candidates when a fragment-specific page is not present.
+/// </remarks>
+internal sealed class DocPathResolver
+{
+    private readonly Dictionary<string, DocLookupBucket> _lookup;
+
+    private DocPathResolver(Dictionary<string, DocLookupBucket> lookup)
+    {
+        _lookup = lookup;
+    }
+
+    /// <summary>
+    /// Builds a resolver for a docs snapshot.
+    /// </summary>
+    /// <param name="docs">The harvested docs whose source and canonical paths should be resolvable.</param>
+    /// <returns>A resolver that can match source paths, canonical route paths, and route-relative variants.</returns>
+    internal static DocPathResolver Create(IEnumerable<DocNode> docs)
+    {
+        ArgumentNullException.ThrowIfNull(docs);
+
+        var lookup = new Dictionary<string, DocLookupBucket>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var doc in docs)
+        {
+            var sourcePath = NormalizeLookupPath(doc.Path);
+            AddLookupEntry(lookup, sourcePath, doc);
+
+            if (!string.IsNullOrWhiteSpace(doc.CanonicalPath))
+            {
+                AddLookupEntry(lookup, NormalizeLookupPath(doc.CanonicalPath), doc);
+            }
+        }
+
+        return new DocPathResolver(lookup);
+    }
+
+    /// <summary>
+    /// Resolves a path exactly as authored, using RazorDocs source and canonical matching rules.
+    /// </summary>
+    /// <param name="path">The authored source or canonical path to resolve.</param>
+    /// <returns>The best matching doc node, or <c>null</c> when no harvested doc matches.</returns>
+    internal DocNode? Resolve(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        return ResolveNormalizedPath(path);
+    }
+
+    /// <summary>
+    /// Resolves a path by preserving authored source-relative matches before stripping known docs route roots from
+    /// browser-facing inputs.
+    /// </summary>
+    /// <param name="path">The authored or browser-facing path to resolve.</param>
+    /// <param name="routeRootPaths">Route roots, such as the configured live docs root and the stable <c>/docs</c> root.</param>
+    /// <returns>The best matching doc node, or <c>null</c> when neither route-relative variants nor the original path match.</returns>
+    internal DocNode? Resolve(string path, params string[] routeRootPaths)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(routeRootPaths);
+
+        var isRootedBrowserPath = IsRootedBrowserPath(path);
+        if (!isRootedBrowserPath)
+        {
+            var authoredMatch = ResolveNormalizedPath(path);
+            if (authoredMatch is not null)
+            {
+                return authoredMatch;
+            }
+        }
+
+        var seenRouteRelativePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var routeRootPath in routeRootPaths)
+        {
+            if (!TryStripRouteRoot(path, routeRootPath, out var routeRelativePath)
+                || !seenRouteRelativePaths.Add(routeRelativePath))
+            {
+                continue;
+            }
+
+            var resolved = ResolveNormalizedPath(routeRelativePath);
+            if (resolved is not null)
+            {
+                return resolved;
+            }
+        }
+
+        return isRootedBrowserPath ? ResolveNormalizedPath(path) : null;
+    }
+
+    /// <summary>
+    /// Normalizes a documentation path for lookup by trimming route separators and removing fragment anchors.
+    /// </summary>
+    /// <param name="path">The path to normalize.</param>
+    /// <returns>The normalized lookup path.</returns>
+    internal static string NormalizeLookupPath(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        var sanitized = path.Trim().Replace('\\', '/').Trim('/');
+        var hashIndex = sanitized.IndexOf('#');
+        if (hashIndex >= 0)
+        {
+            sanitized = sanitized[..hashIndex];
+        }
+
+        return sanitized;
+    }
+
+    /// <summary>
+    /// Normalizes a documentation path for canonical comparison by trimming route separators while preserving fragments.
+    /// </summary>
+    /// <param name="path">The path to normalize.</param>
+    /// <returns>The normalized canonical path.</returns>
+    internal static string NormalizeCanonicalPath(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        return path.Trim().Replace('\\', '/').Trim('/');
+    }
+
+    /// <summary>
+    /// Extracts a fragment from a documentation path after canonical normalization.
+    /// </summary>
+    /// <param name="path">The path that may contain a fragment anchor.</param>
+    /// <returns>The fragment without the leading <c>#</c>, or <c>null</c> when no non-empty fragment exists.</returns>
+    internal static string? GetFragment(string path)
+    {
+        var canonical = NormalizeCanonicalPath(path);
+        var hashIndex = canonical.IndexOf('#');
+        if (hashIndex < 0 || hashIndex == canonical.Length - 1)
+        {
+            return null;
+        }
+
+        return canonical[(hashIndex + 1)..];
+    }
+
+    private static void AddLookupEntry(Dictionary<string, DocLookupBucket> lookup, string key, DocNode doc)
+    {
+        if (!lookup.TryGetValue(key, out var bucket))
+        {
+            bucket = new DocLookupBucket();
+            lookup[key] = bucket;
+        }
+
+        if (bucket.SeenDocs.Add(doc))
+        {
+            bucket.OrderedDocs.Add(doc);
+        }
+    }
+
+    private DocNode? ResolveNormalizedPath(string path)
+    {
+        var lookupPath = NormalizeLookupPath(path);
+        var lookupCanonicalPath = NormalizeCanonicalPath(path);
+
+        if (!_lookup.TryGetValue(lookupPath, out var bucket) || bucket.OrderedDocs.Count == 0)
+        {
+            return null;
+        }
+
+        var candidates = bucket.OrderedDocs;
+        var exactCanonicalMatch = candidates.FirstOrDefault(
+            doc => (!string.IsNullOrWhiteSpace(doc.CanonicalPath)
+                    && string.Equals(
+                        NormalizeCanonicalPath(doc.CanonicalPath),
+                        lookupCanonicalPath,
+                        StringComparison.OrdinalIgnoreCase))
+                   || string.Equals(
+                       NormalizeCanonicalPath(doc.Path),
+                       lookupCanonicalPath,
+                       StringComparison.OrdinalIgnoreCase));
+        if (exactCanonicalMatch is not null)
+        {
+            return exactCanonicalMatch;
+        }
+
+        return candidates
+            .OrderBy(doc => string.IsNullOrWhiteSpace(GetFragment(doc.CanonicalPath ?? doc.Path)) ? 0 : 1)
+            .ThenBy(doc => string.IsNullOrWhiteSpace(doc.Content) ? 1 : 0)
+            .ThenBy(doc => doc.Path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    private static bool IsRootedBrowserPath(string path)
+    {
+        var trimmedPath = path.TrimStart();
+        return trimmedPath.StartsWith("/", StringComparison.Ordinal)
+               || trimmedPath.StartsWith("\\", StringComparison.Ordinal);
+    }
+
+    private static bool TryStripRouteRoot(string path, string routeRootPath, out string routeRelativePath)
+    {
+        routeRelativePath = path;
+
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(routeRootPath))
+        {
+            return false;
+        }
+
+        var normalizedPath = path.Trim().Replace('\\', '/').TrimStart('/');
+        var normalizedRouteRoot = routeRootPath.Trim().Replace('\\', '/').Trim('/');
+        if (normalizedRouteRoot.Length == 0)
+        {
+            return false;
+        }
+
+        if (string.Equals(normalizedPath, normalizedRouteRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            routeRelativePath = string.Empty;
+            return true;
+        }
+
+        var routePrefix = normalizedRouteRoot + "/";
+        if (normalizedPath.StartsWith(routePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            routeRelativePath = normalizedPath[routePrefix.Length..];
+            return true;
+        }
+
+        return false;
+    }
+
+    private sealed class DocLookupBucket
+    {
+        internal List<DocNode> OrderedDocs { get; } = [];
+
+        internal HashSet<DocNode> SeenDocs { get; } = new(ReferenceEqualityComparer.Instance);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Views/Docs/Details.cshtml
@@ -143,7 +143,7 @@
 
     @if (!Model.IsCSharpApiDoc)
     {
-        <h1 class="text-3xl font-bold tracking-tight text-white">@Model.Title</h1>
+        <h1 class="max-w-full break-words text-3xl font-bold leading-tight tracking-tight text-white">@Model.Title</h1>
         @if (Model.ShowSummary && !string.IsNullOrWhiteSpace(Model.Summary))
         {
             <p class="mt-3 max-w-3xl text-base text-slate-400">@Model.Summary</p>

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -83,6 +83,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - RazorDocs pages can now expose typed `On this page` outlines, explicit proof-path previous/next links, related-page cards, and sidebar anchor navigation from harvested metadata instead of scraping rendered HTML.
 - Public docs navigation now groups pages by intent-first sections, preserves authored editorial breadcrumbs, and keeps Start Here recovery links hidden when that section is unavailable.
 - RazorDocs landing curation now uses `featured_page_groups`, so root and section landing pages can organize next-step links by reader intent instead of rendering one flat list.
+- RazorDocs page lookup now uses one shared path resolver for details pages, landing curation, related-page links, and search recovery links, keeping source paths, canonical `.html` paths, fragments, backslash normalization, and configured docs-root prefixes behaviorally aligned.
 - The release contract is designed so future tooling can generate both a changelog entry and a blog-style tagged release note from the same underlying signals.
 - RazorDocs now rewrites authored doc links from a harvested target manifest instead of broad suffix heuristics, so normal site links such as `../privacy.html` stay untouched and missing doc targets do not become broken `/docs/...` routes.
 - RazorDocs details pages can now render a `Source of truth` strip with `View source`, `Edit this page`, and relative `Last updated` evidence driven by contributor metadata, configured URL templates, and git freshness when available.


### PR DESCRIPTION
## Summary

- Extract a shared internal `DocPathResolver` for RazorDocs source, canonical, fragment, and route-prefixed path matching.
- Wire page details, related-page resolution, landing curation, and search fallback links through the shared resolver.
- Add focused resolver tests and update RazorDocs authoring docs, changelog, and unreleased release notes.

## Why

`DocsController`, `DocAggregator`, and `DocFeaturedPageResolver` each carried their own lookup buckets and normalization rules. That made fragment handling, canonical matching, backslash normalization, and route-root stripping easy to drift over time.

## Validation

- `dotnet format ForgeTrust.Runnable.slnx`
- `dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --no-restore` passed, 802 tests.

Fixes #133