### PR TITLE
docs(razordocs): clarify test exclusion patterns

### DIFF
--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/HarvestPathExclusions.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/HarvestPathExclusions.cs
@@ -46,7 +46,8 @@ internal static class HarvestPathExclusions
     /// Directory names that should always be excluded in addition to the shared hidden-directory behavior.
     /// </param>
     /// <param name="excludeTestProjectDirectories">
-    /// When <c>true</c>, also excludes project-style test directory names such as <c>*.Tests</c> and <c>*Tests</c>.
+    /// When <c>true</c>, also excludes project-style test directory names such as <c>*.Tests</c>,
+    /// <c>*.UnitTests</c>, <c>*-Tests</c>, and <c>*_Tests</c>.
     /// </param>
     /// <returns><c>true</c> if the file should be excluded; otherwise, <c>false</c>.</returns>
     internal static bool ShouldExcludeFilePath(

--- a/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/HarvestPathExclusions.cs
+++ b/Web/ForgeTrust.Runnable.Web.RazorDocs/Services/HarvestPathExclusions.cs
@@ -46,8 +46,11 @@ internal static class HarvestPathExclusions
     /// Directory names that should always be excluded in addition to the shared hidden-directory behavior.
     /// </param>
     /// <param name="excludeTestProjectDirectories">
-    /// When <c>true</c>, also excludes project-style test directory names such as <c>*.Tests</c>,
-    /// <c>*.UnitTests</c>, <c>*-Tests</c>, and <c>*_Tests</c>.
+    /// When <c>true</c>, also excludes test-project directory segments by case-insensitive exact names
+    /// (<c>Test</c>, <c>Tests</c>, <c>UnitTests</c>, <c>IntegrationTests</c>, <c>FunctionalTests</c>,
+    /// <c>E2ETests</c>) and case-insensitive suffix patterns (<c>*.Tests</c>, <c>*.UnitTests</c>,
+    /// <c>*.IntegrationTests</c>, <c>*.FunctionalTests</c>, <c>*.E2ETests</c>, <c>*-Tests</c>,
+    /// and <c>*_Tests</c>).
     /// </param>
     /// <returns><c>true</c> if the file should be excluded; otherwise, <c>false</c>.</returns>
     internal static bool ShouldExcludeFilePath(


### PR DESCRIPTION
## Summary
- Clarifies the HarvestPathExclusions XML documentation so it names the supported test-project suffix patterns instead of implying every *Tests segment is excluded.

## Tests
- git diff --check