### PR TITLE
refactor(config): move ConfigKeyAttribute to its own file

### DIFF
--- a/Config/ForgeTrust.Runnable.Config/ConfigKeyAttribute.cs
+++ b/Config/ForgeTrust.Runnable.Config/ConfigKeyAttribute.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+
+namespace ForgeTrust.Runnable.Config;
+
+/// <summary>
+/// Specifies the configuration key or path for a type.
+/// </summary>
+public class ConfigKeyAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the configuration key or path for this type.
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this key should be treated as a root key, ignoring the declaring type hierarchy.
+    /// </summary>
+    public bool Root { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigKeyAttribute"/> class with a specific key.
+    /// </summary>
+    /// <param name="key">The configuration key.</param>
+    /// <param name="root">Whether this is a root key.</param>
+    public ConfigKeyAttribute(string key, bool root = false)
+    {
+        Key = key;
+        Root = root;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigKeyAttribute"/> class for a specific type.
+    /// </summary>
+    /// <param name="t">The type to derive the key from.</param>
+    public ConfigKeyAttribute(Type t)
+    {
+        Key = GetKeyPath(t);
+        var foundAttr = GetAttribute(t);
+        Root = foundAttr?.Root ?? false;
+    }
+
+    /// <summary>
+    /// Extracts the configuration key from an object's type attribute.
+    /// </summary>
+    /// <param name="obj">The object to extract the key from.</param>
+    /// <returns>The configuration key, or null if not specified.</returns>
+    public static string? ExtractKey(object obj)
+    {
+        return ExtractKey(obj.GetType());
+    }
+
+    /// <summary>
+    /// Extracts the configuration key from a type's attribute.
+    /// </summary>
+    /// <param name="type">The type to extract the key from.</param>
+    /// <returns>The configuration key, or null if not specified.</returns>
+    public static string? ExtractKey(Type type)
+    {
+        var attribute = GetAttribute(type);
+
+        return attribute?.Key;
+    }
+
+    private static ConfigKeyAttribute? GetAttribute(
+        Type type) =>
+        type.GetCustomAttribute<ConfigKeyAttribute>(false);
+
+    /// <summary>
+    /// Computes the full configuration key path for a type, recursively including declaring types unless <see cref="Root"/> is true.
+    /// </summary>
+    /// <param name="type">The type to compute the path for.</param>
+    /// <returns>The computed configuration key path.</returns>
+    public static string GetKeyPath(
+        Type type)
+    {
+        var attribute = GetAttribute(type);
+        var isRoot = attribute?.Root ?? false;
+        var thisMember = attribute?.Key ?? type.Name;
+        if (isRoot || type.DeclaringType == null)
+        {
+            return thisMember;
+        }
+
+        var parentPath = GetKeyPath(type.DeclaringType);
+
+        return $"{parentPath}.{thisMember}";
+    }
+}

--- a/Config/ForgeTrust.Runnable.Config/RunnableConfigModule.cs
+++ b/Config/ForgeTrust.Runnable.Config/RunnableConfigModule.cs
@@ -49,13 +49,8 @@ public class RunnableConfigModule : IRunnableModule
                 type,
                 sp =>
                 {
-                    // Determine the key path (your existing attribute helper)
                     var key = ConfigKeyAttribute.GetKeyPath(type);
-
-                    // Create instance (supports ctor DI if needed)
                     var instance = (IConfig)ActivatorUtilities.CreateInstance(sp, type);
-
-                    // Call your init with required services
                     instance.Init(
                         sp.GetRequiredService<IConfigManager>(),
                         sp.GetRequiredService<IEnvironmentProvider>(),
@@ -69,90 +64,5 @@ public class RunnableConfigModule : IRunnableModule
     /// <inheritdoc />
     public void RegisterDependentModules(ModuleDependencyBuilder builder)
     {
-    }
-}
-
-/// <summary>
-/// Specifies the configuration key or path for a type.
-/// </summary>
-public class ConfigKeyAttribute : Attribute
-{
-    /// <summary>
-    /// Gets the configuration key or path for this type.
-    /// </summary>
-    public string Key { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether this key should be treated as a root key, ignoring the declaring type hierarchy.
-    /// </summary>
-    public bool Root { get; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ConfigKeyAttribute"/> class with a specific key.
-    /// </summary>
-    /// <param name="key">The configuration key.</param>
-    /// <param name="root">Whether this is a root key.</param>
-    public ConfigKeyAttribute(string key, bool root = false)
-    {
-        Key = key;
-        Root = root;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ConfigKeyAttribute"/> class for a specific type.
-    /// </summary>
-    /// <param name="t">The type to derive the key from.</param>
-    public ConfigKeyAttribute(Type t)
-    {
-        Key = GetKeyPath(t);
-        var foundAttr = GetAttribute(t);
-        Root = foundAttr?.Root ?? false;
-    }
-
-    /// <summary>
-    /// Extracts the configuration key from an object's type attribute.
-    /// </summary>
-    /// <param name="obj">The object to extract the key from.</param>
-    /// <returns>The configuration key, or null if not specified.</returns>
-    public static string? ExtractKey(object obj)
-    {
-        return ExtractKey(obj.GetType());
-    }
-
-    /// <summary>
-    /// Extracts the configuration key from a type's attribute.
-    /// </summary>
-    /// <param name="type">The type to extract the key from.</param>
-    /// <returns>The configuration key, or null if not specified.</returns>
-    public static string? ExtractKey(Type type)
-    {
-        var attribute = GetAttribute(type);
-
-        return attribute?.Key;
-    }
-
-    private static ConfigKeyAttribute? GetAttribute(
-        Type type) =>
-        type.GetCustomAttribute<ConfigKeyAttribute>(false);
-
-    /// <summary>
-    /// Computes the full configuration key path for a type, recursively including declaring types unless <see cref="Root"/> is true.
-    /// </summary>
-    /// <param name="type">The type to compute the path for.</param>
-    /// <returns>The computed configuration key path.</returns>
-    public static string GetKeyPath(
-        Type type)
-    {
-        var attribute = GetAttribute(type);
-        var isRoot = attribute?.Root ?? false;
-        var thisMember = attribute?.Key ?? type.Name;
-        if (isRoot || type.DeclaringType == null)
-        {
-            return thisMember;
-        }
-
-        var parentPath = GetKeyPath(type.DeclaringType);
-
-        return $"{parentPath}.{thisMember}";
     }
 }

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -58,6 +58,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Nested config validation can now opt into Microsoft Options `[ValidateObjectMembers]` and `[ValidateEnumeratedItems]` markers while Runnable owns traversal, path formatting, and cycle protection.
 - Scalar config wrappers can now validate resolved primitive values directly with `ConfigValueNotEmpty`, `ConfigValueRange`, and `ConfigValueMinLength` attributes, while wrapper-specific scalar rules can override `ValidateValue`.
 - Config wrappers can now opt into required resolved presence with `ConfigKeyRequired`, so startup fails when no provider value and no default are available while defaults and supplied zero values still count as present.
+- `ConfigKeyAttribute` now lives in its own public API source file, keeping configuration key attributes discoverable while leaving `RunnableConfigModule` focused on service registration.
 - The new `examples/config-validation` sample demonstrates an intentional startup validation failure for a scalar `ConfigStruct<int>` without printing the invalid configured value.
 - Environment variables can now patch individual members of object-valued config loaded from lower-priority providers, so `APP__SETTINGS__DATABASE__PORT` can override one nested value without replacing the rest of the JSON-backed options object.
 


### PR DESCRIPTION
## Summary

- Move the public ConfigKeyAttribute type into its own ConfigKeyAttribute.cs file.
- Leave RunnableConfigModule focused on service/module registration logic.
- Preserve the existing namespace, public API shape, and behavior.

Fixes #223

## Validation

- dotnet format Config/ForgeTrust.Runnable.Config/ForgeTrust.Runnable.Config.csproj
- dotnet test Config/ForgeTrust.Runnable.Config.Tests/ForgeTrust.Runnable.Config.Tests.csproj