### PR TITLE
docs: add Runnable evaluator start-here path

### DIFF
--- a/README.md.yml
+++ b/README.md.yml
@@ -1,6 +1,45 @@
 title: Runnable
 summary: Runnable gives .NET teams a modular startup pipeline for web, console, and distributed apps. Start with the pillar you need, then drill into concrete examples and API reference.
 featured_page_groups:
+  - intent: evaluate-runnable
+    label: Decide if Runnable fits
+    summary: Start here when you need to know whether Runnable is better than plain ASP.NET Core startup code for your app or team.
+    order: 1
+    pages:
+      - question: Should my team use Runnable?
+        path: start-here/should-i-use-runnable.md
+        supporting_copy: Compare plain ASP.NET Core with Runnable's module model before installing extra packages.
+        order: 10
+      - question: What is the evaluator path?
+        path: start-here/runnable-evaluator.md
+        supporting_copy: Follow the shortest reading path for team leads, managers, architects, and senior developers evaluating startup standardization.
+        order: 20
+  - intent: prove-first-service
+    label: Prove the first service
+    summary: Run the smallest web proof, then inspect the first reusable startup concern.
+    order: 2
+    pages:
+      - question: Can I run it in minutes?
+        path: start-here/first-success-path.md
+        supporting_copy: Start with the existing web example and verify the first response before reading deeper docs.
+        order: 10
+      - question: What does a module buy me?
+        path: guides/from-program-cs-to-module.md
+        supporting_copy: See browser status and production error page setup move from scattered startup policy to a named Runnable concern.
+        order: 20
+  - intent: recover-and-read
+    label: Recover and read the vocabulary
+    summary: Use these when the first run or first module does not behave as expected.
+    order: 3
+    pages:
+      - question: Why did startup or module composition fail?
+        path: troubleshooting/startup-and-modules.md
+        supporting_copy: Diagnose module registration, dependency, configuration, route, static asset, docs surface, and package-choice mistakes.
+        order: 10
+      - question: What do the core terms mean?
+        path: concepts/glossary.md
+        supporting_copy: Learn the vocabulary used by Runnable package docs and examples.
+        order: 20
   - intent: choose-package
     label: Choose a package
     summary: Start here when you need the smallest useful install path for a new app.

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRunnableEvaluatorDocsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRunnableEvaluatorDocsTests.cs
@@ -1,0 +1,251 @@
+using FakeItEasy;
+using ForgeTrust.Runnable.Caching;
+using ForgeTrust.Runnable.Web.RazorDocs.Models;
+using ForgeTrust.Runnable.Web.RazorDocs.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.Runnable.Web.RazorDocs.Tests;
+
+public sealed class RepositoryRunnableEvaluatorDocsTests
+{
+    private static readonly string[] EvaluatorSequence =
+    [
+        "start-here/runnable-evaluator.md",
+        "start-here/should-i-use-runnable.md",
+        "start-here/first-success-path.md",
+        "guides/from-program-cs-to-module.md"
+    ];
+
+    private static readonly string[] AuthoredPages =
+    [
+        "start-here/runnable-evaluator.md",
+        "start-here/should-i-use-runnable.md",
+        "start-here/first-success-path.md",
+        "guides/from-program-cs-to-module.md",
+        "troubleshooting/startup-and-modules.md",
+        "concepts/glossary.md"
+    ];
+
+    [Fact]
+    public async Task EvaluatorDocs_ShouldBeHarvestedWithMetadata_AndFeaturedFromRootLanding()
+    {
+        var docs = await HarvestRepositoryDocsAsync();
+        var rootLanding = SingleDoc(docs, "README.md");
+
+        foreach (var path in AuthoredPages)
+        {
+            var doc = SingleDoc(docs, path);
+
+            Assert.NotNull(doc.Metadata);
+            Assert.False(string.IsNullOrWhiteSpace(doc.Metadata.Title));
+            Assert.False(string.IsNullOrWhiteSpace(doc.Metadata.Summary));
+            Assert.False(string.IsNullOrWhiteSpace(doc.Metadata.PageType));
+            Assert.False(string.IsNullOrWhiteSpace(doc.Metadata.NavGroup));
+            Assert.NotEmpty(doc.Metadata.Aliases ?? []);
+            Assert.NotEmpty(doc.Metadata.Keywords ?? []);
+            Assert.NotNull(doc.Metadata.Order);
+        }
+
+        AssertEvaluatorSequenceMetadata(docs);
+
+        var groups = rootLanding.Metadata?.FeaturedPageGroups ?? [];
+        AssertIntentOrder(groups, "evaluate-runnable", "prove-first-service", "recover-and-read");
+        Assert.Contains(groups, group => string.Equals(group.Intent, "choose-package", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(groups, group => string.Equals(group.Intent, "evaluate-release", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(groups, group => string.Equals(group.Intent, "build-docs", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(groups, group => string.Equals(group.Intent, "see-it-working", StringComparison.OrdinalIgnoreCase));
+
+        AssertFeaturedPage(groups, "evaluate-runnable", "start-here/should-i-use-runnable.md");
+        AssertFeaturedPage(groups, "evaluate-runnable", "start-here/runnable-evaluator.md");
+        AssertFeaturedPage(groups, "prove-first-service", "start-here/first-success-path.md");
+        AssertFeaturedPage(groups, "prove-first-service", "guides/from-program-cs-to-module.md");
+        AssertFeaturedPage(groups, "recover-and-read", "troubleshooting/startup-and-modules.md");
+        AssertFeaturedPage(groups, "recover-and-read", "concepts/glossary.md");
+    }
+
+    [Fact]
+    public async Task EvaluatorDocs_ShouldResolveSequenceRelatedPages_AndSearchMetadata()
+    {
+        var docs = await HarvestRepositoryDocsAsync();
+        var aggregator = CreateAggregator(docs);
+
+        await AssertSequenceAsync(aggregator);
+        await AssertRelatedPagesAsync(aggregator);
+
+        var searchIndex = await aggregator.GetSearchIndexPayloadAsync();
+
+        AssertSearchMetadata(
+            searchIndex,
+            "start-here/should-i-use-runnable.md",
+            aliases: ["plain ASP.NET Core"],
+            keywords: []);
+        AssertSearchMetadata(
+            searchIndex,
+            "guides/from-program-cs-to-module.md",
+            aliases: ["Program.cs", "status pages"],
+            keywords: ["WebOptions.Errors"]);
+        AssertSearchMetadata(
+            searchIndex,
+            "start-here/runnable-evaluator.md",
+            aliases: ["startup standardization"],
+            keywords: []);
+        AssertSearchMetadata(
+            searchIndex,
+            "troubleshooting/startup-and-modules.md",
+            aliases: ["module did not run"],
+            keywords: []);
+    }
+
+    private static async Task<IReadOnlyList<DocNode>> HarvestRepositoryDocsAsync()
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var harvester = new MarkdownHarvester(A.Fake<ILogger<MarkdownHarvester>>());
+
+        return (await harvester.HarvestAsync(repoRoot)).ToList();
+    }
+
+    private static DocAggregator CreateAggregator(IReadOnlyList<DocNode> docs)
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var harvester = A.Fake<IDocHarvester>();
+        var environment = A.Fake<IWebHostEnvironment>();
+        var sanitizer = A.Fake<IRazorDocsHtmlSanitizer>();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var memo = new Memo(cache);
+
+        A.CallTo(() => harvester.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(docs);
+        A.CallTo(() => environment.ContentRootPath).Returns(repoRoot);
+        A.CallTo(() => sanitizer.Sanitize(A<string>._)).ReturnsLazily((string input) => input);
+
+        return new DocAggregator(
+            [harvester],
+            new RazorDocsOptions
+            {
+                Source = new RazorDocsSourceOptions
+                {
+                    RepositoryRoot = repoRoot
+                }
+            },
+            environment,
+            memo,
+            sanitizer,
+            A.Fake<ILogger<DocAggregator>>());
+    }
+
+    private static DocNode SingleDoc(IReadOnlyList<DocNode> docs, string path)
+    {
+        return Assert.Single(docs, doc => string.Equals(doc.Path, path, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void AssertEvaluatorSequenceMetadata(IReadOnlyList<DocNode> docs)
+    {
+        for (var index = 0; index < EvaluatorSequence.Length; index++)
+        {
+            var doc = SingleDoc(docs, EvaluatorSequence[index]);
+
+            Assert.Equal("runnable-evaluator", doc.Metadata?.SequenceKey);
+            Assert.Equal((index + 1) * 10, doc.Metadata?.Order);
+        }
+
+        Assert.Null(SingleDoc(docs, "troubleshooting/startup-and-modules.md").Metadata?.SequenceKey);
+        Assert.Null(SingleDoc(docs, "concepts/glossary.md").Metadata?.SequenceKey);
+    }
+
+    private static void AssertIntentOrder(
+        IReadOnlyList<DocFeaturedPageGroupDefinition> groups,
+        params string[] expectedLeadingIntents)
+    {
+        var actualLeadingIntents = groups
+            .Take(expectedLeadingIntents.Length)
+            .Select(group => group.Intent)
+            .ToArray();
+
+        Assert.Equal(expectedLeadingIntents, actualLeadingIntents);
+    }
+
+    private static void AssertFeaturedPage(
+        IReadOnlyList<DocFeaturedPageGroupDefinition> groups,
+        string intent,
+        string path)
+    {
+        var group = Assert.Single(
+            groups,
+            item => string.Equals(item.Intent, intent, StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(
+            group.Pages ?? [],
+            page => string.Equals(page.Path, path, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static async Task AssertSequenceAsync(DocAggregator aggregator)
+    {
+        var evaluator = await aggregator.GetDocDetailsAsync("start-here/runnable-evaluator.md");
+        Assert.NotNull(evaluator);
+        Assert.Null(evaluator!.PreviousPage);
+        Assert.Equal("/docs/start-here/should-i-use-runnable.md.html", evaluator.NextPage?.Href);
+
+        var decision = await aggregator.GetDocDetailsAsync("start-here/should-i-use-runnable.md");
+        Assert.NotNull(decision);
+        Assert.Equal("/docs/start-here/runnable-evaluator.md.html", decision!.PreviousPage?.Href);
+        Assert.Equal("/docs/start-here/first-success-path.md.html", decision.NextPage?.Href);
+
+        var firstSuccess = await aggregator.GetDocDetailsAsync("start-here/first-success-path.md");
+        Assert.NotNull(firstSuccess);
+        Assert.Equal("/docs/start-here/should-i-use-runnable.md.html", firstSuccess!.PreviousPage?.Href);
+        Assert.Equal("/docs/guides/from-program-cs-to-module.md.html", firstSuccess.NextPage?.Href);
+
+        var proof = await aggregator.GetDocDetailsAsync("guides/from-program-cs-to-module.md");
+        Assert.NotNull(proof);
+        Assert.Equal("/docs/start-here/first-success-path.md.html", proof!.PreviousPage?.Href);
+        Assert.Null(proof.NextPage);
+    }
+
+    private static async Task AssertRelatedPagesAsync(DocAggregator aggregator)
+    {
+        var proof = await aggregator.GetDocDetailsAsync("guides/from-program-cs-to-module.md");
+        Assert.NotNull(proof);
+        AssertRelatedHref(proof!, "/docs/Web/ForgeTrust.Runnable.Web/README.md.html");
+        AssertRelatedHref(proof!, "/docs/ForgeTrust.Runnable.Core/README.md.html");
+
+        var troubleshooting = await aggregator.GetDocDetailsAsync("troubleshooting/startup-and-modules.md");
+        Assert.NotNull(troubleshooting);
+        AssertRelatedHref(troubleshooting!, "/docs/examples/config-validation/README.md.html");
+        AssertRelatedHref(troubleshooting!, "/docs/ForgeTrust.Runnable.Core/README.md.html");
+        AssertRelatedHref(troubleshooting!, "/docs/packages/README.md.html");
+
+        var glossary = await aggregator.GetDocDetailsAsync("concepts/glossary.md");
+        Assert.NotNull(glossary);
+        AssertRelatedHref(glossary!, "/docs/ForgeTrust.Runnable.Core/README.md.html");
+        AssertRelatedHref(glossary!, "/docs/Web/ForgeTrust.Runnable.Web/README.md.html");
+    }
+
+    private static void AssertRelatedHref(DocDetailsViewModel details, string expectedHref)
+    {
+        Assert.Contains(
+            details.RelatedPages,
+            page => string.Equals(page.Href, expectedHref, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void AssertSearchMetadata(
+        DocsSearchIndexPayload payload,
+        string sourcePath,
+        IReadOnlyList<string> aliases,
+        IReadOnlyList<string> keywords)
+    {
+        var document = Assert.Single(
+            payload.Documents,
+            doc => doc.Path.EndsWith(sourcePath, StringComparison.OrdinalIgnoreCase));
+
+        foreach (var alias in aliases)
+        {
+            Assert.Contains(document.Aliases, item => string.Equals(item, alias, StringComparison.OrdinalIgnoreCase));
+        }
+
+        foreach (var keyword in keywords)
+        {
+            Assert.Contains(document.Keywords, item => string.Equals(item, keyword, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRunnableEvaluatorDocsTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/RepositoryRunnableEvaluatorDocsTests.cs
@@ -71,6 +71,7 @@ public sealed class RepositoryRunnableEvaluatorDocsTests
         var docs = await HarvestRepositoryDocsAsync();
         var aggregator = CreateAggregator(docs);
 
+        await AssertStartHereLandingAndOrderAsync(aggregator);
         await AssertSequenceAsync(aggregator);
         await AssertRelatedPagesAsync(aggregator);
 
@@ -151,6 +152,34 @@ public sealed class RepositoryRunnableEvaluatorDocsTests
 
         Assert.Null(SingleDoc(docs, "troubleshooting/startup-and-modules.md").Metadata?.SequenceKey);
         Assert.Null(SingleDoc(docs, "concepts/glossary.md").Metadata?.SequenceKey);
+    }
+
+    private static async Task AssertStartHereLandingAndOrderAsync(DocAggregator aggregator)
+    {
+        var sections = await aggregator.GetPublicSectionsAsync();
+        var startHere = Assert.Single(
+            sections,
+            section => section.Section == DocPublicSection.StartHere);
+
+        Assert.Equal("start-here/runnable-evaluator.md", startHere.LandingDoc?.Path);
+        Assert.Equal(
+            [
+                "start-here/runnable-evaluator.md",
+                "start-here/should-i-use-runnable.md",
+                "start-here/first-success-path.md",
+                "packages/README.md",
+                "Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md"
+            ],
+            startHere.VisiblePages
+                .Where(doc =>
+                    doc.Path.StartsWith("start-here/", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(doc.Path, "packages/README.md", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(
+                        doc.Path,
+                        "Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md",
+                        StringComparison.OrdinalIgnoreCase))
+                .Select(doc => doc.Path)
+                .ToArray());
     }
 
     private static void AssertIntentOrder(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md.yml
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/use-razordocs.md.yml
@@ -2,7 +2,7 @@ title: Use RazorDocs in your repository
 summary: Learn when to adopt RazorDocs, how to host it, and how to use authored metadata to turn repository Markdown and C# APIs into a usable docs site.
 page_type: guide
 nav_group: Start Here
-order: 15
+order: 60
 aliases:
   - RazorDocs adoption
   - repository docs

--- a/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/RazorDocsLandingPlaywrightTests.cs
@@ -35,15 +35,33 @@ public sealed class RazorDocsLandingPlaywrightTests
         Assert.DoesNotContain(
             "Welcome to the technical documentation.",
             await page.InnerTextAsync("body"));
-        Assert.Equal("/docs/packages/README.md.html", await page.GetAttributeAsync("main a.group", "href"));
+        Assert.Equal("/docs/start-here/should-i-use-runnable.md.html", await page.GetAttributeAsync("main a.group", "href"));
 
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/start-here/should-i-use-runnable.md.html",
+            "Should my team use Runnable?",
+            "Should I Use Runnable?",
+            "GUIDE");
+
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/start-here/runnable-evaluator.md.html",
+            "What is the evaluator path?",
+            "Start Here for Runnable Evaluators",
+            "GUIDE");
+        await AssertFeaturedCardAsync(
+            page,
+            "/docs/start-here/first-success-path.md.html",
+            "Can I run it in minutes?",
+            "First Success Path",
+            "TUTORIAL");
         await AssertFeaturedCardAsync(
             page,
             "/docs/packages/README.md.html",
             "Which Runnable package should I install first?",
             "Runnable v0.1 package chooser",
             "GUIDE");
-
         await AssertFeaturedCardAsync(
             page,
             "/docs/releases/README.md.html",

--- a/concepts/glossary.md
+++ b/concepts/glossary.md
@@ -1,0 +1,53 @@
+# Runnable Glossary
+
+This glossary defines the terms needed to read the Runnable package docs and examples. Package READMEs remain the source of truth for full API behavior.
+
+## RunnableStartup
+
+`RunnableStartup` is the startup pipeline that composes modules on top of the .NET Generic Host. Use the package-specific entry points, such as `WebApp<TModule>`, unless you need deeper host customization.
+
+## Root Module
+
+The root module is the module type passed to a Runnable entry point. It is the starting point for module composition.
+
+Example:
+
+```csharp
+await WebApp<ExampleModule>.RunAsync(args);
+```
+
+`ExampleModule` is the root module.
+
+## Dependent Module
+
+A dependent module is another module registered by a module through `RegisterDependentModules`. Use dependencies when one module needs another module's services, options, middleware, endpoints, or host behavior.
+
+## Host Module
+
+A host module participates in .NET host setup through the core module lifecycle. `IRunnableHostModule` is the core contract for modules that can configure services and host behavior.
+
+## StartupContext
+
+`StartupContext` carries startup metadata such as the app label, host application identity, application discovery assembly, environment, and console output mode.
+
+Keep display labels and host identity separate. Static web assets use host identity, not the label you want to show to users.
+
+## Package Module
+
+A package module is a Runnable module shipped by a package, such as the Web, Console, Aspire, or optional web modules. Install package modules only when the [package chooser](../packages/README.md) says they match the app.
+
+## Web Module
+
+A web module participates in ASP.NET Core startup through `IRunnableWebModule`. It can configure web options, register middleware, and map endpoints.
+
+The base web package is [ForgeTrust.Runnable.Web](../Web/ForgeTrust.Runnable.Web/README.md).
+
+## Console Startup
+
+Console startup is the Runnable path for CLI commands and worker-style processes. Start with the [Console package docs](../Console/ForgeTrust.Runnable.Console/README.md) when the app is command-oriented instead of web-oriented.
+
+## Package Chooser
+
+The package chooser is the generated install map for the coordinated Runnable package family. Use it before adding optional modules.
+
+Read it here: [Runnable v0.1 package chooser](../packages/README.md)

--- a/concepts/glossary.md.yml
+++ b/concepts/glossary.md.yml
@@ -1,0 +1,18 @@
+title: Runnable Glossary
+summary: Define the core Runnable terms used by package docs, examples, and the evaluator path.
+page_type: glossary
+nav_group: Concepts
+order: 40
+aliases:
+  - RunnableStartup
+  - root module
+  - StartupContext
+  - host module
+keywords:
+  - IRunnableModule
+  - IRunnableHostModule
+  - WebApp
+  - package chooser
+related_pages:
+  - ForgeTrust.Runnable.Core/README.md
+  - Web/ForgeTrust.Runnable.Web/README.md

--- a/guides/from-program-cs-to-module.md
+++ b/guides/from-program-cs-to-module.md
@@ -1,0 +1,81 @@
+# From Program.cs to a Runnable Module
+
+The clearest Runnable proof is not a smaller `Program.cs`. It is a startup policy that becomes named, tested, and reusable.
+
+This page uses browser status pages and production error pages from `ForgeTrust.Runnable.Web` as that proof.
+
+## Plain ASP.NET Core Baseline
+
+ASP.NET Core can handle this directly. A small app can use built-in status-code pages, exception handling, Problem Details, endpoint handlers, or custom middleware.
+
+That baseline is correct when the policy is local and obvious.
+
+The cost appears when several services must remember the same details:
+
+- Which requests should get browser HTML instead of API-friendly behavior?
+- Which status codes have conventional pages?
+- Which route previews are safe for checking the pages?
+- Which production `500` page avoids leaking exception details?
+- Where does each service document the convention?
+
+Plain ASP.NET Core gives you the primitives. Runnable gives the team one named place to express the convention.
+
+## Runnable Module Version
+
+Runnable Web exposes the concern through `WebOptions.Errors`.
+
+```csharp
+public void ConfigureWebOptions(StartupContext context, WebOptions options)
+{
+    options.Mvc = options.Mvc with
+    {
+        MvcSupportLevel = MvcSupport.Controllers
+    };
+
+    options.Errors.UseConventionalBrowserStatusPages();
+    options.Errors.UseConventionalExceptionPage();
+}
+```
+
+The browser status page call enables conventional browser-facing pages for empty `401`, `403`, and `404` responses. The production exception page call enables a generic browser-facing `500` page for unhandled exceptions.
+
+These are separate features. Status-code pages do not catch thrown exceptions.
+
+## Behavior Contract
+
+Runnable Web verifies this behavior in package tests:
+
+```bash
+dotnet test Web/ForgeTrust.Runnable.Web.Tests/ForgeTrust.Runnable.Web.Tests.csproj --filter "BrowserStatusPageTests|ConventionalExceptionPageTests"
+```
+
+The source-of-truth test classes are:
+
+- `Web/ForgeTrust.Runnable.Web.Tests/BrowserStatusPageTests.cs`
+- `Web/ForgeTrust.Runnable.Web.Tests/ConventionalExceptionPageTests.cs`
+
+Those tests cover the HTTP contract this page relies on:
+
+- Browser requests to empty supported status responses render recovery-oriented HTML and preserve the original status.
+- Direct preview routes such as `/_runnable/errors/404` render the conventional page.
+- JSON and non-HTML requests do not receive browser HTML.
+- Production exception pages return a generic `500` page for browser requests.
+- The generic `500` page includes a request id but not exception messages, stack traces, headers, cookies, route values, or form fields.
+- JSON requests to throwing endpoints do not render the conventional HTML exception page.
+
+## What The Module Buys
+
+The value is not that ASP.NET Core cannot do this. It can.
+
+The value is that a team can point service owners at one module-level behavior contract instead of copying a `Program.cs` block and hoping every service keeps the same edge cases.
+
+For a single service, this is useful when the error posture is important enough to name. Across several services, it becomes a standard.
+
+## Pitfalls
+
+- Do not enable browser pages for API-only behavior that should stay JSON or Problem Details.
+- Do not expose exception details on production `500` pages.
+- Do not assume status-code pages catch thrown exceptions. They handle empty status responses; exception handling is a separate pipeline.
+- Do not duplicate the full Web package reference here. Use the [Runnable Web README](../Web/ForgeTrust.Runnable.Web/README.md) for the full API shape.
+
+Next recovery path: [Troubleshoot Startup and Modules](../troubleshooting/startup-and-modules.md)

--- a/guides/from-program-cs-to-module.md.yml
+++ b/guides/from-program-cs-to-module.md.yml
@@ -1,0 +1,20 @@
+title: From Program.cs to a Runnable Module
+summary: See browser status pages and production error pages move from local startup policy to a named Runnable Web behavior contract.
+page_type: guide
+nav_group: How-to Guides
+sequence_key: runnable-evaluator
+order: 40
+aliases:
+  - Program.cs
+  - error pages
+  - status pages
+  - module extraction
+keywords:
+  - UseConventionalBrowserStatusPages
+  - UseConventionalExceptionPage
+  - WebOptions.Errors
+  - BrowserStatusPageMode
+related_pages:
+  - Web/ForgeTrust.Runnable.Web/README.md
+  - ForgeTrust.Runnable.Core/README.md
+  - start-here/should-i-use-runnable.md

--- a/packages/README.md.yml
+++ b/packages/README.md.yml
@@ -2,8 +2,7 @@ title: Runnable v0.1 package chooser
 summary: Start with the package that matches the app you are building, then add optional web modules and support surfaces only when you need them.
 page_type: guide
 nav_group: Start Here
-order: 5
-section_landing: true
+order: 50
 breadcrumbs:
   - Start Here
   - Packages

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -20,6 +20,7 @@ Runnable is putting the release contract in place before `v0.1.0`. This slice is
 - Runnable now ships a public release hub, a changelog, an unreleased page, and a tagged release template inside the repository.
 - Release-note pages can show status, freshness, scope, migration guidance, and provenance in a shared trust bar instead of bespoke page chrome.
 - Runnable now ships a generated package chooser that tells first-time adopters which package to install first, which optional modules to add next, and which proof paths to follow for release risk and working examples.
+- The public docs Start Here path now leads with a Runnable evaluator sequence for teams comparing module-based startup against plain ASP.NET Core `Program.cs` configuration.
 - The root README now has a single hello-world quickstart that starts the smallest web example on an explicit port and proves the response with `curl`.
 
 ### Contribution contract

--- a/start-here/first-success-path.md
+++ b/start-here/first-success-path.md
@@ -1,0 +1,53 @@
+# First Success Path
+
+Run the smallest web example first. Do not install optional packages yet.
+
+From the repository root:
+
+```bash
+dotnet run --project examples/web-app -- --port 5055
+```
+
+Then open <http://127.0.0.1:5055> or run:
+
+```bash
+curl http://127.0.0.1:5055
+```
+
+Expected response:
+
+```text
+Hello World from the root!
+```
+
+That proves the base `ForgeTrust.Runnable.Web` path: a root module, the Runnable startup pipeline, and one mapped endpoint.
+
+## What This Example Shows
+
+The example uses `WebApp<ExampleModule>.RunAsync(...)` and maps the root endpoint from web options. The module also contributes its own endpoint at `/module`.
+
+Try it:
+
+```bash
+curl http://127.0.0.1:5055/module
+```
+
+Expected response:
+
+```text
+Hello from the example module!
+```
+
+## What This Example Does Not Prove
+
+This first run does not prove the status-page behavior used later in the evaluator path. It only proves the base web host starts and the module contributes behavior.
+
+For the status-page proof, read [From Program.cs to a Runnable Module](../guides/from-program-cs-to-module.md). That page points at the Web package behavior and the tests that verify browser status pages and production exception pages.
+
+## Pitfalls
+
+- Pass `--port 5055` when following docs. Without it, Runnable may choose a deterministic development port for your worktree.
+- Start with `ForgeTrust.Runnable.Web` for a normal web app. Add optional modules only when the [package chooser](../packages/README.md) points to them.
+- Treat the startup log as the source of truth if you choose a different port.
+
+Next: [From Program.cs to a Runnable Module](../guides/from-program-cs-to-module.md)

--- a/start-here/first-success-path.md.yml
+++ b/start-here/first-success-path.md.yml
@@ -1,0 +1,19 @@
+title: First Success Path
+summary: Run the existing minimal web example and verify the first response before reading deeper docs.
+page_type: tutorial
+nav_group: Start Here
+sequence_key: runnable-evaluator
+order: 30
+aliases:
+  - quickstart
+  - first run
+  - hello world
+keywords:
+  - WebApp
+  - root module
+  - dotnet run
+  - examples/web-app
+related_pages:
+  - examples/web-app/README.md
+  - Web/ForgeTrust.Runnable.Web/README.md
+  - guides/from-program-cs-to-module.md

--- a/start-here/runnable-evaluator.md
+++ b/start-here/runnable-evaluator.md
@@ -1,0 +1,41 @@
+# Start Here for Runnable Evaluators
+
+Use this path when you need to decide whether Runnable belongs in an ASP.NET Core service or across a set of services.
+
+The target reader is a team lead, engineering manager, architect, or senior developer who owns startup consistency. You may be evaluating from one service first. That is fine. The question is still the same: when does a named Runnable module make startup clearer than keeping the setup directly in `Program.cs`?
+
+## The Short Path
+
+1. Read [Should I Use Runnable?](should-i-use-runnable.md) to decide whether plain ASP.NET Core is still enough.
+2. Run [First Success Path](first-success-path.md) to prove the smallest web app starts.
+3. Read [From Program.cs to a Runnable Module](../guides/from-program-cs-to-module.md) to inspect one concrete startup concern as a module.
+4. Keep [Troubleshoot Startup and Modules](../troubleshooting/startup-and-modules.md) nearby if the first run or module composition does not behave as expected.
+5. Use the [Runnable Glossary](../concepts/glossary.md) when a term in package docs is unfamiliar.
+
+## What Runnable Is
+
+Runnable is a small module composition layer over familiar .NET and ASP.NET Core primitives. It does not replace the host, middleware, routing, dependency injection, or options model.
+
+Runnable gives you a place to name startup concerns. A module can register services, configure host behavior, configure web options, register middleware, and map endpoints through one documented surface.
+
+Start with the [package chooser](../packages/README.md) when you need an install path. Start with this evaluator path when you need the adoption argument.
+
+## What To Look For
+
+Look for a setup concern that is repeated, safety-sensitive, or easy to configure differently in each service.
+
+Good early candidates look like this:
+
+- Each service needs the same browser-facing recovery behavior.
+- Each service needs the same API-friendly exception or status behavior.
+- A team wants the same startup convention without copying a block of `Program.cs`.
+- A setup concern has enough policy that it deserves a name, tests, and reference docs.
+
+Runnable is not valuable because `Program.cs` is bad. It is valuable when `Program.cs` is carrying a policy that your team should understand, reuse, and verify.
+
+## Common Pitfalls
+
+- Do not install every optional Runnable package first. Pick the package that matches the app.
+- Do not hide ASP.NET Core. Runnable should make the underlying ASP.NET Core behavior easier to find, not harder.
+- Do not turn a one-off local choice into a shared module too early. Name the concern when the policy matters.
+- Do not compare Runnable against large application frameworks in this Start Here path. The first comparison is plain ASP.NET Core startup code.

--- a/start-here/runnable-evaluator.md.yml
+++ b/start-here/runnable-evaluator.md.yml
@@ -3,6 +3,7 @@ summary: Follow the shortest path for deciding whether Runnable fits an ASP.NET 
 page_type: guide
 nav_group: Start Here
 sequence_key: runnable-evaluator
+section_landing: true
 order: 10
 aliases:
   - Runnable evaluator

--- a/start-here/runnable-evaluator.md.yml
+++ b/start-here/runnable-evaluator.md.yml
@@ -1,0 +1,21 @@
+title: Start Here for Runnable Evaluators
+summary: Follow the shortest path for deciding whether Runnable fits an ASP.NET Core app or a team-wide startup standard.
+page_type: guide
+nav_group: Start Here
+sequence_key: runnable-evaluator
+order: 10
+aliases:
+  - Runnable evaluator
+  - team standard
+  - startup standardization
+  - plain ASP.NET Core
+keywords:
+  - Program.cs
+  - modules
+  - startup
+  - team lead
+  - architect
+related_pages:
+  - start-here/should-i-use-runnable.md
+  - start-here/first-success-path.md
+  - packages/README.md

--- a/start-here/should-i-use-runnable.md
+++ b/start-here/should-i-use-runnable.md
@@ -1,0 +1,42 @@
+# Should I Use Runnable?
+
+Start with plain ASP.NET Core. Reach for Runnable when a startup concern is important enough to name, test, document, and reuse.
+
+That rule works for one service and for many services. A single `Program.cs` can still benefit when the setup is complex, safety-sensitive, or easy to get wrong. The value becomes more obvious when the same concern appears across several services.
+
+## Decision Matrix
+
+| Situation | Plain ASP.NET Core is enough | Runnable helps |
+| --- | --- | --- |
+| One small service has a simple startup file | Keep the code in `Program.cs`. | Not needed yet. |
+| One service has setup policy that is hard to read or easy to misorder | Still possible, especially with local extension methods. | Name the policy as a module and test the behavior. |
+| Several services copy the same startup block | Works, but drift is likely. | Put the shared convention behind one module contract. |
+| A team needs onboarding docs for startup behavior | The docs must explain local code in each app. | The docs can point to one module and its behavior contract. |
+| The app needs custom low-level host behavior | Plain ASP.NET Core gives full control. | Use Runnable only if the module hook makes the policy clearer. |
+
+## Use Plain ASP.NET Core When
+
+- The setup is short, local, and obvious.
+- The behavior belongs to only one app.
+- The app already has a clear extension method or startup convention.
+- A module would make the code harder to trace.
+
+This is not a failure. ASP.NET Core already has excellent primitives for middleware, routing, options, status pages, exception handling, and dependency injection.
+
+## Use Runnable When
+
+- The setup has a name your team uses in conversation.
+- The setup must behave the same way across services.
+- The setup has sharp edges that deserve tests.
+- The setup should live near package docs rather than inside each app's `Program.cs`.
+- A team lead needs one documented startup convention that service owners can follow.
+
+The first proof in this docs path is browser status pages and production error pages. ASP.NET Core can handle those directly. Runnable helps when the team wants one named behavior contract for browser HTML, API-friendly responses, preview routes, and safe production `500` pages.
+
+## Pitfalls
+
+- Do not adopt Runnable to avoid learning ASP.NET Core. You still need to understand the host, middleware, routing, and options model.
+- Do not standardize a concern before it has a real policy. A module with no policy is just indirection.
+- Do not compare this Start Here path against larger frameworks. The honest first question is whether Runnable is clearer than the plain ASP.NET Core startup code your team would otherwise write.
+
+Next: [First Success Path](first-success-path.md)

--- a/start-here/should-i-use-runnable.md.yml
+++ b/start-here/should-i-use-runnable.md.yml
@@ -1,0 +1,18 @@
+title: Should I Use Runnable?
+summary: Decide when plain ASP.NET Core startup code is enough and when a Runnable module makes a setup concern clearer.
+page_type: guide
+nav_group: Start Here
+sequence_key: runnable-evaluator
+order: 20
+aliases:
+  - plain ASP.NET Core
+  - why Runnable
+  - use Runnable
+keywords:
+  - baseline
+  - startup glue
+  - module
+  - Program.cs
+related_pages:
+  - start-here/runnable-evaluator.md
+  - guides/from-program-cs-to-module.md

--- a/troubleshooting/startup-and-modules.md
+++ b/troubleshooting/startup-and-modules.md
@@ -1,0 +1,106 @@
+# Troubleshoot Startup and Modules
+
+Use this page when the first run or first module does not behave as expected.
+
+Each section gives the symptom, likely cause, check, and fix. Start with the visible symptom. Startup failures often look like docs, route, or package issues at first, but the root cause is usually module registration, dependency order, configuration, or package choice.
+
+## Module Did Not Run
+
+### Symptom
+
+The app starts, but the service, middleware, endpoint, or option your module owns is missing.
+
+### Likely Cause
+
+The root module did not register the module, or the app is running a different root module than the one you edited.
+
+### Check
+
+Find the root module passed to `WebApp<TModule>`, `ConsoleApp<TModule>`, or `RunnableStartup<TModule>`. Then check `RegisterDependentModules`.
+
+### Fix
+
+Register the missing module through `ModuleDependencyBuilder`, or move the behavior into the root module if it is truly app-local.
+
+## Dependency Module Did Not Register
+
+### Symptom
+
+A module runs, but a service or option from another module is missing.
+
+### Likely Cause
+
+The module assumes another Runnable module is present but does not declare that dependency.
+
+### Check
+
+Search for the service or option owner. If it lives in another module, the consuming module should register that dependency in `RegisterDependentModules`.
+
+### Fix
+
+Add the dependency module explicitly. Do not duplicate the dependency module's service registrations in the consuming module.
+
+## Configuration Failed At Startup
+
+### Symptom
+
+Startup exits before the app begins listening, often with a configuration validation message.
+
+### Likely Cause
+
+A strongly typed configuration value is missing or outside its allowed range.
+
+### Check
+
+Run the config validation example to see the expected failure shape:
+
+```bash
+dotnet run --project examples/config-validation
+```
+
+The error should name the key and rule without printing the attempted value.
+
+### Fix
+
+Set the missing value, correct the value, or relax the validation rule if the module contract was too strict.
+
+Do not print configuration values while debugging. They may contain secrets.
+
+## Web Route, Static Asset, Or Docs Surface Is Missing
+
+### Symptom
+
+A web route returns `404`, a static asset is missing, or the docs surface does not appear where expected.
+
+### Likely Cause
+
+The wrong module is registered, the app's host identity is not the assembly that owns static web assets, or the docs route root is not the one you are opening.
+
+### Check
+
+- Confirm the expected web module is registered.
+- Confirm the startup log shows the URL you are opening.
+- For RazorDocs, check whether the app is mounted at `/docs` or a configured docs root.
+- For static web assets in custom hosts, check `StartupContext.HostApplicationName` and `StartupContext.OverrideEntryPointAssembly`.
+
+### Fix
+
+Use the app's logged URL and configured docs root. When a custom host needs a different assembly identity, set `StartupContext.OverrideEntryPointAssembly` instead of overloading the display name.
+
+## Wrong Package Installed First
+
+### Symptom
+
+The app has extra packages, but the first example still does not map to the kind of app you are building.
+
+### Likely Cause
+
+An optional package was installed before the base package or the package chooser was skipped.
+
+### Check
+
+Read the [Runnable v0.1 package chooser](../packages/README.md). Start with the package that matches the app type.
+
+### Fix
+
+For a normal ASP.NET Core app, start with `ForgeTrust.Runnable.Web`. Add optional packages such as OpenAPI, Scalar, RazorWire, Tailwind, or RazorDocs only when the app needs them.

--- a/troubleshooting/startup-and-modules.md.yml
+++ b/troubleshooting/startup-and-modules.md.yml
@@ -1,0 +1,19 @@
+title: Troubleshoot Startup and Modules
+summary: Diagnose first-run module registration, dependency, configuration, route, static asset, docs surface, and package-choice failures.
+page_type: troubleshooting
+nav_group: Troubleshooting
+order: 10
+aliases:
+  - module did not run
+  - dependency module
+  - config failed
+  - wrong package
+keywords:
+  - StartupContext
+  - IRunnableModule
+  - dependency
+  - configuration
+related_pages:
+  - examples/config-validation/README.md
+  - ForgeTrust.Runnable.Core/README.md
+  - packages/README.md


### PR DESCRIPTION
## Summary
- Adds a Start Here evaluator path for team leads, managers, and architects comparing Runnable to plain ASP.NET Core startup patterns.
- Makes the Runnable evaluator page the Start Here section landing page and moves package/RazorDocs adoption after the evaluator sequence.
- Adds docs and Playwright coverage for section landing order and featured cards.

## Validation
- dotnet test Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj
- dotnet test Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --filter "RazorDocsLandingPlaywrightTests.Landing_UsesFeaturedPagesFromRootReadme"
- dotnet format Web/ForgeTrust.Runnable.Web.RazorDocs.Tests/ForgeTrust.Runnable.Web.RazorDocs.Tests.csproj --no-restore
- dotnet format Web/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests/ForgeTrust.Runnable.Web.RazorWire.IntegrationTests.csproj --no-restore
- git diff --check
- Live smoke: /docs/sections/start-here resolves to /docs/start-here/runnable-evaluator.md.html

Fixes #107