### PR TITLE
fix(razordocs): make snapshot cache expiration configurable

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -3298,6 +3298,7 @@ public class DocAggregatorTests : IDisposable
     [Theory]
     [InlineData(0)]
     [InlineData(double.Epsilon)]
+    [InlineData(0.333)]
     [InlineData(double.MaxValue)]
     public void Constructor_ShouldThrow_WhenCacheExpirationIsInvalid(double cacheExpirationMinutes)
     {

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocAggregatorTests.cs
@@ -89,6 +89,45 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDocsAsync_ShouldExpireSnapshotUsingConfiguredCacheExpiration()
+    {
+        var harvester = A.Fake<IDocHarvester>();
+        var harvestCount = 0;
+        A.CallTo(() => harvester.HarvestAsync(A<string>._, A<CancellationToken>._))
+            .ReturnsLazily(() =>
+            {
+                var currentHarvest = Interlocked.Increment(ref harvestCount);
+                return new[] { new DocNode($"Harvest {currentHarvest}", "path", "<p>content</p>") };
+            });
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        using var memo = new Memo(cache);
+        var aggregator = new DocAggregator(
+            [harvester],
+            new RazorDocsOptions
+            {
+                CacheExpirationMinutes = RazorDocsOptions.MinCacheExpirationMinutes,
+                Source = new RazorDocsSourceOptions
+                {
+                    RepositoryRoot = Path.GetTempPath()
+                }
+            },
+            _envFake,
+            memo,
+            _sanitizerFake,
+            _loggerFake);
+
+        var first = await aggregator.GetDocsAsync();
+        await Task.Delay(TimeSpan.FromMilliseconds(1100));
+        var second = await aggregator.GetDocsAsync();
+
+        Assert.Equal("Harvest 1", Assert.Single(first).Title);
+        Assert.Equal("Harvest 2", Assert.Single(second).Title);
+        A.CallTo(() => harvester.HarvestAsync(A<string>._, A<CancellationToken>._))
+            .MustHaveHappenedTwiceExactly();
+    }
+
+    [Fact]
     public async Task GetDocsAsync_ShouldSanitizeContent_WhenHarvested()
     {
         // Arrange
@@ -3254,6 +3293,29 @@ public class DocAggregatorTests : IDisposable
 
         Assert.Equal(nameof(RazorDocsSourceOptions.RepositoryRoot), ex.ParamName);
         Assert.Contains("whitespace", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(double.Epsilon)]
+    [InlineData(double.MaxValue)]
+    public void Constructor_ShouldThrow_WhenCacheExpirationIsInvalid(double cacheExpirationMinutes)
+    {
+        var options = new RazorDocsOptions
+        {
+            CacheExpirationMinutes = cacheExpirationMinutes
+        };
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => new DocAggregator(
+                new[] { _harvesterFake },
+                options,
+                _envFake,
+                _memo,
+                _sanitizerFake,
+                _loggerFake));
+
+        Assert.Equal(nameof(RazorDocsOptions.CacheExpirationMinutes), ex.ParamName);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/DocsControllerTests.cs
@@ -2235,6 +2235,48 @@ public class DocsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task SearchIndex_ShouldUseConfiguredSnapshotCacheExpirationForCacheControlHeader()
+    {
+        var harvester = A.Fake<IDocHarvester>();
+        A.CallTo(() => harvester.HarvestAsync(A<string>._, A<CancellationToken>._))
+            .Returns([new DocNode("Getting Started", "guides/start", "<p>First steps.</p>")]);
+
+        var env = A.Fake<IWebHostEnvironment>();
+        A.CallTo(() => env.ContentRootPath).Returns(Path.GetTempPath());
+        var sanitizer = A.Fake<IRazorDocsHtmlSanitizer>();
+        A.CallTo(() => sanitizer.Sanitize(A<string>._))
+            .ReturnsLazily((string input) => input);
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        using var memo = new Memo(cache);
+        var aggregator = new DocAggregator(
+            [harvester],
+            new RazorDocsOptions
+            {
+                CacheExpirationMinutes = 0.5,
+                Source = new RazorDocsSourceOptions
+                {
+                    RepositoryRoot = Path.GetTempPath()
+                }
+            },
+            env,
+            memo,
+            sanitizer,
+            A.Fake<ILogger<DocAggregator>>());
+        var controller = new DocsController(
+            aggregator,
+            new DocFeaturedPageResolver(_featuredPageResolverLoggerFake),
+            _controllerLoggerFake)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        _ = await controller.SearchIndex();
+
+        Assert.Equal("private,max-age=30", controller.Response.Headers.CacheControl.ToString());
+    }
+
+    [Fact]
     public async Task SearchIndex_ShouldRefreshCache_WhenAuthenticatedRefreshRequested()
     {
         var docs = new List<DocNode>

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
@@ -449,6 +449,7 @@ public sealed class RazorDocsOptionsTests
     [InlineData(double.NaN)]
     [InlineData(double.Epsilon)]
     [InlineData(0.0001)]
+    [InlineData(0.333)]
     [InlineData(double.MaxValue)]
     [InlineData(35791395)]
     public void Validator_ShouldRejectInvalidCacheExpirationMinutes(double cacheExpirationMinutes)
@@ -467,6 +468,24 @@ public sealed class RazorDocsOptionsTests
             failure => failure.Contains(
                 "CacheExpirationMinutes must be a finite number between",
                 StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validator_ShouldAllowWholeSecondCacheExpirationMinutes()
+    {
+        var validator = new RazorDocsOptionsValidator();
+        var options = new RazorDocsOptions
+        {
+            CacheExpirationMinutes = 0.1,
+            Routing = new RazorDocsRoutingOptions
+            {
+                DocsRootPath = "/docs"
+            }
+        };
+
+        var result = validator.Validate(Options.DefaultName, options);
+
+        Assert.False(result.Failed);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
@@ -47,6 +47,37 @@ public sealed class RazorDocsOptionsTests
     }
 
     [Fact]
+    public void RazorDocsOptions_ShouldDefaultCacheExpirationToFiveMinutes()
+    {
+        var options = new RazorDocsOptions();
+
+        Assert.Equal(5, options.CacheExpirationMinutes);
+        Assert.Equal(1d / 60d, RazorDocsOptions.MinCacheExpirationMinutes);
+        Assert.Equal((int.MaxValue - 1) / 60d, RazorDocsOptions.MaxCacheExpirationMinutes);
+    }
+
+    [Fact]
+    public void AddRazorDocs_ShouldBindConfiguredCacheExpirationMinutes()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["RazorDocs:CacheExpirationMinutes"] = "0.5"
+                    })
+                .Build());
+
+        services.AddRazorDocs();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<RazorDocsOptions>>().Value;
+
+        Assert.Equal(0.5, options.CacheExpirationMinutes);
+    }
+
+    [Fact]
     public void AddRazorDocs_ShouldTrimAndDeduplicateConfiguredNamespacePrefixes()
     {
         var services = new ServiceCollection();
@@ -409,6 +440,69 @@ public sealed class RazorDocsOptionsTests
 
         Assert.True(result.Failed);
         Assert.Contains(result.Failures, failure => failure.Contains("Unsupported RazorDocs mode", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NaN)]
+    [InlineData(double.Epsilon)]
+    [InlineData(0.0001)]
+    [InlineData(double.MaxValue)]
+    [InlineData(35791395)]
+    public void Validator_ShouldRejectInvalidCacheExpirationMinutes(double cacheExpirationMinutes)
+    {
+        var validator = new RazorDocsOptionsValidator();
+        var options = new RazorDocsOptions
+        {
+            CacheExpirationMinutes = cacheExpirationMinutes
+        };
+
+        var result = validator.Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(
+            result.Failures,
+            failure => failure.Contains(
+                "CacheExpirationMinutes must be a finite number between",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validator_ShouldAllowMinimumCacheExpirationMinutes()
+    {
+        var validator = new RazorDocsOptionsValidator();
+        var options = new RazorDocsOptions
+        {
+            CacheExpirationMinutes = RazorDocsOptions.MinCacheExpirationMinutes,
+            Routing = new RazorDocsRoutingOptions
+            {
+                DocsRootPath = "/docs"
+            }
+        };
+
+        var result = validator.Validate(Options.DefaultName, options);
+
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void Validator_ShouldAllowMaximumCacheExpirationMinutes()
+    {
+        var validator = new RazorDocsOptionsValidator();
+        var options = new RazorDocsOptions
+        {
+            CacheExpirationMinutes = RazorDocsOptions.MaxCacheExpirationMinutes,
+            Routing = new RazorDocsRoutingOptions
+            {
+                DocsRootPath = "/docs"
+            }
+        };
+
+        var result = validator.Validate(Options.DefaultName, options);
+
+        Assert.False(result.Failed);
     }
 
     [Fact]

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RazorDocsOptionsTests.cs
@@ -78,6 +78,31 @@ public sealed class RazorDocsOptionsTests
     }
 
     [Fact]
+    public void AddRazorDocs_ShouldRejectInvalidConfiguredCacheExpirationMinutes()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["RazorDocs:CacheExpirationMinutes"] = "-1"
+                    })
+                .Build());
+
+        services.AddRazorDocs();
+
+        using var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => _ = provider.GetRequiredService<IOptions<RazorDocsOptions>>().Value);
+
+        Assert.Contains(
+            ex.Failures,
+            failure => failure.Contains("CacheExpirationMinutes", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void AddRazorDocs_ShouldTrimAndDeduplicateConfiguredNamespacePrefixes()
     {
         var services = new ServiceCollection();

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Controllers/DocsController.cs
@@ -23,7 +23,6 @@ public class DocsController : Controller
     private const string CuratedLandingDescription = "Start with the proof path that answers the first evaluator questions, then move into the sections that fit your next decision.";
     private const string SectionUnavailableHeading = "Section unavailable";
     private static readonly string[] DefaultProofPathStageLabels = ["Understand", "See Proof", "Adopt Next"];
-    private static readonly TimeSpan SearchIndexCacheDuration = DocAggregator.SnapshotCacheDuration;
     private static readonly TimeSpan SearchShellFallbackBudget = TimeSpan.FromMilliseconds(500);
 
     private readonly DocAggregator _aggregator;
@@ -363,7 +362,7 @@ public class DocsController : Controller
         }
 
         // Keep response caching private by default; docs may be served behind auth.
-        Response.Headers.CacheControl = $"private,max-age={(int)SearchIndexCacheDuration.TotalSeconds}";
+        Response.Headers.CacheControl = $"private,max-age={(int)_aggregator.SnapshotCacheDuration.TotalSeconds}";
 
         var payload = await _aggregator.GetSearchIndexPayloadAsync(HttpContext.RequestAborted);
         var pathBaseAwarePayload = PrefixSearchIndexPathsForPathBase(payload, Request.PathBase.Value);

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -75,6 +75,7 @@ Use the default single-surface configuration when you want the live docs experie
 {
   "RazorDocs": {
     "Mode": "Source",
+    "CacheExpirationMinutes": 5,
     "Source": {
       "RepositoryRoot": "/path/to/repo"
     }
@@ -224,6 +225,16 @@ RazorDocs does not regenerate these trees at request time. It resolves extension
 - Do not point `recommendedVersion` at a hidden or broken release tree.
 - Do not assume `RazorDocs:Versioning:Enabled` means the runtime can read request-time bundles. This slice still serves the live preview from source and mounts published releases as static trees.
 - Do not forget `search-index.json` in an exported release tree. A release without it is intentionally marked unavailable.
+
+`RazorDocs:CacheExpirationMinutes` controls the absolute lifetime of the shared docs snapshot that backs docs pages, public-section data, and `/docs/search-index.json`. It defaults to `5`, must be a finite number between `RazorDocsOptions.MinCacheExpirationMinutes` and `RazorDocsOptions.MaxCacheExpirationMinutes`, and is interpreted as minutes. Use shorter values for source-backed development hosts where authors need edits to appear quickly; use longer values for production hosts when harvesters are expensive or the docs corpus changes only during deploys.
+
+Pitfalls:
+
+- Do not set `CacheExpirationMinutes` to `0` to disable caching. RazorDocs rejects zero and negative values because every request would rebuild the docs snapshot and search index.
+- Do not set tiny positive values below `RazorDocsOptions.MinCacheExpirationMinutes`; the search-index `Cache-Control` `max-age` header cannot represent sub-second cache lifetimes.
+- Do not set huge finite values such as `double.MaxValue`. RazorDocs caps the value so the derived search-index `Cache-Control` `max-age` remains representable.
+- The search-index response uses the same duration for its private `Cache-Control` `max-age`, so client refresh behavior stays aligned with server-side snapshot reuse.
+- Manual refresh through `/docs/search-index.json?refresh=1` still invalidates the server snapshot generation immediately for authenticated users; it does not change the configured TTL for later entries.
 
 ## Contributor Provenance
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -241,7 +241,7 @@ Pitfalls:
 - Do not set fractional-second values such as `0.333` minutes. RazorDocs rejects values that cannot round-trip to a whole-second `max-age`.
 - Do not set huge finite values such as `double.MaxValue`. RazorDocs caps the value so the derived search-index `Cache-Control` `max-age` remains representable.
 - The search-index response uses the same duration for its private `Cache-Control` `max-age`, so client refresh behavior stays aligned with server-side snapshot reuse.
-- Manual refresh through `/docs/search-index.json?refresh=1` still invalidates the server snapshot generation immediately for authenticated users; it does not change the configured TTL for later entries.
+- Manual refresh through `{DocsRootPath}/search-index.json?refresh=1` still invalidates the server snapshot generation immediately for authenticated users; it does not change the configured TTL for later entries. For example, when `RazorDocs:Routing:DocsRootPath` is `/docs/next`, use `/docs/next/search-index.json?refresh=1`.
 
 ## Contributor Provenance
 

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -124,6 +124,12 @@ Enable versioning when you want the host to keep serving the live unreleased sna
 - `RazorDocs:Source:RepositoryRoot`
   - Optional absolute or app-relative repository root for source harvesting.
   - When omitted, RazorDocs falls back to repository discovery from the content root.
+- `RazorDocs:CacheExpirationMinutes`
+  - Controls the absolute lifetime of the shared docs snapshot that backs docs pages, public-section data, and `/docs/search-index.json`.
+  - Defaults to `5` minutes.
+  - Must be a finite positive number from `0.016666666666666666` through `35791394.1`, inclusive.
+  - Must map to a whole number of seconds, because `/docs/search-index.json` uses the same duration for its private `Cache-Control` `max-age` header.
+  - Do not use `0`, sub-second values, or extreme values such as `double.MaxValue`; RazorDocs rejects values outside the supported range during options validation.
 - `RazorDocs:Routing:DocsRootPath`
   - Controls the live source-backed docs root.
   - Defaults to `/docs` when versioning is off.
@@ -226,12 +232,13 @@ RazorDocs does not regenerate these trees at request time. It resolves extension
 - Do not assume `RazorDocs:Versioning:Enabled` means the runtime can read request-time bundles. This slice still serves the live preview from source and mounts published releases as static trees.
 - Do not forget `search-index.json` in an exported release tree. A release without it is intentionally marked unavailable.
 
-`RazorDocs:CacheExpirationMinutes` controls the absolute lifetime of the shared docs snapshot that backs docs pages, public-section data, and `/docs/search-index.json`. It defaults to `5`, must be a finite number between `RazorDocsOptions.MinCacheExpirationMinutes` and `RazorDocsOptions.MaxCacheExpirationMinutes`, and is interpreted as minutes. Use shorter values for source-backed development hosts where authors need edits to appear quickly; use longer values for production hosts when harvesters are expensive or the docs corpus changes only during deploys.
+`RazorDocs:CacheExpirationMinutes` is interpreted as minutes. Use shorter values for source-backed development hosts where authors need edits to appear quickly; use longer values for production hosts when harvesters are expensive or the docs corpus changes only during deploys.
 
 Pitfalls:
 
 - Do not set `CacheExpirationMinutes` to `0` to disable caching. RazorDocs rejects zero and negative values because every request would rebuild the docs snapshot and search index.
-- Do not set tiny positive values below `RazorDocsOptions.MinCacheExpirationMinutes`; the search-index `Cache-Control` `max-age` header cannot represent sub-second cache lifetimes.
+- Do not set tiny positive values below `0.016666666666666666` minutes; the search-index `Cache-Control` `max-age` header cannot represent sub-second cache lifetimes.
+- Do not set fractional-second values such as `0.333` minutes. RazorDocs rejects values that cannot round-trip to a whole-second `max-age`.
 - Do not set huge finite values such as `double.MaxValue`. RazorDocs caps the value so the derived search-index `Cache-Control` `max-age` remains representable.
 - The search-index response uses the same duration for its private `Cache-Control` `max-age`, so client refresh behavior stays aligned with server-side snapshot reuse.
 - Manual refresh through `/docs/search-index.json?refresh=1` still invalidates the server snapshot generation immediately for authenticated users; it does not change the configured TTL for later entries.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -125,10 +125,10 @@ Enable versioning when you want the host to keep serving the live unreleased sna
   - Optional absolute or app-relative repository root for source harvesting.
   - When omitted, RazorDocs falls back to repository discovery from the content root.
 - `RazorDocs:CacheExpirationMinutes`
-  - Controls the absolute lifetime of the shared docs snapshot that backs docs pages, public-section data, and `/docs/search-index.json`.
+  - Controls the absolute lifetime of the shared docs snapshot that backs docs pages, public-section data, and `{DocsRootPath}/search-index.json`; for example, `/docs/search-index.json` by default or `/docs/next/search-index.json` when `RazorDocs:Routing:DocsRootPath` is `/docs/next`.
   - Defaults to `5` minutes.
   - Must be a finite positive number from `0.016666666666666666` through `35791394.1`, inclusive.
-  - Must map to a whole number of seconds, because `/docs/search-index.json` uses the same duration for its private `Cache-Control` `max-age` header.
+  - Must map to a whole number of seconds, because `{DocsRootPath}/search-index.json` uses the same duration for its private `Cache-Control` `max-age` header.
   - Do not use `0`, sub-second values, or extreme values such as `double.MaxValue`; RazorDocs rejects values outside the supported range during options validation.
 - `RazorDocs:Routing:DocsRootPath`
   - Controls the live source-backed docs root.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsOptions.cs
@@ -14,9 +14,43 @@ public sealed class RazorDocsOptions
     public const string SectionName = "RazorDocs";
 
     /// <summary>
+    /// Gets the default value, in minutes, for <see cref="CacheExpirationMinutes"/>.
+    /// </summary>
+    public const double DefaultCacheExpirationMinutes = 5;
+
+    /// <summary>
+    /// Gets the smallest supported value, in minutes, for <see cref="CacheExpirationMinutes"/>.
+    /// </summary>
+    /// <remarks>
+    /// The limit keeps the configured duration representable by the derived search-index <c>Cache-Control</c>
+    /// <c>max-age</c> header, which uses whole seconds.
+    /// </remarks>
+    public const double MinCacheExpirationMinutes = 1d / 60d;
+
+    /// <summary>
+    /// Gets the largest supported value, in minutes, for <see cref="CacheExpirationMinutes"/>.
+    /// </summary>
+    /// <remarks>
+    /// The limit keeps the derived search-index <c>Cache-Control</c> <c>max-age</c> within the range of a 32-bit
+    /// positive delta-seconds value.
+    /// </remarks>
+    public const double MaxCacheExpirationMinutes = (int.MaxValue - 1) / 60d;
+
+    /// <summary>
     /// Gets or sets the active docs source mode.
     /// </summary>
     public RazorDocsMode Mode { get; set; } = RazorDocsMode.Source;
+
+    /// <summary>
+    /// Gets or sets the absolute docs snapshot cache lifetime in minutes.
+    /// The default is 5 minutes.
+    /// </summary>
+    /// <remarks>
+    /// This setting controls the shared aggregation snapshot used by docs pages, public-section data, and the generated
+    /// search-index payload. Shorter values make source-backed development changes visible sooner, while longer values
+    /// reduce repeated harvest and search-index generation work in production hosts.
+    /// </remarks>
+    public double CacheExpirationMinutes { get; set; } = DefaultCacheExpirationMinutes;
 
     /// <summary>
     /// Gets source-mode settings used when docs are harvested from a repository checkout.
@@ -290,6 +324,12 @@ public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOption
             failures.Add($"Unsupported RazorDocs mode '{options.Mode}'.");
         }
 
+        if (!IsValidCacheExpirationMinutes(options.CacheExpirationMinutes))
+        {
+            failures.Add(
+                $"RazorDocs:CacheExpirationMinutes must be a finite number between {RazorDocsOptions.MinCacheExpirationMinutes} and {RazorDocsOptions.MaxCacheExpirationMinutes}.");
+        }
+
         if (source is null)
         {
             failures.Add("RazorDocs:Source must not be null.");
@@ -457,6 +497,13 @@ public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOption
         return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
+    }
+
+    internal static bool IsValidCacheExpirationMinutes(double cacheExpirationMinutes)
+    {
+        return double.IsFinite(cacheExpirationMinutes)
+               && cacheExpirationMinutes >= RazorDocsOptions.MinCacheExpirationMinutes
+               && cacheExpirationMinutes <= RazorDocsOptions.MaxCacheExpirationMinutes;
     }
 
     private static bool IsValidDocsRootPath(string docsRootPath)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsOptions.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/RazorDocsOptions.cs
@@ -43,12 +43,15 @@ public sealed class RazorDocsOptions
 
     /// <summary>
     /// Gets or sets the absolute docs snapshot cache lifetime in minutes.
-    /// The default is 5 minutes.
+    /// The default is <see cref="DefaultCacheExpirationMinutes"/> minutes.
     /// </summary>
     /// <remarks>
     /// This setting controls the shared aggregation snapshot used by docs pages, public-section data, and the generated
     /// search-index payload. Shorter values make source-backed development changes visible sooner, while longer values
-    /// reduce repeated harvest and search-index generation work in production hosts.
+    /// reduce repeated harvest and search-index generation work in production hosts. The value must be finite, must be
+    /// between <see cref="MinCacheExpirationMinutes"/> and <see cref="MaxCacheExpirationMinutes"/>, and must represent
+    /// a whole number of seconds because the generated search-index <c>Cache-Control</c> <c>max-age</c> header uses
+    /// whole-second delta values. Values outside those constraints are rejected during options validation.
     /// </remarks>
     public double CacheExpirationMinutes { get; set; } = DefaultCacheExpirationMinutes;
 
@@ -327,7 +330,7 @@ public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOption
         if (!IsValidCacheExpirationMinutes(options.CacheExpirationMinutes))
         {
             failures.Add(
-                $"RazorDocs:CacheExpirationMinutes must be a finite number between {RazorDocsOptions.MinCacheExpirationMinutes} and {RazorDocsOptions.MaxCacheExpirationMinutes}.");
+                $"RazorDocs:CacheExpirationMinutes must be a finite number between {RazorDocsOptions.MinCacheExpirationMinutes} and {RazorDocsOptions.MaxCacheExpirationMinutes} minutes that maps to a whole number of seconds.");
         }
 
         if (source is null)
@@ -501,9 +504,15 @@ public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOption
 
     internal static bool IsValidCacheExpirationMinutes(double cacheExpirationMinutes)
     {
-        return double.IsFinite(cacheExpirationMinutes)
-               && cacheExpirationMinutes >= RazorDocsOptions.MinCacheExpirationMinutes
-               && cacheExpirationMinutes <= RazorDocsOptions.MaxCacheExpirationMinutes;
+        if (!double.IsFinite(cacheExpirationMinutes)
+            || cacheExpirationMinutes < RazorDocsOptions.MinCacheExpirationMinutes
+            || cacheExpirationMinutes > RazorDocsOptions.MaxCacheExpirationMinutes)
+        {
+            return false;
+        }
+
+        var cacheDuration = TimeSpan.FromMinutes(cacheExpirationMinutes);
+        return cacheDuration.Ticks % TimeSpan.TicksPerSecond == 0;
     }
 
     private static bool IsValidDocsRootPath(string docsRootPath)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/DocAggregator.cs
@@ -96,7 +96,6 @@ public class DocAggregator
     // Bound per-document heading volume so search-index size stays predictable for large docs sets.
     private const int MaxHeadingsPerDocument = 24;
     private const int SearchSnippetMaxLength = 220;
-    internal static readonly TimeSpan SnapshotCacheDuration = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan HarvesterTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan ContributorFreshnessTimeout = TimeSpan.FromSeconds(30);
 
@@ -109,10 +108,15 @@ public class DocAggregator
     private readonly RazorDocsContributorOptions _contributorOptions;
     private readonly Func<string, CancellationToken, Task<DateTimeOffset?>> _resolveGitLastUpdatedUtcAsync;
     private readonly TimeSpan _contributorFreshnessTimeout;
+    private readonly CachePolicy _docsCachePolicy;
     private readonly Func<DateTimeOffset> _utcNow;
-    private static readonly CachePolicy DocsCachePolicy = CachePolicy.Absolute(SnapshotCacheDuration);
     private readonly Guid _cacheScope = Guid.NewGuid();
     private long _cacheGeneration;
+
+    /// <summary>
+    /// Gets the configured absolute lifetime for the shared docs snapshot cache.
+    /// </summary>
+    internal TimeSpan SnapshotCacheDuration { get; }
 
     private static readonly Regex ScriptOrStyleRegex = new(
         "<script[^>]*>[\\s\\S]*?</script>|<style[^>]*>[\\s\\S]*?</style>",
@@ -299,6 +303,8 @@ public class DocAggregator
         _docsUrlBuilder = docsUrlBuilder;
         _logger = logger;
         _contributorOptions = options.Contributor ?? throw new ArgumentNullException(nameof(options.Contributor));
+        SnapshotCacheDuration = ResolveSnapshotCacheDuration(options);
+        _docsCachePolicy = CachePolicy.Absolute(SnapshotCacheDuration);
         _contributorFreshnessTimeout = contributorFreshnessTimeout ?? ContributorFreshnessTimeout;
         _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
         _repositoryRoot = options.Mode switch
@@ -317,6 +323,19 @@ public class DocAggregator
         {
             return ResolveGitLastUpdatedUtcAsync(_repositoryRoot, sourcePath, _logger, cancellationToken);
         }
+    }
+
+    private static TimeSpan ResolveSnapshotCacheDuration(RazorDocsOptions options)
+    {
+        if (!RazorDocsOptionsValidator.IsValidCacheExpirationMinutes(options.CacheExpirationMinutes))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(RazorDocsOptions.CacheExpirationMinutes),
+                options.CacheExpirationMinutes,
+                $"RazorDocs cache expiration must be a finite number of minutes between {RazorDocsOptions.MinCacheExpirationMinutes} and {RazorDocsOptions.MaxCacheExpirationMinutes}.");
+        }
+
+        return TimeSpan.FromMinutes(options.CacheExpirationMinutes);
     }
 
     private static string ResolveRepositoryRoot(
@@ -472,7 +491,8 @@ public class DocAggregator
     /// The search-index payload is generated from the same harvested snapshot.
     /// Caller cancellation does not cancel shared snapshot computation; callers can cancel their own wait.
     /// Harvester execution is bounded by a timeout so a single slow harvester cannot block snapshot regeneration indefinitely.
-    /// The memoized cache entry is created with a 5-minute absolute expiration.
+    /// The memoized cache entry is created with the configured absolute expiration from
+    /// <see cref="RazorDocsOptions.CacheExpirationMinutes"/>.
     /// </remarks>
     /// <returns>A cached snapshot containing both docs and search-index payload.</returns>
     private async Task<CachedDocsSnapshot> GetCachedDocsSnapshotAsync()
@@ -484,6 +504,7 @@ public class DocAggregator
         var logger = _logger;
         var harvesterTimeout = HarvesterTimeout;
         var snapshotCacheDuration = SnapshotCacheDuration;
+        var docsCachePolicy = _docsCachePolicy;
 
         return await _memo.GetAsync(
                    _cacheScope,
@@ -626,7 +647,7 @@ public class DocAggregator
                            searchIndexPayload,
                            contributorProvenanceByPath);
                    },
-                   DocsCachePolicy,
+                   docsCachePolicy,
                    cancellationToken: CancellationToken.None);
     }
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -92,6 +92,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Contributor provenance now degrades safely: namespace and API pages stay explicit-override-only for the MVP, and missing or slow git history omits only freshness instead of breaking docs rendering.
 - RazorDocs generated C# API references can now render per-symbol source links for documented types, methods, properties, and enums that point at the exact source file and line, with immutable refs available when hosts want links pinned to the code version used to build the docs.
 - The primary RazorDocs Pages deployment now configures commit-pinned symbol source links, so generated C# API `Source` chips resolve to the exact file and line from the CI build revision.
+- RazorDocs snapshot caching is now configurable with `RazorDocs:CacheExpirationMinutes`, so development hosts can shorten reuse while production hosts can choose a longer docs and search-index cache lifetime.
 - Shared RazorDocs badges, metadata chips, provenance strips, and trust bars now live in the shared package stylesheet while `search.css` stays focused on search-specific UI.
 - RazorDocs search now keeps failure recovery markup out of the active search shell until the index actually fails to load, so successful searches no longer expose hidden failure copy to text extraction tools.
 - RazorDocs now documents the namespace README merge contract with positive and negative examples, while detail-page titles wrap on narrow screens so long package names do not clip on mobile.


### PR DESCRIPTION
## Summary
- add RazorDocs:CacheExpirationMinutes with documented min/max bounds
- wire DocAggregator snapshot cache policy and search-index Cache-Control max-age to the configured TTL
- add option binding, validation, cache expiry, and controller header regression coverage

Fixes #35

## Verification
- dotnet format Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj
- dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --no-restore
- git diff --check
- /review clean after merging latest origin/main