### PR TITLE
docs(razordocs): add consumer landing page

### DIFF
--- a/README.md.yml
+++ b/README.md.yml
@@ -19,6 +19,15 @@ featured_page_groups:
         path: releases/README.md
         supporting_copy: Start with the public release hub, then drill into the unreleased proof artifact, changelog, and pre-1.0 upgrade policy.
         order: 10
+  - intent: build-docs
+    label: Build docs with RazorDocs
+    summary: Use this path when you want to host authored docs and generated API reference from your own repository.
+    order: 15
+    pages:
+      - question: How do I use RazorDocs in my own repository?
+        path: Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md
+        supporting_copy: Follow the consumer landing page for the package thesis, host shape, authoring model, and adoption checklist.
+        order: 10
   - intent: see-it-working
     label: See it working
     summary: Follow concrete application paths before drilling into reference material.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRazorDocsConsumerLandingTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRazorDocsConsumerLandingTests.cs
@@ -28,7 +28,9 @@ public sealed class RepositoryRazorDocsConsumerLandingTests
         var featuredGroup = Assert.Single(
             rootLanding.Metadata?.FeaturedPageGroups ?? [],
             group => string.Equals(group.Intent, "build-docs", StringComparison.OrdinalIgnoreCase));
-        var featuredPage = Assert.Single(featuredGroup.Pages ?? []);
+        var featuredPage = Assert.Single(
+            featuredGroup.Pages ?? [],
+            page => string.Equals(page.Path, ConsumerLandingPath, StringComparison.OrdinalIgnoreCase));
         Assert.Equal("How do I use RazorDocs in my own repository?", featuredPage.Question);
         Assert.Equal(ConsumerLandingPath, featuredPage.Path);
         Assert.Contains("host shape", featuredPage.SupportingCopy);

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRazorDocsConsumerLandingTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRazorDocsConsumerLandingTests.cs
@@ -1,0 +1,36 @@
+using FakeItEasy;
+using ForgeTrust.Runnable.Web.RazorDocs.Services;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
+
+public sealed class RepositoryRazorDocsConsumerLandingTests
+{
+    private const string ConsumerLandingPath = "Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md";
+
+    [Fact]
+    public async Task ConsumerLanding_ShouldBeHarvestedAndFeaturedFromRootLanding()
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var harvester = new MarkdownHarvester(A.Fake<ILogger<MarkdownHarvester>>());
+
+        var docs = (await harvester.HarvestAsync(repoRoot)).ToList();
+
+        var rootLanding = Assert.Single(docs, doc => string.Equals(doc.Path, "README.md", StringComparison.OrdinalIgnoreCase));
+        var consumerLanding = Assert.Single(
+            docs,
+            doc => string.Equals(doc.Path, ConsumerLandingPath, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("Use RazorDocs in your repository", consumerLanding.Metadata?.Title);
+        Assert.Equal("guide", consumerLanding.Metadata?.PageType);
+        Assert.Equal("Start Here", consumerLanding.Metadata?.NavGroup);
+        Assert.Contains("RazorDocs is the documentation surface", consumerLanding.Content);
+
+        var featuredGroup = Assert.Single(
+            rootLanding.Metadata?.FeaturedPageGroups ?? [],
+            group => string.Equals(group.Intent, "build-docs", StringComparison.OrdinalIgnoreCase));
+        var featuredPage = Assert.Single(featuredGroup.Pages ?? []);
+        Assert.Equal("How do I use RazorDocs in my own repository?", featuredPage.Question);
+        Assert.Equal(ConsumerLandingPath, featuredPage.Path);
+        Assert.Contains("host shape", featuredPage.SupportingCopy);
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
@@ -6,6 +6,8 @@ Documentation site generation and hosting for Runnable web applications.
 
 `ForgeTrust.Runnable.Web.RazorDocs` is the reusable Razor Class Library package behind the RazorDocs experience. It aggregates Markdown and C# API documentation into a browsable docs UI, supports an optional version archive for published releases, and is intended to be embedded into Runnable web applications or used by the standalone RazorDocs host.
 
+If you are evaluating RazorDocs for your own repository, start with [Use RazorDocs in your repository](./use-razordocs.md). That page explains the consumer model, host shape, authoring metadata, and adoption checklist before you drill into this package reference.
+
 ## What It Provides
 
 - `RazorDocsWebModule` for wiring the docs UI into a Runnable web host

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md
@@ -1,0 +1,141 @@
+# Use RazorDocs in your repository
+
+RazorDocs is the documentation surface for a repository that wants authored guidance, working examples, and source-derived API reference in one place. It is not a separate content management system. It reads the docs and code you already keep with the product, then serves them through a navigable ASP.NET Core experience.
+
+Runnable is the first proof site. The public docs you are reading are harvested from this repository, grouped with RazorDocs metadata, searched with the built-in search index, and published from the same package a consumer can install.
+
+## When to use it
+
+Use RazorDocs when your repository has more than API reference and less than a full documentation platform team.
+
+Good fits:
+
+- A .NET library or app with package READMEs, examples, and XML-doc-commented APIs.
+- A product repo where install, upgrade, release, and troubleshooting docs need to stay close to code.
+- An internal platform where engineers need a searchable source-of-truth site instead of scattered Markdown links.
+- A docs site that should prove the package it describes by dogfooding its own renderer.
+
+Poor fits:
+
+- A marketing site where every section needs bespoke campaign design.
+- A documentation source that does not live with code and does not benefit from generated API reference.
+- A static artifact that must be edited by non-technical authors without touching Git.
+
+## The consumer model
+
+RazorDocs has three moving parts:
+
+1. **A host** that runs `RazorDocsWebModule` or the standalone RazorDocs app.
+2. **A source repository** that contains Markdown pages, package READMEs, examples, and C# source.
+3. **Metadata** that tells RazorDocs how to group, feature, search, and explain those pages.
+
+The result is a docs surface with:
+
+- section-first navigation such as Start Here, Examples, Releases, Troubleshooting, and API Reference
+- source-derived C# API pages
+- a search index that includes titles, summaries, headings, aliases, keywords, and page types
+- optional trust bars for release notes, policies, and provenance-heavy pages
+- optional `Source of truth` links back to the exact files readers should inspect or edit
+
+## Fastest path
+
+For a dedicated docs host, reference `ForgeTrust.Runnable.Web.RazorDocs` and run the module:
+
+```csharp
+await WebApp<RazorDocsWebModule>.RunAsync(args);
+```
+
+Point the host at the repository you want to harvest:
+
+```json
+{
+  "RazorDocs": {
+    "Mode": "Source",
+    "Source": {
+      "RepositoryRoot": "/path/to/repo"
+    }
+  }
+}
+```
+
+If `RazorDocs:Source:RepositoryRoot` is omitted, RazorDocs falls back to repository discovery from the app content root. That is convenient for local dogfooding, but production hosts should make the repository root explicit so the docs source is not guessed from deployment layout.
+
+## Author the first useful page set
+
+Start with pages that answer adoption questions before you tune visuals:
+
+- `README.md` for the repository-level entry point.
+- `packages/README.md` or package-level READMEs for install choices.
+- `examples/.../README.md` for runnable proof paths.
+- `releases/README.md`, `CHANGELOG.md`, or upgrade-policy pages when release risk matters.
+- Troubleshooting pages for the failure modes your users actually hit.
+
+Use sidecar metadata for portability-sensitive files such as README pages:
+
+```yaml
+# README.md.yml
+title: My Product
+summary: Start here when you need to choose the right package and prove the first workflow.
+featured_page_groups:
+  - intent: adopt
+    label: Adopt the docs package
+    summary: The shortest path from repository Markdown to a usable docs site.
+    pages:
+      - question: How do I host these docs?
+        path: docs/hosting.md
+        supporting_copy: Start with the host shape, then add metadata once the page renders.
+```
+
+Use inline front matter for ordinary authored pages when GitHub rendering is not the primary surface:
+
+```yaml
+---
+title: Troubleshoot search indexing
+summary: Fix missing or stale search results in a RazorDocs host.
+page_type: troubleshooting
+nav_group: Troubleshooting
+aliases:
+  - search index
+  - missing results
+---
+```
+
+## Curate the landing page
+
+RazorDocs does not require a bespoke homepage template for each repo. The root landing can be curated from metadata:
+
+- Put `featured_page_groups` in `README.md.yml`.
+- Group destinations by reader intent, not by folder structure.
+- Link to real harvested pages by source path.
+- Keep each row focused on the question the reader has in their head.
+
+The important part is that curation stays authored content. If the product story changes, edit Markdown or sidecar YAML. Do not fork `DocsController` to hardcode a new marketing panel.
+
+## Add reference and proof over time
+
+Once the first pages render, improve the docs in layers:
+
+1. Add XML docs to public C# APIs so generated reference pages are useful.
+2. Add `summary`, `page_type`, `nav_group`, `aliases`, and `keywords` metadata to high-traffic pages.
+3. Add troubleshooting pages for the first support questions people ask.
+4. Add release notes and trust metadata when adoption depends on upgrade confidence.
+5. Add versioned published trees only after the live source-backed docs are useful.
+
+That order matters. A beautiful archive of weak docs is still weak docs.
+
+## Adoption checklist
+
+- Pick a host: embedded Runnable web module or standalone RazorDocs app.
+- Configure `RazorDocs:Source:RepositoryRoot` for the repository to harvest.
+- Keep `RazorDocs:Mode` set to `Source` unless a later bundle-hosting slice changes that contract.
+- Add sidecar metadata for repository and package README files.
+- Feature the first consumer paths through `featured_page_groups`.
+- Verify `/docs`, `/docs/search`, and `/docs/search-index.json`.
+- Run the standalone host or export pipeline in CI before publishing a public docs surface.
+
+## Where to go next
+
+- [RazorDocs package reference](./README.md)
+- [Standalone RazorDocs host](../ForgeTrust.Runnable.Web.RazorDocs.Standalone/README.md)
+- [Package chooser](../../packages/README.md)
+- [Release hub](../../releases/README.md)

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md.yml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md.yml
@@ -1,0 +1,22 @@
+title: Use RazorDocs in your repository
+summary: Learn when to adopt RazorDocs, how to host it, and how to use authored metadata to turn repository Markdown and C# APIs into a usable docs site.
+page_type: guide
+nav_group: Start Here
+order: 15
+aliases:
+  - RazorDocs adoption
+  - repository docs
+  - docs hosting
+  - generated API reference
+keywords:
+  - RazorDocsWebModule
+  - AddRazorDocs
+  - featured_page_groups
+  - repository root
+breadcrumbs:
+  - Start Here
+  - Use RazorDocs in your repository
+related_pages:
+  - Web/ForgeTrust.Runnable.Web.RazorDocs/README.md
+  - Web/ForgeTrust.Runnable.Web.RazorDocs.Standalone/README.md
+  - packages/README.md

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -94,6 +94,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Shared RazorDocs badges, metadata chips, provenance strips, and trust bars now live in the shared package stylesheet while `search.css` stays focused on search-specific UI.
 - RazorDocs search now keeps failure recovery markup out of the active search shell until the index actually fails to load, so successful searches no longer expose hidden failure copy to text extraction tools.
 - RazorDocs now documents the namespace README merge contract with positive and negative examples, while detail-page titles wrap on narrow screens so long package names do not clip on mobile.
+- RazorDocs now has an authored consumer landing page for teams evaluating how to use RazorDocs in their own repositories, and the root docs landing features it through `featured_page_groups` instead of hardcoded controller copy.
 - RazorDocs now treats `Releases` as a first-class public section and suppresses breadcrumb links to generated parent routes that do not correspond to published docs pages, keeping static export warnings focused on actionable broken links.
 - RazorDocs wayfinding coverage now waits for docs content replacement before asserting sequence-link destinations, keeping the details-page proof path deterministic in CI.
 - RazorDocs Playwright integration coverage now hosts the standalone docs app in-process through the standalone host builder, avoiding fixture-time `dotnet run` rebuilds and stale standalone `bin` output during focused test runs.


### PR DESCRIPTION
## Summary
- Add an authored RazorDocs consumer landing page for teams evaluating repository adoption
- Feature the page from the root docs landing through existing featured_page_groups metadata
- Add a repository-harvest regression test and update unreleased notes

Fixes #126

## Validation
- dotnet format
- dotnet build
- dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj
- Local smoke: served RazorDocs standalone at http://127.0.0.1:6274 and verified /docs plus the new consumer page returned 200