### PR TITLE
feat: add protected NuGet prerelease publish workflow

### DIFF
--- a/.github/release-ops.md
+++ b/.github/release-ops.md
@@ -53,3 +53,92 @@ rejects stable versions and SemVer build metadata because this path is for
 prerelease package identity that NuGet will preserve exactly.
 
 Tracked follow-up for actual publishing: #253, "Add protected NuGet prerelease publish workflow after rename pass".
+
+## Protected NuGet prerelease publish
+
+The prerelease publish slice lives in `.github/workflows/nuget-prerelease-publish.yml`.
+It has no `pull_request`, `pull_request_target`, or `workflow_dispatch` entry point.
+It runs only when the main repository receives an annotated prerelease tag that
+matches:
+
+```text
+v<major>.<minor>.<patch>-<preview|alpha|beta|rc>.<positive-number>
+```
+
+Examples: `v0.4.0-preview.1`, `v0.4.0-rc.2`.
+
+The workflow resolves annotated tags to the tagged commit with
+`refs/tags/<tag>^{commit}`, verifies that commit is reachable from `origin/main`,
+and then checks that `build.yml` and `package-gate.yml` have successful completed
+runs for that exact commit before any protected publish job can start.
+
+Publishing is gated by the GitHub Environment named `nuget-prerelease`. Store the
+NuGet API token only as that environment's `NUGET_API_KEY` secret. The publish job
+passes the key through the environment variable consumed by the PackageIndex tool;
+do not add a repository-level NuGet API secret and do not pass the key as an input
+or workflow-dispatch parameter.
+
+Before creating the first prerelease tag, create the `nuget-prerelease` environment
+in repository settings with required reviewers and prevent self-review enabled.
+Add `NUGET_API_KEY` only as an environment secret there. Verify that no repository
+or organization `NUGET_API_KEY` secret exists, because a repo/org secret with the
+same name would weaken the intended environment-only secret boundary. The workflow
+fails closed if the environment is missing or has no required-reviewer protection.
+
+The PackageIndex tool owns the package contract for the workflow:
+
+```bash
+dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- \
+  verify-packages \
+  --package-version 0.4.0-preview.1 \
+  --artifacts-output artifacts/packages \
+  --artifact-manifest artifacts/packages/package-artifact-manifest.json \
+  --report artifacts/packages/package-validation-report.md
+```
+
+`verify-packages` writes both the markdown validation report and
+`package-artifact-manifest.json`. The JSON manifest records the prerelease version,
+manifest order, package id, project path, publish decision, artifact file name, tool
+flag, and SHA-512 hash for every `publish` and `support_publish` package selected
+from `packages/package-index.yml`.
+
+The protected publish job downloads that exact artifact bundle and runs:
+
+```bash
+dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- \
+  publish-prerelease \
+  --artifacts-input artifacts/packages \
+  --artifact-manifest artifacts/packages/package-artifact-manifest.json \
+  --publish-log artifacts/packages/package-publish-log.md
+```
+
+`publish-prerelease` re-reads `packages/package-index.yml`, verifies that the JSON
+artifact manifest exactly matches the current package plan and SHA-512 hashes, then
+runs `dotnet nuget push --skip-duplicate` in manifest order. Captured publish
+output is redacted before it is written to the uploaded ledger artifact, and the
+ledger is rewritten after every package attempt so partial-publish evidence survives
+later command failures. The publish ledger uses these statuses:
+
+- `pushed`: NuGet accepted the package.
+- `duplicate-reported`: `--skip-duplicate` reported that the package already exists.
+- `failed`: the package push failed.
+- `skipped-after-failure`: the package was not attempted because an earlier package
+  failed.
+
+Partial publish recovery uses the same tag and the same package version. Re-run the
+failed workflow after fixing transient NuGet or environment problems. Already
+published packages should become `duplicate-reported`, and the first package that
+previously failed should be the first new `pushed` entry. Do not retag or create a
+new package version for a transient partial publish.
+
+Content or metadata defects require a new prerelease version. Once any package has
+been accepted by NuGet, treat the entire coordinated package version as immutable.
+Fix the defect in source, create the next prerelease tag, and let the workflow
+publish the next package family.
+
+After publishing, the workflow runs `smoke-install` from a fresh NuGet configuration
+that clears inherited sources and points only at nuget.org. It restores every direct
+`publish` package from `packages/package-index.yml` with a shared fresh
+`NUGET_PACKAGES` directory, isolated `DOTNET_CLI_HOME`, and retry/backoff for NuGet
+indexing delay. Tool packages, when they become publishable, use an isolated
+`dotnet tool install --tool-path` smoke path instead of a project restore.

--- a/.github/release-ops.md
+++ b/.github/release-ops.md
@@ -83,7 +83,8 @@ in repository settings with required reviewers and prevent self-review enabled.
 Add `NUGET_API_KEY` only as an environment secret there. Verify that no repository
 or organization `NUGET_API_KEY` secret exists, because a repo/org secret with the
 same name would weaken the intended environment-only secret boundary. The workflow
-fails closed if the environment is missing or has no required-reviewer protection.
+fails closed if the environment is missing, has no required-reviewer protection, or
+does not prevent self-review.
 
 The PackageIndex tool owns the package contract for the workflow:
 

--- a/.github/release-ops.md
+++ b/.github/release-ops.md
@@ -42,6 +42,7 @@ dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurf
   verify-packages \
   --package-version 0.0.0-ci.local \
   --artifacts-output artifacts/packages \
+  --artifact-manifest artifacts/packages/package-artifact-manifest.json \
   --report artifacts/package-validation-report.md
 ```
 

--- a/.github/workflows/nuget-prerelease-publish.yml
+++ b/.github/workflows/nuget-prerelease-publish.yml
@@ -74,9 +74,16 @@ jobs:
 
           required_reviewer_rules="$(gh api "repos/${GITHUB_REPOSITORY}/environments/nuget-prerelease" \
             --jq '[.protection_rules[]? | select(.type == "required_reviewers")] | length')"
+          prevent_self_review_rules="$(gh api "repos/${GITHUB_REPOSITORY}/environments/nuget-prerelease" \
+            --jq '[.protection_rules[]? | select(.type == "required_reviewers" and .prevent_self_review == true)] | length')"
 
           if [[ "${required_reviewer_rules}" -lt 1 ]]; then
             echo "Environment 'nuget-prerelease' must exist with required reviewers before prerelease publishing can run." >&2
+            exit 1
+          fi
+
+          if [[ "${prevent_self_review_rules}" -lt 1 ]]; then
+            echo "Environment 'nuget-prerelease' must prevent self-review before prerelease publishing can run." >&2
             exit 1
           fi
 

--- a/.github/workflows/nuget-prerelease-publish.yml
+++ b/.github/workflows/nuget-prerelease-publish.yml
@@ -72,10 +72,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          required_reviewer_rules="$(gh api "repos/${GITHUB_REPOSITORY}/environments/nuget-prerelease" \
-            --jq '[.protection_rules[]? | select(.type == "required_reviewers")] | length')"
-          prevent_self_review_rules="$(gh api "repos/${GITHUB_REPOSITORY}/environments/nuget-prerelease" \
-            --jq '[.protection_rules[]? | select(.type == "required_reviewers" and .prevent_self_review == true)] | length')"
+          if ! environment_json="$(gh api "repos/${GITHUB_REPOSITORY}/environments/nuget-prerelease")"; then
+            echo "Environment 'nuget-prerelease' must exist before prerelease publishing can run." >&2
+            exit 1
+          fi
+
+          required_reviewer_rules="$(jq '[.protection_rules[]? | select(.type == "required_reviewers")] | length' <<< "${environment_json}")"
+          prevent_self_review_rules="$(jq '[.protection_rules[]? | select(.type == "required_reviewers" and .prevent_self_review == true)] | length' <<< "${environment_json}")"
 
           if [[ "${required_reviewer_rules}" -lt 1 ]]; then
             echo "Environment 'nuget-prerelease' must exist with required reviewers before prerelease publishing can run." >&2

--- a/.github/workflows/nuget-prerelease-publish.yml
+++ b/.github/workflows/nuget-prerelease-publish.yml
@@ -1,0 +1,242 @@
+name: NuGet Prerelease Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: nuget-prerelease-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate-tag:
+    if: ${{ github.repository == 'forge-trust/AppSurface' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      package-version: ${{ steps.tag.outputs.package-version }}
+      tag-commit: ${{ steps.tag.outputs.tag-commit }}
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Validate prerelease tag
+        id: tag
+        run: |
+          set -euo pipefail
+
+          tag_name="${GITHUB_REF_NAME}"
+          tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(preview|alpha|beta|rc)\.[1-9][0-9]*$'
+          if [[ ! "${tag_name}" =~ ${tag_pattern} ]]; then
+            echo "Tag '${tag_name}' must match v<major>.<minor>.<patch>-<preview|alpha|beta|rc>.<positive-number>." >&2
+            exit 1
+          fi
+
+          tag_type="$(git cat-file -t "refs/tags/${tag_name}")"
+          if [[ "${tag_type}" != "tag" ]]; then
+            echo "Prerelease publish requires an annotated tag. '${tag_name}' is ${tag_type}." >&2
+            exit 1
+          fi
+
+          tag_commit="$(git rev-parse "refs/tags/${tag_name}^{commit}")"
+          git fetch origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+            echo "Tag '${tag_name}' resolves to ${tag_commit}, which is not reachable from origin/main." >&2
+            exit 1
+          fi
+
+          {
+            echo "package-version=${tag_name#v}"
+            echo "tag-commit=${tag_commit}"
+          } >> "${GITHUB_OUTPUT}"
+
+  validate-release-environment:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: read
+
+    steps:
+      - name: Validate protected NuGet environment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          required_reviewer_rules="$(gh api "repos/${GITHUB_REPOSITORY}/environments/nuget-prerelease" \
+            --jq '[.protection_rules[]? | select(.type == "required_reviewers")] | length')"
+
+          if [[ "${required_reviewer_rules}" -lt 1 ]]; then
+            echo "Environment 'nuget-prerelease' must exist with required reviewers before prerelease publishing can run." >&2
+            exit 1
+          fi
+
+  validate-source-ci:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Validate source workflows succeeded
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_COMMIT: ${{ needs.validate-tag.outputs.tag-commit }}
+        run: |
+          set -euo pipefail
+
+          for workflow in build.yml package-gate.yml; do
+            run_url="$(gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow "${workflow}" \
+              --branch main \
+              --commit "${TAG_COMMIT}" \
+              --json conclusion,status,url \
+              --jq '[.[] | select(.status == "completed" and .conclusion == "success")][0].url // ""')"
+
+            if [[ -z "${run_url}" ]]; then
+              echo "Required workflow '${workflow}' has no successful completed run for ${TAG_COMMIT} on main." >&2
+              exit 1
+            fi
+
+            echo "Validated ${workflow}: ${run_url}"
+          done
+
+  pack-and-verify:
+    needs:
+      - validate-tag
+      - validate-source-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout tag commit
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag-commit }}
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Verify package artifacts
+        env:
+          PACKAGE_VERSION: ${{ needs.validate-tag.outputs.package-version }}
+          PACKAGE_ARTIFACTS: ${{ runner.temp }}/package-artifacts
+        run: |
+          dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- \
+            verify-packages \
+            --package-version "${PACKAGE_VERSION}" \
+            --artifacts-output "${PACKAGE_ARTIFACTS}" \
+            --artifact-manifest "${PACKAGE_ARTIFACTS}/package-artifact-manifest.json" \
+            --report "${PACKAGE_ARTIFACTS}/package-validation-report.md"
+
+      - name: Upload validated package artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: appsurface-prerelease-packages-${{ needs.validate-tag.outputs.package-version }}
+          path: ${{ runner.temp }}/package-artifacts
+          if-no-files-found: error
+
+  publish-nuget:
+    needs:
+      - validate-tag
+      - validate-release-environment
+      - pack-and-verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: nuget-prerelease
+
+    steps:
+      - name: Checkout tag commit
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag-commit }}
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Download validated package artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: appsurface-prerelease-packages-${{ needs.validate-tag.outputs.package-version }}
+          path: ${{ runner.temp }}/package-artifacts
+
+      - name: Publish packages to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          PACKAGE_ARTIFACTS: ${{ runner.temp }}/package-artifacts
+        run: |
+          dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- \
+            publish-prerelease \
+            --artifacts-input "${PACKAGE_ARTIFACTS}" \
+            --artifact-manifest "${PACKAGE_ARTIFACTS}/package-artifact-manifest.json" \
+            --publish-log "${PACKAGE_ARTIFACTS}/package-publish-log.md"
+
+      - name: Upload publish ledger
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: appsurface-prerelease-publish-log-${{ needs.validate-tag.outputs.package-version }}
+          path: ${{ runner.temp }}/package-artifacts/package-publish-log.md
+          if-no-files-found: warn
+
+  smoke-install:
+    needs:
+      - validate-tag
+      - publish-nuget
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout tag commit
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag-commit }}
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Download validated package artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: appsurface-prerelease-packages-${{ needs.validate-tag.outputs.package-version }}
+          path: ${{ runner.temp }}/package-artifacts
+
+      - name: Smoke install published packages
+        env:
+          PACKAGE_ARTIFACTS: ${{ runner.temp }}/package-artifacts
+          SMOKE_WORK_DIR: ${{ runner.temp }}/package-smoke
+        run: |
+          dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- \
+            smoke-install \
+            --artifact-manifest "${PACKAGE_ARTIFACTS}/package-artifact-manifest.json" \
+            --smoke-work-dir "${SMOKE_WORK_DIR}" \
+            --smoke-report "${SMOKE_WORK_DIR}/package-smoke-report.md"
+
+      - name: Upload smoke install report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: appsurface-prerelease-smoke-${{ needs.validate-tag.outputs.package-version }}
+          path: ${{ runner.temp }}/package-smoke/package-smoke-report.md
+          if-no-files-found: warn

--- a/.github/workflows/package-artifacts.yml
+++ b/.github/workflows/package-artifacts.yml
@@ -37,6 +37,7 @@ jobs:
             verify-packages \
             --package-version "$PACKAGE_VERSION" \
             --artifacts-output "$RUNNER_TEMP/package-artifacts" \
+            --artifact-manifest "$RUNNER_TEMP/package-artifacts/package-artifact-manifest.json" \
             --report "$RUNNER_TEMP/package-artifacts/package-validation-report.md"
 
       - name: Upload package artifacts

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Autofac" Version="8.0.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageVersion Include="CliFx" Version="2.3.6" />
+    <PackageVersion Include="CliWrap" Version="3.10.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="FakeItEasy" Version="9.0.0" />

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -21,6 +21,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - Release-note pages can show status, freshness, scope, migration guidance, and provenance in a shared trust bar instead of bespoke page chrome.
 - AppSurface now ships a generated package chooser that tells first-time adopters which package to install first, which optional modules to add next, and which proof paths to follow for release risk and working examples.
 - AppSurface now builds and uploads validated prerelease package artifacts on pull requests and manual workflow runs, using the package chooser manifest as the single source of truth for publish decisions, dependency expectations, tool packages, first-party DLL version identity, and Tailwind runtime payload presence before NuGet publishing is enabled.
+- AppSurface now has a protected, tag-only NuGet prerelease publish workflow that revalidates package artifact manifests, requires a reviewed `nuget-prerelease` environment, writes a redacted publish ledger, and smoke-restores published packages from a clean NuGet configuration before a prerelease is considered ready.
 - The public docs Start Here path now leads with an AppSurface evaluator sequence for teams comparing module-based startup against plain ASP.NET Core `Program.cs` configuration.
 - The root README now has a single hello-world quickstart that starts the smallest web example on an explicit port and proves the response with `curl`.
 

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
@@ -1464,6 +1464,24 @@ public sealed class PackageArtifactValidationTests : IDisposable
     }
 
     [Fact]
+    public async Task CliWrapCommandRunner_ReturnsResultWhenProcessCannotStart()
+    {
+        var result = await new CliWrapCommandRunner().RunAsync(
+            new ExternalCommandRequest(
+                "definitely-not-a-real-package-index-command",
+                [],
+                _repositoryRoot,
+                "missing command",
+                "starting missing command",
+                30_000),
+            CancellationToken.None);
+
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Contains("missing command failed", result.StandardError, StringComparison.Ordinal);
+        Assert.Contains("definitely-not-a-real-package-index-command", result.StandardError, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PackagePrereleasePublishWorkflow_PushesArtifactsInManifestOrderAndWritesLedger()
     {
         await WriteFileAsync("packages/package-index.yml",

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
@@ -1215,6 +1215,37 @@ public sealed class PackageArtifactValidationTests : IDisposable
     }
 
     [Fact]
+    public async Task PackageArtifactManifestReader_RejectsArtifactFileNamesWithDirectorySegments()
+    {
+        var manifestPath = Path.Combine(_repositoryRoot, "manifest.json");
+        await File.WriteAllTextAsync(
+            manifestPath,
+            $$"""
+            {
+              "schema_version": 1,
+              "package_version": "{{PackageVersion}}",
+              "generated_at_utc": "2026-05-12T00:00:00Z",
+              "entries": [
+                {
+                  "package_id": "ForgeTrust.AppSurface.Web",
+                  "project_path": "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj",
+                  "decision": "publish",
+                  "artifact_file_name": "../ForgeTrust.AppSurface.Web.{{PackageVersion}}.nupkg",
+                  "sha512": "abc",
+                  "is_tool": false
+                }
+              ]
+            }
+            """,
+            Encoding.UTF8);
+
+        var error = await Assert.ThrowsAsync<PackageIndexException>(
+            () => new PackageArtifactManifestReader().ReadAsync(manifestPath, CancellationToken.None));
+
+        Assert.Contains("without directory segments", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task PackageArtifactWorkflow_RunsRestoreBuildPackAndWritesReport()
     {
         await WriteFileAsync("packages/package-index.yml",
@@ -1233,6 +1264,7 @@ public sealed class PackageArtifactValidationTests : IDisposable
         await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/README.md", "# Web");
         var artifactDirectory = Path.Combine(_repositoryRoot, "artifacts");
         var reportPath = Path.Combine(artifactDirectory, "package-validation-report.md");
+        var artifactManifestPath = Path.Combine(artifactDirectory, "package-artifact-manifest.json");
         Directory.CreateDirectory(artifactDirectory);
         var stalePackage = Path.Combine(artifactDirectory, "stale.nupkg");
         var staleSymbolPackage = Path.Combine(artifactDirectory, "stale.snupkg");
@@ -1255,7 +1287,8 @@ public sealed class PackageArtifactValidationTests : IDisposable
                 ManifestPath,
                 artifactDirectory,
                 reportPath,
-                PackageVersion));
+                PackageVersion,
+                artifactManifestPath));
 
         Assert.Single(report.Entries);
         Assert.Equal(["dotnet restore", "dotnet build", "dotnet pack"], commandRunner.OperationNames);
@@ -1274,6 +1307,7 @@ public sealed class PackageArtifactValidationTests : IDisposable
         Assert.False(File.Exists(stalePackage));
         Assert.False(File.Exists(staleSymbolPackage));
         Assert.True(File.Exists(reportPath), $"Expected report at {reportPath}.");
+        Assert.True(File.Exists(artifactManifestPath), $"Expected artifact manifest at {artifactManifestPath}.");
     }
 
     [Fact]
@@ -1290,7 +1324,8 @@ public sealed class PackageArtifactValidationTests : IDisposable
                 Path.Combine(missingRepository, "packages", "package-index.yml"),
                 Path.Combine(missingRepository, "artifacts"),
                 Path.Combine(missingRepository, "report.md"),
-                PackageVersion)));
+                PackageVersion,
+                Path.Combine(missingRepository, "manifest.json"))));
 
         var missingManifestError = await Assert.ThrowsAsync<PackageIndexException>(
             () => workflow.RunAsync(new PackageArtifactRequest(
@@ -1298,7 +1333,8 @@ public sealed class PackageArtifactValidationTests : IDisposable
                 ManifestPath,
                 Path.Combine(_repositoryRoot, "artifacts"),
                 Path.Combine(_repositoryRoot, "report.md"),
-                PackageVersion)));
+                PackageVersion,
+                Path.Combine(_repositoryRoot, "manifest.json"))));
 
         await WriteFileAsync("packages/package-index.yml", "packages: []");
         var missingArtifactPathError = await Assert.ThrowsAsync<PackageIndexException>(
@@ -1307,19 +1343,30 @@ public sealed class PackageArtifactValidationTests : IDisposable
                 ManifestPath,
                 " ",
                 Path.Combine(_repositoryRoot, "report.md"),
-                PackageVersion)));
+                PackageVersion,
+                Path.Combine(_repositoryRoot, "manifest.json"))));
         var missingReportPathError = await Assert.ThrowsAsync<PackageIndexException>(
             () => workflow.RunAsync(new PackageArtifactRequest(
                 _repositoryRoot,
                 ManifestPath,
                 Path.Combine(_repositoryRoot, "artifacts"),
                 "",
-                PackageVersion)));
+                PackageVersion,
+                Path.Combine(_repositoryRoot, "manifest.json"))));
+        var missingArtifactManifestPathError = await Assert.ThrowsAsync<PackageIndexException>(
+            () => workflow.RunAsync(new PackageArtifactRequest(
+                _repositoryRoot,
+                ManifestPath,
+                Path.Combine(_repositoryRoot, "artifacts"),
+                Path.Combine(_repositoryRoot, "report.md"),
+                PackageVersion,
+                "")));
 
         Assert.Contains("Repository root", missingRepositoryError.Message, StringComparison.Ordinal);
         Assert.Contains("Manifest", missingManifestError.Message, StringComparison.Ordinal);
         Assert.Contains("output path", missingArtifactPathError.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("report path", missingReportPathError.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("manifest path", missingArtifactManifestPathError.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -1414,6 +1461,411 @@ public sealed class PackageArtifactValidationTests : IDisposable
                     "probing",
                     30_000),
                 cts.Token));
+    }
+
+    [Fact]
+    public async Task PackagePrereleasePublishWorkflow_PushesArtifactsInManifestOrderAndWritesLedger()
+    {
+        await WriteFileAsync("packages/package-index.yml",
+            """
+            packages:
+              - project: ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj
+                classification: support
+                publish_decision: support_publish
+                order: 10
+                note: Core dependency.
+              - project: Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj
+                classification: public
+                publish_decision: publish
+                order: 20
+                use_when: Install this first.
+                includes: Web.
+                does_not_include: Extras.
+                start_here_path: Web/ForgeTrust.AppSurface.Web/README.md
+                expected_dependency_package_ids:
+                  - ForgeTrust.AppSurface.Core
+            """);
+        await WriteFileAsync("ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", "<Project />");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "<Project />");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/README.md", "# Web");
+        var artifactDirectory = Path.Combine(_repositoryRoot, "artifacts");
+        Directory.CreateDirectory(artifactDirectory);
+        var corePackagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Core.{PackageVersion}.nupkg");
+        var webPackagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Web.{PackageVersion}.nupkg");
+        await File.WriteAllTextAsync(corePackagePath, "core", Encoding.UTF8);
+        await File.WriteAllTextAsync(webPackagePath, "web", Encoding.UTF8);
+        var manifestPath = Path.Combine(artifactDirectory, "package-artifact-manifest.json");
+        await new PackageArtifactManifestWriter().WriteAsync(
+            new PackageArtifactValidationReport(
+                PackageVersion,
+                [
+                    new PackageArtifactValidationReportEntry(
+                        "ForgeTrust.AppSurface.Core",
+                        "ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj",
+                        PackagePublishDecision.SupportPublish,
+                        [],
+                        corePackagePath),
+                    new PackageArtifactValidationReportEntry(
+                        "ForgeTrust.AppSurface.Web",
+                        "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj",
+                        PackagePublishDecision.Publish,
+                        ["ForgeTrust.AppSurface.Core"],
+                        webPackagePath)
+                ]),
+            artifactDirectory,
+            manifestPath,
+            CancellationToken.None);
+        var commandRunner = new RecordingExternalCommandRunner([
+            new ExternalCommandResult(0, "pushed", string.Empty),
+            new ExternalCommandResult(0, "Package already exists.", string.Empty)
+        ]);
+        var workflow = new PackagePrereleasePublishWorkflow(
+            CreateResolver(new Dictionary<string, PackageProjectMetadata>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj"] = CreateMetadata(
+                    "ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj",
+                    "ForgeTrust.AppSurface.Core"),
+                ["Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj"] = CreateMetadata(
+                    "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj",
+                    "ForgeTrust.AppSurface.Web",
+                    projectReferences: [Path.Combine(_repositoryRoot, "ForgeTrust.AppSurface.Core", "ForgeTrust.AppSurface.Core.csproj")])
+            }),
+            new PackageArtifactManifestReader(),
+            commandRunner,
+            new PackagePublishLedgerRenderer());
+        var publishLogPath = Path.Combine(artifactDirectory, "publish.md");
+        Environment.SetEnvironmentVariable("PACKAGE_INDEX_TEST_NUGET_API_KEY", "secret");
+
+        try
+        {
+            var ledger = await workflow.RunAsync(
+                new PackagePrereleasePublishRequest(
+                    _repositoryRoot,
+                    ManifestPath,
+                    artifactDirectory,
+                    manifestPath,
+                    publishLogPath,
+                    "https://api.nuget.org/v3/index.json",
+                    "PACKAGE_INDEX_TEST_NUGET_API_KEY"),
+                CancellationToken.None);
+
+            Assert.Equal([PackagePublishStatus.Pushed, PackagePublishStatus.DuplicateReported], ledger.Entries.Select(entry => entry.Status).ToArray());
+            Assert.EndsWith($"ForgeTrust.AppSurface.Core.{PackageVersion}.nupkg", commandRunner.Requests[0].Arguments[2], StringComparison.Ordinal);
+            Assert.EndsWith($"ForgeTrust.AppSurface.Web.{PackageVersion}.nupkg", commandRunner.Requests[1].Arguments[2], StringComparison.Ordinal);
+            Assert.All(commandRunner.Requests, request => Assert.Contains("--skip-duplicate", request.Arguments));
+            Assert.Contains("duplicate-reported", await File.ReadAllTextAsync(publishLogPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PACKAGE_INDEX_TEST_NUGET_API_KEY", null);
+        }
+    }
+
+    [Fact]
+    public async Task PackagePrereleasePublishWorkflow_StopsAfterFirstPublishFailure()
+    {
+        await WriteFileAsync("packages/package-index.yml",
+            """
+            packages:
+              - project: ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj
+                classification: public
+                publish_decision: publish
+                order: 10
+                use_when: Core.
+                includes: Core.
+                does_not_include: Web.
+                start_here_path: ForgeTrust.AppSurface.Core/README.md
+              - project: Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj
+                classification: public
+                publish_decision: publish
+                order: 20
+                use_when: Web.
+                includes: Web.
+                does_not_include: Extras.
+                start_here_path: Web/ForgeTrust.AppSurface.Web/README.md
+            """);
+        await WriteFileAsync("ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", "<Project />");
+        await WriteFileAsync("ForgeTrust.AppSurface.Core/README.md", "# Core");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "<Project />");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/README.md", "# Web");
+        var artifactDirectory = Path.Combine(_repositoryRoot, "artifacts");
+        Directory.CreateDirectory(artifactDirectory);
+        var corePackagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Core.{PackageVersion}.nupkg");
+        var webPackagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Web.{PackageVersion}.nupkg");
+        await File.WriteAllTextAsync(corePackagePath, "core", Encoding.UTF8);
+        await File.WriteAllTextAsync(webPackagePath, "web", Encoding.UTF8);
+        var manifestPath = Path.Combine(artifactDirectory, "package-artifact-manifest.json");
+        await new PackageArtifactManifestWriter().WriteAsync(
+            new PackageArtifactValidationReport(
+                PackageVersion,
+                [
+                    new PackageArtifactValidationReportEntry("ForgeTrust.AppSurface.Core", "ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", PackagePublishDecision.Publish, [], corePackagePath),
+                    new PackageArtifactValidationReportEntry("ForgeTrust.AppSurface.Web", "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", PackagePublishDecision.Publish, [], webPackagePath)
+                ]),
+            artifactDirectory,
+            manifestPath,
+            CancellationToken.None);
+        var commandRunner = new RecordingExternalCommandRunner([
+            new ExternalCommandResult(1, string.Empty, "nuget outage")
+        ]);
+        var workflow = new PackagePrereleasePublishWorkflow(
+            CreateResolver(new Dictionary<string, PackageProjectMetadata>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj"] = CreateMetadata("ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", "ForgeTrust.AppSurface.Core"),
+                ["Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj"] = CreateMetadata("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "ForgeTrust.AppSurface.Web")
+            }),
+            new PackageArtifactManifestReader(),
+            commandRunner,
+            new PackagePublishLedgerRenderer());
+        Environment.SetEnvironmentVariable("PACKAGE_INDEX_TEST_NUGET_API_KEY", "secret");
+
+        try
+        {
+            var ledger = await workflow.RunAsync(
+                new PackagePrereleasePublishRequest(
+                    _repositoryRoot,
+                    ManifestPath,
+                    artifactDirectory,
+                    manifestPath,
+                    Path.Combine(artifactDirectory, "publish.md"),
+                    "https://api.nuget.org/v3/index.json",
+                    "PACKAGE_INDEX_TEST_NUGET_API_KEY"),
+                CancellationToken.None);
+
+            Assert.Equal([PackagePublishStatus.Failed, PackagePublishStatus.SkippedAfterFailure], ledger.Entries.Select(entry => entry.Status).ToArray());
+            Assert.Single(commandRunner.Requests);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PACKAGE_INDEX_TEST_NUGET_API_KEY", null);
+        }
+    }
+
+    [Fact]
+    public async Task PackagePrereleasePublishWorkflow_RedactsSecretsAndPersistsLedgerAfterEachAttempt()
+    {
+        await WriteFileAsync("packages/package-index.yml",
+            """
+            packages:
+              - project: ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj
+                classification: public
+                publish_decision: publish
+                order: 10
+                use_when: Core.
+                includes: Core.
+                does_not_include: Web.
+                start_here_path: ForgeTrust.AppSurface.Core/README.md
+              - project: Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj
+                classification: public
+                publish_decision: publish
+                order: 20
+                use_when: Web.
+                includes: Web.
+                does_not_include: Extras.
+                start_here_path: Web/ForgeTrust.AppSurface.Web/README.md
+            """);
+        await WriteFileAsync("ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", "<Project />");
+        await WriteFileAsync("ForgeTrust.AppSurface.Core/README.md", "# Core");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "<Project />");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/README.md", "# Web");
+        var artifactDirectory = Path.Combine(_repositoryRoot, "artifacts");
+        Directory.CreateDirectory(artifactDirectory);
+        var corePackagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Core.{PackageVersion}.nupkg");
+        var webPackagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Web.{PackageVersion}.nupkg");
+        await File.WriteAllTextAsync(corePackagePath, "core", Encoding.UTF8);
+        await File.WriteAllTextAsync(webPackagePath, "web", Encoding.UTF8);
+        var manifestPath = Path.Combine(artifactDirectory, "package-artifact-manifest.json");
+        await new PackageArtifactManifestWriter().WriteAsync(
+            new PackageArtifactValidationReport(
+                PackageVersion,
+                [
+                    new PackageArtifactValidationReportEntry("ForgeTrust.AppSurface.Core", "ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", PackagePublishDecision.Publish, [], corePackagePath),
+                    new PackageArtifactValidationReportEntry("ForgeTrust.AppSurface.Web", "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", PackagePublishDecision.Publish, [], webPackagePath)
+                ]),
+            artifactDirectory,
+            manifestPath,
+            CancellationToken.None);
+        var publishLogPath = Path.Combine(artifactDirectory, "publish.md");
+        var commandRunner = new RecordingExternalCommandRunner([
+            new ExternalCommandResult(0, "api-key: super-secret-token", "pushed super-secret-token"),
+            new InvalidOperationException("runner crashed")
+        ]);
+        var workflow = new PackagePrereleasePublishWorkflow(
+            CreateResolver(new Dictionary<string, PackageProjectMetadata>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj"] = CreateMetadata("ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", "ForgeTrust.AppSurface.Core"),
+                ["Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj"] = CreateMetadata("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "ForgeTrust.AppSurface.Web")
+            }),
+            new PackageArtifactManifestReader(),
+            commandRunner,
+            new PackagePublishLedgerRenderer());
+        Environment.SetEnvironmentVariable("PACKAGE_INDEX_TEST_NUGET_API_KEY", "super-secret-token");
+
+        try
+        {
+            var ledger = await workflow.RunAsync(
+                new PackagePrereleasePublishRequest(
+                    _repositoryRoot,
+                    ManifestPath,
+                    artifactDirectory,
+                    manifestPath,
+                    publishLogPath,
+                    "https://api.nuget.org/v3/index.json",
+                    "PACKAGE_INDEX_TEST_NUGET_API_KEY"),
+                CancellationToken.None);
+
+            Assert.Equal([PackagePublishStatus.Pushed, PackagePublishStatus.Failed], ledger.Entries.Select(entry => entry.Status).ToArray());
+            var ledgerMarkdown = await File.ReadAllTextAsync(publishLogPath);
+            Assert.Contains("ForgeTrust.AppSurface.Core", ledgerMarkdown, StringComparison.Ordinal);
+            Assert.Contains("runner crashed", ledgerMarkdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("super-secret-token", ledgerMarkdown, StringComparison.Ordinal);
+            Assert.Contains("[redacted]", ledgerMarkdown, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PACKAGE_INDEX_TEST_NUGET_API_KEY", null);
+        }
+    }
+
+    [Fact]
+    public async Task PackageSmokeInstallWorkflow_RestoresPublicPackagesWithRetryAndIsolatedConfig()
+    {
+        await WriteFileAsync("packages/package-index.yml",
+            """
+            packages:
+              - project: ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj
+                classification: support
+                publish_decision: support_publish
+                order: 10
+                note: Core dependency.
+              - project: Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj
+                classification: public
+                publish_decision: publish
+                order: 20
+                use_when: Web.
+                includes: Web.
+                does_not_include: Extras.
+                start_here_path: Web/ForgeTrust.AppSurface.Web/README.md
+            """);
+        await WriteFileAsync("ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", "<Project />");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "<Project />");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/README.md", "# Web");
+        var artifactDirectory = Path.Combine(_repositoryRoot, "artifacts");
+        Directory.CreateDirectory(artifactDirectory);
+        var packagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Web.{PackageVersion}.nupkg");
+        await File.WriteAllTextAsync(packagePath, "web", Encoding.UTF8);
+        var supportPackagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Core.{PackageVersion}.nupkg");
+        await File.WriteAllTextAsync(supportPackagePath, "core", Encoding.UTF8);
+        var manifestPath = Path.Combine(artifactDirectory, "package-artifact-manifest.json");
+        await new PackageArtifactManifestWriter().WriteAsync(
+            new PackageArtifactValidationReport(
+                PackageVersion,
+                [
+                    new PackageArtifactValidationReportEntry("ForgeTrust.AppSurface.Core", "ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", PackagePublishDecision.SupportPublish, [], supportPackagePath),
+                    new PackageArtifactValidationReportEntry("ForgeTrust.AppSurface.Web", "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", PackagePublishDecision.Publish, [], packagePath)
+                ]),
+            artifactDirectory,
+            manifestPath,
+            CancellationToken.None);
+        var commandRunner = new RecordingExternalCommandRunner([
+            new ExternalCommandResult(1, string.Empty, "not indexed yet"),
+            new ExternalCommandResult(0, "restored", string.Empty)
+        ]);
+        var delays = new List<TimeSpan>();
+        var workflow = new PackageSmokeInstallWorkflow(
+            new PackageArtifactManifestReader(),
+            CreateResolver(new Dictionary<string, PackageProjectMetadata>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj"] = CreateMetadata("ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj", "ForgeTrust.AppSurface.Core"),
+                ["Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj"] = CreateMetadata("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "ForgeTrust.AppSurface.Web")
+            }),
+            commandRunner,
+            new PackageSmokeInstallReportRenderer(),
+            (delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            });
+        var workDirectory = Path.Combine(_repositoryRoot, "smoke");
+
+        var report = await workflow.RunAsync(
+            new PackageSmokeInstallRequest(
+                _repositoryRoot,
+                ManifestPath,
+                manifestPath,
+                workDirectory,
+                Path.Combine(workDirectory, "smoke.md"),
+                "https://api.nuget.org/v3/index.json"),
+            CancellationToken.None);
+
+        var entry = Assert.Single(report.Entries);
+        Assert.Equal("ForgeTrust.AppSurface.Web", entry.PackageId);
+        Assert.Equal(PackageSmokeInstallStatus.Restored, entry.Status);
+        Assert.Equal(2, commandRunner.Requests.Count);
+        Assert.Single(delays);
+        Assert.True(File.Exists(Path.Combine(workDirectory, "NuGet.config")));
+        Assert.Contains("<clear />", await File.ReadAllTextAsync(Path.Combine(workDirectory, "NuGet.config")), StringComparison.Ordinal);
+        Assert.Contains("NUGET_PACKAGES", commandRunner.Requests[0].Environment!.Keys);
+    }
+
+    [Fact]
+    public async Task PackageSmokeInstallWorkflow_RejectsManifestThatDoesNotMatchPackagePlan()
+    {
+        await WriteFileAsync("packages/package-index.yml",
+            """
+            packages:
+              - project: Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj
+                classification: public
+                publish_decision: publish
+                order: 10
+                use_when: Web.
+                includes: Web.
+                does_not_include: Extras.
+                start_here_path: Web/ForgeTrust.AppSurface.Web/README.md
+            """);
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "<Project />");
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/README.md", "# Web");
+        var artifactDirectory = Path.Combine(_repositoryRoot, "artifacts");
+        Directory.CreateDirectory(artifactDirectory);
+        var packagePath = Path.Combine(artifactDirectory, $"ForgeTrust.AppSurface.Web.{PackageVersion}.nupkg");
+        await File.WriteAllTextAsync(packagePath, "web", Encoding.UTF8);
+        var manifestPath = Path.Combine(artifactDirectory, "package-artifact-manifest.json");
+        await new PackageArtifactManifestWriter().WriteAsync(
+            new PackageArtifactValidationReport(
+                PackageVersion,
+                [
+                    new PackageArtifactValidationReportEntry(
+                        "ForgeTrust.AppSurface.Web\"><PackageReference Include=\"Bad",
+                        "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj",
+                        PackagePublishDecision.Publish,
+                        [],
+                        packagePath)
+                ]),
+            artifactDirectory,
+            manifestPath,
+            CancellationToken.None);
+        var workflow = new PackageSmokeInstallWorkflow(
+            new PackageArtifactManifestReader(),
+            CreateResolver(new Dictionary<string, PackageProjectMetadata>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj"] = CreateMetadata("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "ForgeTrust.AppSurface.Web")
+            }),
+            new RecordingExternalCommandRunner([]),
+            new PackageSmokeInstallReportRenderer(),
+            (_, _) => Task.CompletedTask);
+
+        var error = await Assert.ThrowsAsync<PackageIndexException>(
+            () => workflow.RunAsync(
+                new PackageSmokeInstallRequest(
+                    _repositoryRoot,
+                    ManifestPath,
+                    manifestPath,
+                    Path.Combine(_repositoryRoot, "smoke"),
+                    Path.Combine(_repositoryRoot, "smoke", "report.md"),
+                    "https://api.nuget.org/v3/index.json"),
+                CancellationToken.None));
+
+        Assert.Contains("does not match package plan", error.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     private string ManifestPath => Path.Combine(_repositoryRoot, "packages", "package-index.yml");
@@ -1642,6 +2094,37 @@ public sealed class PackageArtifactValidationTests : IDisposable
             }
 
             return Task.FromResult(new CommandRunResult(string.Empty, string.Empty));
+        }
+    }
+
+    private sealed class RecordingExternalCommandRunner : IExternalCommandRunner
+    {
+        private readonly Queue<object> _results;
+
+        public RecordingExternalCommandRunner(IEnumerable<object> results)
+        {
+            _results = new Queue<object>(results);
+        }
+
+        public List<ExternalCommandRequest> Requests { get; } = [];
+
+        public Task<ExternalCommandResult> RunAsync(
+            ExternalCommandRequest request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            if (_results.Count == 0)
+            {
+                return Task.FromResult(new ExternalCommandResult(0, string.Empty, string.Empty));
+            }
+
+            var result = _results.Dequeue();
+            if (result is Exception exception)
+            {
+                throw exception;
+            }
+
+            return Task.FromResult((ExternalCommandResult)result);
         }
     }
 }

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageIndexGeneratorTests.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageIndexGeneratorTests.cs
@@ -967,7 +967,14 @@ public sealed class PackageIndexGeneratorTests : IDisposable
         Assert.Equal(Path.Combine(_repositoryRoot, "packages", "package-index.yml"), defaults.Request.ManifestPath);
         Assert.Equal(Path.Combine(_repositoryRoot, "packages", "README.md"), defaults.Request.OutputPath);
         Assert.Equal(Path.Combine(_repositoryRoot, "artifacts", "packages"), defaults.ArtifactsOutputPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "artifacts", "packages"), defaults.ArtifactsInputPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "artifacts", "package-artifact-manifest.json"), defaults.ArtifactManifestPath);
         Assert.Equal(Path.Combine(_repositoryRoot, "artifacts", "package-validation-report.md"), defaults.ReportPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "artifacts", "package-publish-log.md"), defaults.PublishLogPath);
+        Assert.Equal("https://api.nuget.org/v3/index.json", defaults.Source);
+        Assert.Equal("NUGET_API_KEY", defaults.ApiKeyEnvironmentVariable);
+        Assert.Equal(Path.Combine(_repositoryRoot, "artifacts", "package-smoke"), defaults.SmokeWorkDirectory);
+        Assert.Equal(Path.Combine(_repositoryRoot, "artifacts", "package-smoke-report.md"), defaults.SmokeReportPath);
         Assert.Null(defaults.PackageVersion);
 
         var parsed = CommandLineOptions.Parse(
@@ -976,8 +983,15 @@ public sealed class PackageIndexGeneratorTests : IDisposable
                 "--manifest", "manifest.yml",
                 "--output", "chooser.md",
                 "--artifacts-output", "packages-out",
+                "--artifacts-input", "packages-in",
+                "--artifact-manifest", "artifact-manifest.json",
                 "--package-version", "0.0.0-ci.99",
-                "--report", "package-report.md"
+                "--report", "package-report.md",
+                "--publish-log", "publish-log.md",
+                "--source", "https://example.test/v3/index.json",
+                "--api-key-env", "CUSTOM_NUGET_KEY",
+                "--smoke-work-dir", "smoke",
+                "--smoke-report", "smoke-report.md"
             ],
             _repositoryRoot);
 
@@ -985,21 +999,48 @@ public sealed class PackageIndexGeneratorTests : IDisposable
         Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "manifest.yml")), parsed.Request.ManifestPath);
         Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "chooser.md")), parsed.Request.OutputPath);
         Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "packages-out")), parsed.ArtifactsOutputPath);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "packages-in")), parsed.ArtifactsInputPath);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "artifact-manifest.json")), parsed.ArtifactManifestPath);
         Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "package-report.md")), parsed.ReportPath);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "publish-log.md")), parsed.PublishLogPath);
+        Assert.Equal("https://example.test/v3/index.json", parsed.Source);
+        Assert.Equal("CUSTOM_NUGET_KEY", parsed.ApiKeyEnvironmentVariable);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "smoke")), parsed.SmokeWorkDirectory);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_repositoryRoot, "src", "smoke-report.md")), parsed.SmokeReportPath);
         Assert.Equal("0.0.0-ci.99", parsed.PackageVersion);
 
         var absoluteManifest = Path.Combine(_repositoryRoot, "abs", "manifest.yml");
         var absoluteOutput = Path.Combine(_repositoryRoot, "abs", "chooser.md");
         var absoluteArtifacts = Path.Combine(_repositoryRoot, "abs", "artifacts");
+        var absoluteArtifactsInput = Path.Combine(_repositoryRoot, "abs", "artifacts-in");
+        var absoluteArtifactManifest = Path.Combine(_repositoryRoot, "abs", "manifest.json");
         var absoluteReport = Path.Combine(_repositoryRoot, "abs", "report.md");
+        var absolutePublishLog = Path.Combine(_repositoryRoot, "abs", "publish.md");
+        var absoluteSmokeWorkDirectory = Path.Combine(_repositoryRoot, "abs", "smoke");
+        var absoluteSmokeReport = Path.Combine(_repositoryRoot, "abs", "smoke.md");
         var absolute = CommandLineOptions.Parse(
-            ["--manifest", absoluteManifest, "--output", absoluteOutput, "--artifacts-output", absoluteArtifacts, "--report", absoluteReport],
+            [
+                "--manifest", absoluteManifest,
+                "--output", absoluteOutput,
+                "--artifacts-output", absoluteArtifacts,
+                "--artifacts-input", absoluteArtifactsInput,
+                "--artifact-manifest", absoluteArtifactManifest,
+                "--report", absoluteReport,
+                "--publish-log", absolutePublishLog,
+                "--smoke-work-dir", absoluteSmokeWorkDirectory,
+                "--smoke-report", absoluteSmokeReport
+            ],
             _repositoryRoot);
 
         Assert.Equal(absoluteManifest, absolute.Request.ManifestPath);
         Assert.Equal(absoluteOutput, absolute.Request.OutputPath);
         Assert.Equal(absoluteArtifacts, absolute.ArtifactsOutputPath);
+        Assert.Equal(absoluteArtifactsInput, absolute.ArtifactsInputPath);
+        Assert.Equal(absoluteArtifactManifest, absolute.ArtifactManifestPath);
         Assert.Equal(absoluteReport, absolute.ReportPath);
+        Assert.Equal(absolutePublishLog, absolute.PublishLogPath);
+        Assert.Equal(absoluteSmokeWorkDirectory, absolute.SmokeWorkDirectory);
+        Assert.Equal(absoluteSmokeReport, absolute.SmokeReportPath);
     }
 
     [Fact]
@@ -1050,6 +1091,8 @@ public sealed class PackageIndexGeneratorTests : IDisposable
     [InlineData("generate", "-h")]
     [InlineData("verify", "--help")]
     [InlineData("verify-packages", "--help")]
+    [InlineData("publish-prerelease", "--help")]
+    [InlineData("smoke-install", "--help")]
     [InlineData("gate", "--help")]
     public async Task RunAsync_WritesCommandHelpToStandardOut(string command, string helpOption)
     {
@@ -1233,6 +1276,7 @@ public sealed class PackageIndexGeneratorTests : IDisposable
                 "verify-packages",
                 "--package-version", "0.0.0-ci.99",
                 "--artifacts-output", "packages-out",
+                "--artifact-manifest", "reports/artifacts.json",
                 "--report", "reports/packages.md"
             ],
             stdout,
@@ -1257,6 +1301,7 @@ public sealed class PackageIndexGeneratorTests : IDisposable
         Assert.NotNull(capturedRequest);
         Assert.Equal(Path.Combine(_repositoryRoot, "packages-out"), capturedRequest.ArtifactsOutputPath);
         Assert.Equal(Path.Combine(_repositoryRoot, "reports", "packages.md"), capturedRequest.ReportPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "reports", "artifacts.json"), capturedRequest.ArtifactManifestPath);
         Assert.Equal("0.0.0-ci.99", capturedRequest.PackageVersion);
         Assert.Contains("Validated 1 package artifacts for 0.0.0-ci.99. Report: reports/packages.md.", stdout.ToString(), StringComparison.Ordinal);
         Assert.Equal(string.Empty, stderr.ToString());
@@ -1291,6 +1336,99 @@ public sealed class PackageIndexGeneratorTests : IDisposable
         Assert.Equal(1, exitCode);
         Assert.Contains("--package-version", stderr.ToString(), StringComparison.Ordinal);
         Assert.Equal(string.Empty, stdout.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_PublishPrerelease_UsesWorkflowAndReturnsFailureWhenLedgerFails()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        PackagePrereleasePublishRequest? capturedRequest = null;
+
+        var exitCode = await Program.RunAsync(
+            [
+                "publish-prerelease",
+                "--artifacts-input", "packages-in",
+                "--artifact-manifest", "packages-in/artifacts.json",
+                "--publish-log", "reports/publish.md",
+                "--source", "https://example.test/v3/index.json",
+                "--api-key-env", "TEST_KEY"
+            ],
+            stdout,
+            stderr,
+            _repositoryRoot,
+            publishPrereleaseAsync: (request, _) =>
+            {
+                capturedRequest = request;
+                return Task.FromResult(new PackagePublishLedger(
+                    "0.0.0-ci.99",
+                    request.Source,
+                    [
+                        new PackagePublishLedgerEntry(
+                            "ForgeTrust.AppSurface.Web",
+                            "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj",
+                            "ForgeTrust.AppSurface.Web.0.0.0-ci.99.nupkg",
+                            PackagePublishStatus.Failed,
+                            1,
+                            "failed")
+                    ]));
+            });
+
+        Assert.Equal(1, exitCode);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(Path.Combine(_repositoryRoot, "packages-in"), capturedRequest.ArtifactsInputPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "packages-in", "artifacts.json"), capturedRequest.ArtifactManifestPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "reports", "publish.md"), capturedRequest.PublishLogPath);
+        Assert.Equal("https://example.test/v3/index.json", capturedRequest.Source);
+        Assert.Equal("TEST_KEY", capturedRequest.ApiKeyEnvironmentVariable);
+        Assert.Contains("Published 0 package artifacts for 0.0.0-ci.99. Log: reports/publish.md.", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, stderr.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_SmokeInstall_UsesWorkflowAndReturnsSuccess()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        PackageSmokeInstallRequest? capturedRequest = null;
+
+        var exitCode = await Program.RunAsync(
+            [
+                "smoke-install",
+                "--artifact-manifest", "packages-in/artifacts.json",
+                "--smoke-work-dir", "smoke",
+                "--smoke-report", "reports/smoke.md",
+                "--source", "https://example.test/v3/index.json"
+            ],
+            stdout,
+            stderr,
+            _repositoryRoot,
+            smokeInstallAsync: (request, _) =>
+            {
+                capturedRequest = request;
+                return Task.FromResult(new PackageSmokeInstallReport(
+                    "0.0.0-ci.99",
+                    request.Source,
+                    [
+                        new PackageSmokeInstallReportEntry(
+                            "ForgeTrust.AppSurface.Web",
+                            "Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj",
+                            IsTool: false,
+                            PackageSmokeInstallStatus.Restored,
+                            0,
+                            "restored")
+                    ]));
+            });
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(Path.Combine(_repositoryRoot, "packages", "package-index.yml"), capturedRequest.ManifestPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "packages-in", "artifacts.json"), capturedRequest.ArtifactManifestPath);
+        Assert.Equal(Path.Combine(_repositoryRoot, "smoke"), capturedRequest.WorkDirectory);
+        Assert.Equal(Path.Combine(_repositoryRoot, "reports", "smoke.md"), capturedRequest.ReportPath);
+        Assert.Equal("https://example.test/v3/index.json", capturedRequest.Source);
+        Assert.Contains("Smoke installed 1 published prerelease packages for 0.0.0-ci.99. Report: reports/smoke.md.", stdout.ToString(), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, stderr.ToString());
     }
 
     [Fact]

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/packages.lock.json
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/packages.lock.json
@@ -123,8 +123,15 @@
       "forgetrust.appsurface.packageindex": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "YamlDotNet": "[17.0.1, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "YamlDotNet": {
         "type": "CentralTransitive",

--- a/tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CliWrap" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 

--- a/tools/ForgeTrust.AppSurface.PackageIndex/PackageArtifactValidation.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/PackageArtifactValidation.cs
@@ -81,13 +81,24 @@ internal sealed class PackageArtifactValidator
             throw new PackageIndexException($"Unexpected package artifact '{unexpected.PackageId}' at '{unexpected.PackagePath}'.");
         }
 
+        var inspectedByPackageId = inspectedPackages.ToDictionary(
+            package => package.PackageId,
+            package => package,
+            StringComparer.OrdinalIgnoreCase);
+
         return new PackageArtifactValidationReport(
             packageVersion,
-            plan.Entries.Select(entry => new PackageArtifactValidationReportEntry(
-                entry.PackageId,
-                entry.ProjectPath,
-                entry.Decision,
-                entry.ExpectedDependencyPackageIds)).ToArray());
+            plan.Entries.Select(entry =>
+            {
+                var inspected = inspectedByPackageId[entry.PackageId];
+                return new PackageArtifactValidationReportEntry(
+                    entry.PackageId,
+                    entry.ProjectPath,
+                    entry.Decision,
+                    entry.ExpectedDependencyPackageIds,
+                    inspected.PackagePath,
+                    entry.IsTool);
+            }).ToArray());
     }
 
     private static void ValidatePackage(
@@ -497,11 +508,15 @@ internal sealed record PackageArtifactValidationReport(
 /// <param name="ProjectPath">Project that produced the package.</param>
 /// <param name="Decision">Publish decision from the manifest.</param>
 /// <param name="ExpectedDependencyPackageIds">Expected same-version package dependency ids.</param>
+/// <param name="ArtifactPath">Validated <c>.nupkg</c> artifact path.</param>
+/// <param name="IsTool">Whether the package is a .NET tool package.</param>
 internal sealed record PackageArtifactValidationReportEntry(
     string PackageId,
     string ProjectPath,
     PackagePublishDecision Decision,
-    IReadOnlyList<string> ExpectedDependencyPackageIds);
+    IReadOnlyList<string> ExpectedDependencyPackageIds,
+    string ArtifactPath = "",
+    bool IsTool = false);
 
 /// <summary>
 /// Metadata and payload facts inspected from one NuGet package artifact.

--- a/tools/ForgeTrust.AppSurface.PackageIndex/PackageArtifactWorkflow.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/PackageArtifactWorkflow.cs
@@ -12,6 +12,7 @@ internal sealed class PackageArtifactWorkflow
     private readonly PackagePublishPlanResolver _planResolver;
     private readonly ICommandRunner _commandRunner;
     private readonly PackageArtifactValidator _validator;
+    private readonly PackageArtifactManifestWriter _artifactManifestWriter;
 
     /// <summary>
     /// Creates a package artifact workflow.
@@ -27,6 +28,7 @@ internal sealed class PackageArtifactWorkflow
         _planResolver = planResolver;
         _commandRunner = commandRunner;
         _validator = validator;
+        _artifactManifestWriter = new PackageArtifactManifestWriter();
     }
 
     /// <summary>
@@ -114,6 +116,11 @@ internal sealed class PackageArtifactWorkflow
             request.ReportPath,
             PackageArtifactReportRenderer.RenderMarkdown(report),
             cancellationToken);
+        await _artifactManifestWriter.WriteAsync(
+            report,
+            request.ArtifactsOutputPath,
+            request.ArtifactManifestPath,
+            cancellationToken);
 
         return report;
     }
@@ -139,6 +146,11 @@ internal sealed class PackageArtifactWorkflow
         if (string.IsNullOrWhiteSpace(request.ReportPath))
         {
             throw new PackageIndexException("Package artifact report path must be provided.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ArtifactManifestPath))
+        {
+            throw new PackageIndexException("Package artifact manifest path must be provided.");
         }
     }
 
@@ -194,9 +206,11 @@ internal sealed class PackageArtifactWorkflow
 /// <param name="ArtifactsOutputPath">Directory that receives produced <c>.nupkg</c> artifacts.</param>
 /// <param name="ReportPath">Markdown validation report path.</param>
 /// <param name="PackageVersion">Exact prerelease package version to pack and validate.</param>
+/// <param name="ArtifactManifestPath">Machine-readable validation manifest path for the publish workflow.</param>
 internal sealed record PackageArtifactRequest(
     string RepositoryRoot,
     string ManifestPath,
     string ArtifactsOutputPath,
     string ReportPath,
-    string PackageVersion);
+    string PackageVersion,
+    string ArtifactManifestPath);

--- a/tools/ForgeTrust.AppSurface.PackageIndex/PackagePrereleasePublishing.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/PackagePrereleasePublishing.cs
@@ -48,6 +48,17 @@ internal sealed class CliWrapCommandRunner : IExternalCommandRunner
                 string.Empty,
                 $"{request.OperationName} timed out after {request.TimeoutMilliseconds} ms while {request.TimeoutDescription}.");
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new ExternalCommandResult(
+                -1,
+                string.Empty,
+                $"{request.OperationName} failed while {request.TimeoutDescription}: {ex.Message}");
+        }
     }
 }
 

--- a/tools/ForgeTrust.AppSurface.PackageIndex/PackagePrereleasePublishing.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/PackagePrereleasePublishing.cs
@@ -1,0 +1,1074 @@
+using System.Diagnostics;
+using System.Security;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using CliWrap;
+using CliWrap.Buffered;
+
+namespace ForgeTrust.AppSurface.PackageIndex;
+
+/// <summary>
+/// Runs external commands through CliWrap for protected package publishing and smoke-install workflows.
+/// </summary>
+internal sealed class CliWrapCommandRunner : IExternalCommandRunner
+{
+    /// <inheritdoc />
+    public async Task<ExternalCommandResult> RunAsync(ExternalCommandRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.FileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkingDirectory);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(request.TimeoutMilliseconds);
+
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(request.TimeoutMilliseconds);
+            var command = Cli.Wrap(request.FileName)
+                .WithArguments(request.Arguments)
+                .WithWorkingDirectory(request.WorkingDirectory)
+                .WithValidation(CommandResultValidation.None);
+
+            if (request.Environment is not null)
+            {
+                command = command.WithEnvironmentVariables(request.Environment);
+            }
+
+            var result = await command.ExecuteBufferedAsync(timeoutCts.Token);
+            return new ExternalCommandResult(result.ExitCode, result.StandardOutput, result.StandardError);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new ExternalCommandResult(
+                -1,
+                string.Empty,
+                $"{request.OperationName} timed out after {request.TimeoutMilliseconds} ms while {request.TimeoutDescription}.");
+        }
+    }
+}
+
+/// <summary>
+/// External command runner used by publish and smoke workflows when non-zero exit codes are meaningful results.
+/// </summary>
+internal interface IExternalCommandRunner
+{
+    /// <summary>
+    /// Runs a command and returns stdout, stderr, and exit code without throwing for non-zero exits.
+    /// </summary>
+    /// <param name="request">Command request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Captured command result.</returns>
+    Task<ExternalCommandResult> RunAsync(ExternalCommandRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Command invocation for CliWrap-backed release automation.
+/// </summary>
+internal sealed record ExternalCommandRequest(
+    string FileName,
+    IReadOnlyList<string> Arguments,
+    string WorkingDirectory,
+    string OperationName,
+    string TimeoutDescription,
+    int TimeoutMilliseconds,
+    IReadOnlyDictionary<string, string?>? Environment = null);
+
+/// <summary>
+/// Captured command result including non-zero exit codes.
+/// </summary>
+internal sealed record ExternalCommandResult(int ExitCode, string StandardOutput, string StandardError);
+
+/// <summary>
+/// Writes the machine-readable package artifact manifest consumed by protected publish jobs.
+/// </summary>
+internal sealed class PackageArtifactManifestWriter
+{
+    /// <summary>
+    /// Writes a manifest that binds validated package ids to artifact file names and SHA-512 hashes.
+    /// </summary>
+    /// <param name="report">Package artifact validation report.</param>
+    /// <param name="artifactsDirectory">Directory containing the validated package artifacts.</param>
+    /// <param name="manifestPath">Destination manifest path.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    internal async Task WriteAsync(
+        PackageArtifactValidationReport report,
+        string artifactsDirectory,
+        string manifestPath,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactsDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(manifestPath);
+
+        var entries = new List<PackageArtifactManifestEntry>(report.Entries.Count);
+        foreach (var entry in report.Entries)
+        {
+            var artifactPath = string.IsNullOrWhiteSpace(entry.ArtifactPath)
+                ? Path.Combine(artifactsDirectory, $"{entry.PackageId}.{report.PackageVersion}.nupkg")
+                : entry.ArtifactPath;
+            if (!File.Exists(artifactPath))
+            {
+                throw new PackageIndexException($"Validated artifact '{artifactPath}' does not exist.");
+            }
+
+            entries.Add(new PackageArtifactManifestEntry(
+                entry.PackageId,
+                entry.ProjectPath,
+                PackagePublishDecisionFormatter.Format(entry.Decision),
+                Path.GetFileName(artifactPath),
+                await PackageHash.ComputeSha512Async(artifactPath, cancellationToken),
+                entry.IsTool));
+        }
+
+        var manifest = new PackageArtifactManifest(
+            1,
+            report.PackageVersion,
+            DateTimeOffset.UtcNow,
+            entries);
+        Directory.CreateDirectory(Path.GetDirectoryName(manifestPath)!);
+        await using var stream = File.Create(manifestPath);
+        await JsonSerializer.SerializeAsync(stream, manifest, PackageArtifactJson.Options, cancellationToken);
+        await stream.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine), cancellationToken);
+    }
+}
+
+/// <summary>
+/// Reads and validates the artifact manifest written by the package artifact verifier.
+/// </summary>
+internal sealed class PackageArtifactManifestReader
+{
+    /// <summary>
+    /// Reads a package artifact manifest from disk.
+    /// </summary>
+    /// <param name="manifestPath">Manifest path.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Validated artifact manifest.</returns>
+    internal async Task<PackageArtifactManifest> ReadAsync(string manifestPath, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(manifestPath);
+        if (!File.Exists(manifestPath))
+        {
+            throw new PackageIndexException($"Package artifact manifest '{manifestPath}' does not exist.");
+        }
+
+        await using var stream = File.OpenRead(manifestPath);
+        var manifest = await JsonSerializer.DeserializeAsync<PackageArtifactManifest>(
+            stream,
+            PackageArtifactJson.Options,
+            cancellationToken);
+        if (manifest is null)
+        {
+            throw new PackageIndexException($"Package artifact manifest '{manifestPath}' is empty.");
+        }
+
+        Validate(manifest, manifestPath);
+        return manifest;
+    }
+
+    private static void Validate(PackageArtifactManifest manifest, string manifestPath)
+    {
+        if (manifest.SchemaVersion != 1)
+        {
+            throw new PackageIndexException($"Package artifact manifest '{manifestPath}' uses unsupported schema version '{manifest.SchemaVersion}'.");
+        }
+
+        PackageVersionValidator.RequirePrerelease(manifest.PackageVersion);
+        if (manifest.Entries.Count == 0)
+        {
+            throw new PackageIndexException($"Package artifact manifest '{manifestPath}' does not contain any entries.");
+        }
+
+        var packageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in manifest.Entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry.PackageId))
+            {
+                throw new PackageIndexException($"Package artifact manifest '{manifestPath}' contains an entry without a package id.");
+            }
+
+            if (!packageIds.Add(entry.PackageId))
+            {
+                throw new PackageIndexException($"Package artifact manifest '{manifestPath}' contains duplicate package id '{entry.PackageId}'.");
+            }
+
+            RequireManifestValue(manifestPath, entry.PackageId, "project_path", entry.ProjectPath);
+            RequireManifestValue(manifestPath, entry.PackageId, "decision", entry.Decision);
+            RequireManifestValue(manifestPath, entry.PackageId, "artifact_file_name", entry.ArtifactFileName);
+            RequireManifestValue(manifestPath, entry.PackageId, "sha512", entry.Sha512);
+            if (Path.IsPathRooted(entry.ArtifactFileName)
+                || !string.Equals(Path.GetFileName(entry.ArtifactFileName), entry.ArtifactFileName, StringComparison.Ordinal))
+            {
+                throw new PackageIndexException(
+                    $"Package artifact manifest '{manifestPath}' entry '{entry.PackageId}' must use an artifact_file_name without directory segments.");
+            }
+        }
+    }
+
+    private static void RequireManifestValue(
+        string manifestPath,
+        string packageId,
+        string propertyName,
+        string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new PackageIndexException(
+                $"Package artifact manifest '{manifestPath}' entry '{packageId}' is missing '{propertyName}'.");
+        }
+    }
+}
+
+/// <summary>
+/// Publishes a validated prerelease package artifact set to NuGet in manifest order.
+/// </summary>
+internal sealed class PackagePrereleasePublishWorkflow
+{
+    internal const int PushTimeoutMilliseconds = 180_000;
+
+    private readonly PackagePublishPlanResolver _planResolver;
+    private readonly PackageArtifactManifestReader _manifestReader;
+    private readonly IExternalCommandRunner _commandRunner;
+    private readonly PackagePublishLedgerRenderer _ledgerRenderer;
+
+    internal PackagePrereleasePublishWorkflow(
+        PackagePublishPlanResolver planResolver,
+        PackageArtifactManifestReader manifestReader,
+        IExternalCommandRunner commandRunner,
+        PackagePublishLedgerRenderer ledgerRenderer)
+    {
+        _planResolver = planResolver;
+        _manifestReader = manifestReader;
+        _commandRunner = commandRunner;
+        _ledgerRenderer = ledgerRenderer;
+    }
+
+    /// <summary>
+    /// Publishes each artifact selected by the checked-in manifest and writes a markdown ledger.
+    /// </summary>
+    /// <param name="request">Publish request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Publish ledger.</returns>
+    internal async Task<PackagePublishLedger> RunAsync(
+        PackagePrereleasePublishRequest request,
+        CancellationToken cancellationToken)
+    {
+        ValidatePublishRequest(request);
+        var apiKey = Environment.GetEnvironmentVariable(request.ApiKeyEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new PackageIndexException($"Environment variable '{request.ApiKeyEnvironmentVariable}' must contain the NuGet API key.");
+        }
+
+        var plan = await _planResolver.ResolveAsync(request.RepositoryRoot, request.ManifestPath, cancellationToken);
+        var artifactManifest = await _manifestReader.ReadAsync(request.ArtifactManifestPath, cancellationToken);
+        var plannedEntries = PackageArtifactManifestPlanValidator.Validate(
+            plan,
+            artifactManifest,
+            request.ArtifactsInputPath);
+        var ledgerEntries = new List<PackagePublishLedgerEntry>(plannedEntries.Count);
+        var stopPublishing = false;
+
+        foreach (var entry in plannedEntries)
+        {
+            if (stopPublishing)
+            {
+                ledgerEntries.Add(new PackagePublishLedgerEntry(
+                    entry.ManifestEntry.PackageId,
+                    entry.ManifestEntry.ProjectPath,
+                    entry.ManifestEntry.ArtifactFileName,
+                    PackagePublishStatus.SkippedAfterFailure,
+                    0,
+                    "Skipped because an earlier package failed to publish."));
+                await PersistLedgerAsync(
+                    artifactManifest.PackageVersion,
+                    request,
+                    ledgerEntries,
+                    cancellationToken);
+                continue;
+            }
+
+            var result = await RunPushAsync(request, entry, apiKey, cancellationToken);
+
+            var output = RedactSensitiveOutput(CombineOutput(result), apiKey);
+            if (result.ExitCode == 0)
+            {
+                ledgerEntries.Add(new PackagePublishLedgerEntry(
+                    entry.ManifestEntry.PackageId,
+                    entry.ManifestEntry.ProjectPath,
+                    entry.ManifestEntry.ArtifactFileName,
+                    IsDuplicateOutput(output) ? PackagePublishStatus.DuplicateReported : PackagePublishStatus.Pushed,
+                    result.ExitCode,
+                    output));
+                await PersistLedgerAsync(
+                    artifactManifest.PackageVersion,
+                    request,
+                    ledgerEntries,
+                    cancellationToken);
+                continue;
+            }
+
+            stopPublishing = true;
+            ledgerEntries.Add(new PackagePublishLedgerEntry(
+                entry.ManifestEntry.PackageId,
+                entry.ManifestEntry.ProjectPath,
+                entry.ManifestEntry.ArtifactFileName,
+                PackagePublishStatus.Failed,
+                result.ExitCode,
+                output));
+            await PersistLedgerAsync(
+                artifactManifest.PackageVersion,
+                request,
+                ledgerEntries,
+                cancellationToken);
+        }
+
+        var ledger = new PackagePublishLedger(artifactManifest.PackageVersion, request.Source, ledgerEntries);
+        return ledger;
+    }
+
+    private async Task<ExternalCommandResult> RunPushAsync(
+        PackagePrereleasePublishRequest request,
+        PlannedPackageArtifact entry,
+        string apiKey,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _commandRunner.RunAsync(
+                new ExternalCommandRequest(
+                    "dotnet",
+                    [
+                        "nuget",
+                        "push",
+                        entry.ArtifactPath,
+                        "--source",
+                        request.Source,
+                        "--api-key",
+                        apiKey,
+                        "--skip-duplicate"
+                    ],
+                    request.RepositoryRoot,
+                    "dotnet nuget push",
+                    $"publishing '{entry.ManifestEntry.PackageId}'",
+                    PushTimeoutMilliseconds,
+                    ReleaseEnvironment.Default),
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new ExternalCommandResult(-1, string.Empty, ex.Message);
+        }
+    }
+
+    private async Task PersistLedgerAsync(
+        string packageVersion,
+        PackagePrereleasePublishRequest request,
+        IReadOnlyList<PackagePublishLedgerEntry> ledgerEntries,
+        CancellationToken cancellationToken)
+    {
+        var ledger = new PackagePublishLedger(packageVersion, request.Source, ledgerEntries);
+        Directory.CreateDirectory(Path.GetDirectoryName(request.PublishLogPath)!);
+        await File.WriteAllTextAsync(request.PublishLogPath, _ledgerRenderer.RenderMarkdown(ledger), cancellationToken);
+    }
+
+    private static void ValidatePublishRequest(PackagePrereleasePublishRequest request)
+    {
+        if (!Directory.Exists(request.RepositoryRoot))
+        {
+            throw new PackageIndexException($"Repository root '{request.RepositoryRoot}' does not exist.");
+        }
+
+        if (!File.Exists(request.ManifestPath))
+        {
+            throw new PackageIndexException($"Manifest '{Path.GetRelativePath(request.RepositoryRoot, request.ManifestPath)}' does not exist.");
+        }
+
+        if (!Directory.Exists(request.ArtifactsInputPath))
+        {
+            throw new PackageIndexException($"Package artifact input directory '{request.ArtifactsInputPath}' does not exist.");
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ArtifactManifestPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.PublishLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ApiKeyEnvironmentVariable);
+    }
+
+    private static string CombineOutput(ExternalCommandResult result)
+    {
+        return string.Join(
+            Environment.NewLine,
+            new[] { result.StandardOutput.TrimEnd(), result.StandardError.TrimEnd() }.Where(value => !string.IsNullOrWhiteSpace(value)));
+    }
+
+    private static string RedactSensitiveOutput(string output, string apiKey)
+    {
+        if (string.IsNullOrEmpty(output))
+        {
+            return output;
+        }
+
+        var redacted = output.Replace(apiKey, "[redacted]", StringComparison.Ordinal);
+        return Regex.Replace(
+            redacted,
+            @"(?i)(api[-_ ]?key\s*[:=]\s*)[^\s]+",
+            "$1[redacted]");
+    }
+
+    private static bool IsDuplicateOutput(string output)
+    {
+        return output.Contains("already exists", StringComparison.OrdinalIgnoreCase)
+            || output.Contains("conflict", StringComparison.OrdinalIgnoreCase)
+            || output.Contains("409", StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+/// <summary>
+/// Restores published public packages from a clean NuGet configuration after publish completes.
+/// </summary>
+internal sealed class PackageSmokeInstallWorkflow
+{
+    internal const int RestoreTimeoutMilliseconds = 180_000;
+    internal const int ToolInstallTimeoutMilliseconds = 180_000;
+    private static readonly TimeSpan[] RetryDelays =
+    [
+        TimeSpan.FromSeconds(15),
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromSeconds(60),
+        TimeSpan.FromSeconds(120)
+    ];
+
+    private readonly PackageArtifactManifestReader _manifestReader;
+    private readonly PackagePublishPlanResolver _planResolver;
+    private readonly IExternalCommandRunner _commandRunner;
+    private readonly PackageSmokeInstallReportRenderer _reportRenderer;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+
+    internal PackageSmokeInstallWorkflow(
+        PackageArtifactManifestReader manifestReader,
+        PackagePublishPlanResolver planResolver,
+        IExternalCommandRunner commandRunner,
+        PackageSmokeInstallReportRenderer reportRenderer,
+        Func<TimeSpan, CancellationToken, Task> delayAsync)
+    {
+        _manifestReader = manifestReader;
+        _planResolver = planResolver;
+        _commandRunner = commandRunner;
+        _reportRenderer = reportRenderer;
+        _delayAsync = delayAsync;
+    }
+
+    /// <summary>
+    /// Restores each public package from the configured package source in an isolated workspace.
+    /// </summary>
+    /// <param name="request">Smoke install request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Smoke install report.</returns>
+    internal async Task<PackageSmokeInstallReport> RunAsync(
+        PackageSmokeInstallRequest request,
+        CancellationToken cancellationToken)
+    {
+        ValidateSmokeRequest(request);
+        var manifest = await _manifestReader.ReadAsync(request.ArtifactManifestPath, cancellationToken);
+        var plan = await _planResolver.ResolveAsync(
+            request.RepositoryRoot,
+            request.ManifestPath,
+            cancellationToken);
+        var artifactDirectory = Path.GetDirectoryName(Path.GetFullPath(request.ArtifactManifestPath))
+            ?? throw new PackageIndexException("Package artifact manifest path must include a directory.");
+        var entries = PackageArtifactManifestPlanValidator
+            .Validate(plan, manifest, artifactDirectory)
+            .Where(entry => string.Equals(entry.ManifestEntry.Decision, "publish", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        Directory.CreateDirectory(request.WorkDirectory);
+        var nugetConfigPath = Path.Combine(request.WorkDirectory, "NuGet.config");
+        var sharedPackagesPath = Path.Combine(request.WorkDirectory, "packages");
+        var dotnetHomePath = Path.Combine(request.WorkDirectory, "dotnet-home");
+        Directory.CreateDirectory(sharedPackagesPath);
+        Directory.CreateDirectory(dotnetHomePath);
+        await File.WriteAllTextAsync(nugetConfigPath, RenderNuGetConfig(request.Source), cancellationToken);
+
+        var reportEntries = new List<PackageSmokeInstallReportEntry>(entries.Length);
+        foreach (var entry in entries)
+        {
+            var packageWorkDirectory = Path.Combine(request.WorkDirectory, SanitizeFileName(entry.ManifestEntry.PackageId));
+            if (Directory.Exists(packageWorkDirectory))
+            {
+                Directory.Delete(packageWorkDirectory, recursive: true);
+            }
+
+            Directory.CreateDirectory(packageWorkDirectory);
+            ExternalCommandResult result;
+            if (entry.ManifestEntry.IsTool)
+            {
+                result = await RunToolInstallWithRetryAsync(
+                    request,
+                    manifest.PackageVersion,
+                    entry.ManifestEntry,
+                    packageWorkDirectory,
+                    nugetConfigPath,
+                    dotnetHomePath,
+                    sharedPackagesPath,
+                    cancellationToken);
+            }
+            else
+            {
+                await WriteSmokeProjectAsync(
+                    packageWorkDirectory,
+                    entry.ManifestEntry.PackageId,
+                    manifest.PackageVersion,
+                    cancellationToken);
+                result = await RunRestoreWithRetryAsync(
+                    entry.ManifestEntry,
+                    packageWorkDirectory,
+                    nugetConfigPath,
+                    dotnetHomePath,
+                    sharedPackagesPath,
+                    cancellationToken);
+            }
+
+            reportEntries.Add(new PackageSmokeInstallReportEntry(
+                entry.ManifestEntry.PackageId,
+                entry.ManifestEntry.ProjectPath,
+                entry.ManifestEntry.IsTool,
+                result.ExitCode == 0 ? PackageSmokeInstallStatus.Restored : PackageSmokeInstallStatus.Failed,
+                result.ExitCode,
+                CombineOutput(result)));
+        }
+
+        var report = new PackageSmokeInstallReport(manifest.PackageVersion, request.Source, reportEntries);
+        Directory.CreateDirectory(Path.GetDirectoryName(request.ReportPath)!);
+        await File.WriteAllTextAsync(request.ReportPath, _reportRenderer.RenderMarkdown(report), cancellationToken);
+        return report;
+    }
+
+    private async Task<ExternalCommandResult> RunRestoreWithRetryAsync(
+        PackageArtifactManifestEntry entry,
+        string packageWorkDirectory,
+        string nugetConfigPath,
+        string dotnetHomePath,
+        string sharedPackagesPath,
+        CancellationToken cancellationToken)
+    {
+        return await RunWithRetryAsync(
+            () => _commandRunner.RunAsync(
+                new ExternalCommandRequest(
+                    "dotnet",
+                    [
+                        "restore",
+                        Path.Combine(packageWorkDirectory, "Smoke.csproj"),
+                        "--configfile",
+                        nugetConfigPath,
+                        "--packages",
+                        sharedPackagesPath
+                    ],
+                    packageWorkDirectory,
+                    "dotnet restore",
+                    $"restoring '{entry.PackageId}'",
+                    RestoreTimeoutMilliseconds,
+                    CreateSmokeEnvironment(dotnetHomePath, sharedPackagesPath)),
+                cancellationToken),
+            cancellationToken);
+    }
+
+    private async Task<ExternalCommandResult> RunToolInstallWithRetryAsync(
+        PackageSmokeInstallRequest request,
+        string packageVersion,
+        PackageArtifactManifestEntry entry,
+        string packageWorkDirectory,
+        string nugetConfigPath,
+        string dotnetHomePath,
+        string sharedPackagesPath,
+        CancellationToken cancellationToken)
+    {
+        var toolPath = Path.Combine(packageWorkDirectory, "tools");
+        Directory.CreateDirectory(toolPath);
+        return await RunWithRetryAsync(
+            () => _commandRunner.RunAsync(
+                new ExternalCommandRequest(
+                    "dotnet",
+                    [
+                        "tool",
+                        "install",
+                        entry.PackageId,
+                        "--version",
+                        packageVersion,
+                        "--tool-path",
+                        toolPath,
+                        "--configfile",
+                        nugetConfigPath,
+                        "--add-source",
+                        request.Source
+                    ],
+                    packageWorkDirectory,
+                    "dotnet tool install",
+                    $"installing tool '{entry.PackageId}'",
+                    ToolInstallTimeoutMilliseconds,
+                    CreateSmokeEnvironment(dotnetHomePath, sharedPackagesPath)),
+                cancellationToken),
+            cancellationToken);
+    }
+
+    private async Task<ExternalCommandResult> RunWithRetryAsync(
+        Func<Task<ExternalCommandResult>> runAsync,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; attempt <= RetryDelays.Length; attempt++)
+        {
+            var result = await runAsync();
+            if (result.ExitCode == 0 || attempt == RetryDelays.Length)
+            {
+                return result;
+            }
+
+            await _delayAsync(RetryDelays[attempt], cancellationToken);
+        }
+
+        throw new UnreachableException();
+    }
+
+    private static void ValidateSmokeRequest(PackageSmokeInstallRequest request)
+    {
+        if (!Directory.Exists(request.RepositoryRoot))
+        {
+            throw new PackageIndexException($"Repository root '{request.RepositoryRoot}' does not exist.");
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ArtifactManifestPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ManifestPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ReportPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Source);
+    }
+
+    private static async Task WriteSmokeProjectAsync(
+        string packageWorkDirectory,
+        string packageId,
+        string packageVersion,
+        CancellationToken cancellationToken)
+    {
+        var project = new XDocument(
+            new XElement("Project",
+                new XAttribute("Sdk", "Microsoft.NET.Sdk"),
+                new XElement("PropertyGroup",
+                    new XElement("OutputType", "Exe"),
+                    new XElement("TargetFramework", "net10.0"),
+                    new XElement("ImplicitUsings", "enable"),
+                    new XElement("Nullable", "enable")),
+                new XElement("ItemGroup",
+                    new XElement("PackageReference",
+                        new XAttribute("Include", packageId),
+                        new XAttribute("Version", packageVersion)))));
+        await File.WriteAllTextAsync(Path.Combine(packageWorkDirectory, "Smoke.csproj"), project.ToString(), cancellationToken);
+        await File.WriteAllTextAsync(Path.Combine(packageWorkDirectory, "Program.cs"), "Console.WriteLine(\"smoke\");" + Environment.NewLine, cancellationToken);
+    }
+
+    private static string RenderNuGetConfig(string source)
+    {
+        var escapedSource = SecurityElement.Escape(source) ?? source;
+        return $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="nuget-org" value="{{escapedSource}}" />
+              </packageSources>
+            </configuration>
+            """;
+    }
+
+    private static IReadOnlyDictionary<string, string?> CreateSmokeEnvironment(string dotnetHomePath, string sharedPackagesPath)
+    {
+        return new Dictionary<string, string?>
+        {
+            ["DOTNET_CLI_HOME"] = dotnetHomePath,
+            ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
+            ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
+            ["DOTNET_NOLOGO"] = "1",
+            ["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1",
+            ["NUGET_PACKAGES"] = sharedPackagesPath
+        };
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        var invalidCharacters = Path.GetInvalidFileNameChars().ToHashSet();
+        return new string(value.Select(character => invalidCharacters.Contains(character) ? '_' : character).ToArray());
+    }
+
+    private static string CombineOutput(ExternalCommandResult result)
+    {
+        return string.Join(
+            Environment.NewLine,
+            new[] { result.StandardOutput.TrimEnd(), result.StandardError.TrimEnd() }.Where(value => !string.IsNullOrWhiteSpace(value)));
+    }
+}
+
+/// <summary>
+/// Renders protected publish outcomes for workflow artifacts.
+/// </summary>
+internal sealed class PackagePublishLedgerRenderer
+{
+    internal string RenderMarkdown(PackagePublishLedger ledger)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# NuGet prerelease publish ledger");
+        builder.AppendLine();
+        builder.AppendLine($"Version: `{ledger.PackageVersion}`");
+        builder.AppendLine($"Source: `{ledger.Source}`");
+        builder.AppendLine();
+        builder.AppendLine("| Package | Project | Artifact | Status | Exit code |");
+        builder.AppendLine("| --- | --- | --- | --- | --- |");
+        foreach (var entry in ledger.Entries)
+        {
+            builder.AppendLine($"| `{entry.PackageId}` | `{entry.ProjectPath}` | `{entry.ArtifactFileName}` | `{FormatStatus(entry.Status)}` | `{entry.ExitCode}` |");
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("## Details");
+        foreach (var entry in ledger.Entries.Where(entry => !string.IsNullOrWhiteSpace(entry.Output)))
+        {
+            builder.AppendLine();
+            builder.AppendLine($"### {entry.PackageId}");
+            builder.AppendLine();
+            builder.AppendLine("```text");
+            builder.AppendLine(entry.Output.TrimEnd());
+            builder.AppendLine("```");
+        }
+
+        return builder.ToString().TrimEnd() + Environment.NewLine;
+    }
+
+    private static string FormatStatus(PackagePublishStatus status)
+    {
+        return status switch
+        {
+            PackagePublishStatus.Pushed => "pushed",
+            PackagePublishStatus.DuplicateReported => "duplicate-reported",
+            PackagePublishStatus.Failed => "failed",
+            PackagePublishStatus.SkippedAfterFailure => "skipped-after-failure",
+            _ => status.ToString()
+        };
+    }
+}
+
+/// <summary>
+/// Renders package smoke install outcomes for workflow artifacts.
+/// </summary>
+internal sealed class PackageSmokeInstallReportRenderer
+{
+    internal string RenderMarkdown(PackageSmokeInstallReport report)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Package smoke install report");
+        builder.AppendLine();
+        builder.AppendLine($"Version: `{report.PackageVersion}`");
+        builder.AppendLine($"Source: `{report.Source}`");
+        builder.AppendLine();
+        builder.AppendLine("| Package | Project | Kind | Status | Exit code |");
+        builder.AppendLine("| --- | --- | --- | --- | --- |");
+        foreach (var entry in report.Entries)
+        {
+            builder.AppendLine($"| `{entry.PackageId}` | `{entry.ProjectPath}` | `{(entry.IsTool ? "tool" : "package")}` | `{FormatStatus(entry.Status)}` | `{entry.ExitCode}` |");
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("## Details");
+        foreach (var entry in report.Entries.Where(entry => !string.IsNullOrWhiteSpace(entry.Output)))
+        {
+            builder.AppendLine();
+            builder.AppendLine($"### {entry.PackageId}");
+            builder.AppendLine();
+            builder.AppendLine("```text");
+            builder.AppendLine(entry.Output.TrimEnd());
+            builder.AppendLine("```");
+        }
+
+        return builder.ToString().TrimEnd() + Environment.NewLine;
+    }
+
+    private static string FormatStatus(PackageSmokeInstallStatus status)
+    {
+        return status switch
+        {
+            PackageSmokeInstallStatus.Restored => "restored",
+            PackageSmokeInstallStatus.Failed => "failed",
+            _ => status.ToString()
+        };
+    }
+}
+
+/// <summary>
+/// Request for the protected NuGet prerelease publish workflow.
+/// </summary>
+/// <param name="RepositoryRoot">Repository root used for plan resolution.</param>
+/// <param name="ManifestPath">Checked-in package manifest path.</param>
+/// <param name="ArtifactsInputPath">Directory containing validated <c>.nupkg</c> files.</param>
+/// <param name="ArtifactManifestPath">Machine-readable artifact manifest path.</param>
+/// <param name="PublishLogPath">Markdown publish ledger path.</param>
+/// <param name="Source">NuGet source URL.</param>
+/// <param name="ApiKeyEnvironmentVariable">Environment variable that supplies the NuGet API key.</param>
+internal sealed record PackagePrereleasePublishRequest(
+    string RepositoryRoot,
+    string ManifestPath,
+    string ArtifactsInputPath,
+    string ArtifactManifestPath,
+    string PublishLogPath,
+    string Source,
+    string ApiKeyEnvironmentVariable);
+
+/// <summary>
+/// Request for the post-publish smoke install workflow.
+/// </summary>
+/// <param name="RepositoryRoot">Repository root used for path display and validation.</param>
+/// <param name="ManifestPath">Checked-in package manifest path used to revalidate the artifact manifest.</param>
+/// <param name="ArtifactManifestPath">Machine-readable artifact manifest path.</param>
+/// <param name="WorkDirectory">Isolated smoke install work directory.</param>
+/// <param name="ReportPath">Markdown smoke install report path.</param>
+/// <param name="Source">NuGet source URL.</param>
+internal sealed record PackageSmokeInstallRequest(
+    string RepositoryRoot,
+    string ManifestPath,
+    string ArtifactManifestPath,
+    string WorkDirectory,
+    string ReportPath,
+    string Source);
+
+/// <summary>
+/// Machine-readable artifact manifest that binds validated package artifacts to immutable hashes.
+/// </summary>
+/// <param name="SchemaVersion">Manifest schema version.</param>
+/// <param name="PackageVersion">Exact prerelease package version.</param>
+/// <param name="GeneratedAtUtc">UTC timestamp when the manifest was generated.</param>
+/// <param name="Entries">Manifest entries in package publish order.</param>
+internal sealed record PackageArtifactManifest(
+    [property: JsonPropertyName("schema_version")] int SchemaVersion,
+    [property: JsonPropertyName("package_version")] string PackageVersion,
+    [property: JsonPropertyName("generated_at_utc")] DateTimeOffset GeneratedAtUtc,
+    [property: JsonPropertyName("entries")] IReadOnlyList<PackageArtifactManifestEntry> Entries);
+
+/// <summary>
+/// One package artifact selected from the checked-in package manifest.
+/// </summary>
+/// <param name="PackageId">NuGet package id.</param>
+/// <param name="ProjectPath">Repository-relative project path.</param>
+/// <param name="Decision">Publish decision string from the package plan.</param>
+/// <param name="ArtifactFileName">Package artifact file name without directory segments.</param>
+/// <param name="Sha512">Lowercase hexadecimal SHA-512 hash of the package artifact.</param>
+/// <param name="IsTool">Whether the artifact is a .NET tool package.</param>
+internal sealed record PackageArtifactManifestEntry(
+    [property: JsonPropertyName("package_id")] string PackageId,
+    [property: JsonPropertyName("project_path")] string ProjectPath,
+    [property: JsonPropertyName("decision")] string Decision,
+    [property: JsonPropertyName("artifact_file_name")] string ArtifactFileName,
+    [property: JsonPropertyName("sha512")] string Sha512,
+    [property: JsonPropertyName("is_tool")] bool IsTool);
+
+/// <summary>
+/// Publish result for a coordinated prerelease package version.
+/// </summary>
+/// <param name="PackageVersion">Exact prerelease package version.</param>
+/// <param name="Source">NuGet source URL.</param>
+/// <param name="Entries">Per-package publish outcomes.</param>
+internal sealed record PackagePublishLedger(
+    string PackageVersion,
+    string Source,
+    IReadOnlyList<PackagePublishLedgerEntry> Entries);
+
+/// <summary>
+/// Publish outcome for one package artifact.
+/// </summary>
+/// <param name="PackageId">NuGet package id.</param>
+/// <param name="ProjectPath">Repository-relative project path.</param>
+/// <param name="ArtifactFileName">Package artifact file name.</param>
+/// <param name="Status">Publish status.</param>
+/// <param name="ExitCode">Exit code from <c>dotnet nuget push</c>, or zero for skipped packages.</param>
+/// <param name="Output">Captured publish output with secrets excluded.</param>
+internal sealed record PackagePublishLedgerEntry(
+    string PackageId,
+    string ProjectPath,
+    string ArtifactFileName,
+    PackagePublishStatus Status,
+    int ExitCode,
+    string Output);
+
+/// <summary>
+/// Publish status values written to the protected publish ledger.
+/// </summary>
+internal enum PackagePublishStatus
+{
+    Pushed,
+    DuplicateReported,
+    Failed,
+    SkippedAfterFailure
+}
+
+/// <summary>
+/// Smoke install result for packages restored after prerelease publishing.
+/// </summary>
+/// <param name="PackageVersion">Exact prerelease package version.</param>
+/// <param name="Source">NuGet source URL.</param>
+/// <param name="Entries">Per-package smoke install outcomes.</param>
+internal sealed record PackageSmokeInstallReport(
+    string PackageVersion,
+    string Source,
+    IReadOnlyList<PackageSmokeInstallReportEntry> Entries);
+
+/// <summary>
+/// Smoke install outcome for one public package.
+/// </summary>
+/// <param name="PackageId">NuGet package id.</param>
+/// <param name="ProjectPath">Repository-relative project path.</param>
+/// <param name="IsTool">Whether the package was installed as a .NET tool.</param>
+/// <param name="Status">Smoke install status.</param>
+/// <param name="ExitCode">Exit code from the final restore or tool install attempt.</param>
+/// <param name="Output">Captured install output.</param>
+internal sealed record PackageSmokeInstallReportEntry(
+    string PackageId,
+    string ProjectPath,
+    bool IsTool,
+    PackageSmokeInstallStatus Status,
+    int ExitCode,
+    string Output);
+
+/// <summary>
+/// Smoke install status values written to the smoke report.
+/// </summary>
+internal enum PackageSmokeInstallStatus
+{
+    Restored,
+    Failed
+}
+
+/// <summary>
+/// Computes package artifact hashes for manifest generation and publish verification.
+/// </summary>
+internal static class PackageHash
+{
+    internal static async Task<string> ComputeSha512Async(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(path);
+        var hash = await SHA512.HashDataAsync(stream, cancellationToken);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    internal static string ComputeSha512(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var hash = SHA512.HashData(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+/// <summary>
+/// JSON serializer options shared by artifact manifest readers and writers.
+/// </summary>
+internal static class PackageArtifactJson
+{
+    internal static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true
+    };
+}
+
+/// <summary>
+/// Environment variables that make release automation quieter and deterministic.
+/// </summary>
+internal static class ReleaseEnvironment
+{
+    internal static readonly IReadOnlyDictionary<string, string?> Default = new Dictionary<string, string?>
+    {
+        ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
+        ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
+        ["DOTNET_NOLOGO"] = "1",
+        ["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1"
+    };
+}
+
+/// <summary>
+/// Formats package publish decisions for machine-readable release artifacts.
+/// </summary>
+internal static class PackagePublishDecisionFormatter
+{
+    internal static string Format(PackagePublishDecision decision)
+    {
+        return decision switch
+        {
+            PackagePublishDecision.Publish => "publish",
+            PackagePublishDecision.SupportPublish => "support_publish",
+            PackagePublishDecision.DoNotPublish => "do_not_publish",
+            _ => decision.ToString()
+        };
+    }
+}
+
+/// <summary>
+/// Verifies that an artifact manifest still matches the checked-in package plan and validated artifacts.
+/// </summary>
+internal static class PackageArtifactManifestPlanValidator
+{
+    internal static IReadOnlyList<PlannedPackageArtifact> Validate(
+        PackagePublishPlan plan,
+        PackageArtifactManifest manifest,
+        string artifactsInputPath)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactsInputPath);
+
+        if (plan.Entries.Count != manifest.Entries.Count)
+        {
+            throw new PackageIndexException(
+                $"Package artifact manifest contains {manifest.Entries.Count} entries, but the package plan contains {plan.Entries.Count} entries.");
+        }
+
+        var plannedEntries = new List<PlannedPackageArtifact>(plan.Entries.Count);
+        for (var index = 0; index < plan.Entries.Count; index++)
+        {
+            var planEntry = plan.Entries[index];
+            var manifestEntry = manifest.Entries[index];
+            var expectedDecision = PackagePublishDecisionFormatter.Format(planEntry.Decision);
+            if (!string.Equals(planEntry.PackageId, manifestEntry.PackageId, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(planEntry.ProjectPath, manifestEntry.ProjectPath, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(expectedDecision, manifestEntry.Decision, StringComparison.OrdinalIgnoreCase)
+                || planEntry.IsTool != manifestEntry.IsTool)
+            {
+                throw new PackageIndexException(
+                    $"Package artifact manifest entry {index + 1} does not match package plan entry '{planEntry.PackageId}'.");
+            }
+
+            var artifactPath = Path.Combine(artifactsInputPath, manifestEntry.ArtifactFileName);
+            if (!File.Exists(artifactPath))
+            {
+                throw new PackageIndexException($"Package artifact '{manifestEntry.ArtifactFileName}' for '{manifestEntry.PackageId}' does not exist.");
+            }
+
+            var actualHash = PackageHash.ComputeSha512(artifactPath);
+            if (!string.Equals(actualHash, manifestEntry.Sha512, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new PackageIndexException($"Package artifact '{manifestEntry.ArtifactFileName}' for '{manifestEntry.PackageId}' does not match the manifest SHA-512 hash.");
+            }
+
+            plannedEntries.Add(new PlannedPackageArtifact(manifestEntry, artifactPath));
+        }
+
+        return plannedEntries;
+    }
+}
+
+/// <summary>
+/// Package artifact that has been matched to both the checked-in plan and artifact manifest.
+/// </summary>
+/// <param name="ManifestEntry">Manifest entry for the artifact.</param>
+/// <param name="ArtifactPath">Resolved artifact path on disk.</param>
+internal sealed record PlannedPackageArtifact(
+    PackageArtifactManifestEntry ManifestEntry,
+    string ArtifactPath);

--- a/tools/ForgeTrust.AppSurface.PackageIndex/Program.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/Program.cs
@@ -11,6 +11,8 @@ internal static class Program
     private const string VerifyPackagesCommand = "verify-packages";
     private const string VerifyCommand = "verify";
     private const string GateCommand = "gate";
+    private const string PublishPrereleaseCommand = "publish-prerelease";
+    private const string SmokeInstallCommand = "smoke-install";
 
     private static readonly string Usage = """
         ForgeTrust.AppSurface.PackageIndex
@@ -25,6 +27,10 @@ internal static class Program
           verify      Check that packages/README.md is already up to date.
           verify-packages
                       Pack and validate prerelease .nupkg artifacts without publishing them.
+          publish-prerelease
+                      Publish validated prerelease package artifacts to NuGet from a protected workflow job.
+          smoke-install
+                      Restore published prerelease packages from a clean NuGet configuration.
           gate        Validate release metadata, package class rules, and stale brand strings.
 
         Options:
@@ -33,9 +39,19 @@ internal static class Program
           --output <path>       Generated chooser path. Defaults to packages/README.md.
           --artifacts-output <path>
                                 Package artifact output directory. Defaults to artifacts/packages.
+          --artifacts-input <path>
+                                Validated package artifact input directory. Defaults to artifacts/packages.
+          --artifact-manifest <path>
+                                Machine-readable validated artifact manifest path. Defaults to artifacts/package-artifact-manifest.json.
           --package-version <version>
                                 Required prerelease package version for verify-packages.
           --report <path>       Package artifact report path. Defaults to artifacts/package-validation-report.md.
+          --publish-log <path>  Publish ledger path. Defaults to artifacts/package-publish-log.md.
+          --source <url>        NuGet source URL. Defaults to https://api.nuget.org/v3/index.json.
+          --api-key-env <name>  Environment variable containing the NuGet API key. Defaults to NUGET_API_KEY.
+          --smoke-work-dir <path>
+                                Isolated smoke install work directory. Defaults to artifacts/package-smoke.
+          --smoke-report <path> Smoke install report path. Defaults to artifacts/package-smoke-report.md.
           -h, --help            Show this help.
         """;
 
@@ -62,6 +78,8 @@ internal static class Program
     /// <param name="currentDirectory">Working directory used to resolve default repository-relative paths after help handling.</param>
     /// <param name="cancellationToken">Cancellation token propagated to generator operations.</param>
     /// <param name="verifyPackagesAsync">Optional package artifact workflow override used by tests.</param>
+    /// <param name="publishPrereleaseAsync">Optional prerelease publish workflow override used by tests.</param>
+    /// <param name="smokeInstallAsync">Optional smoke install workflow override used by tests.</param>
     /// <returns><c>0</c> when the command succeeds; otherwise a non-zero exit code.</returns>
     internal static async Task<int> RunAsync(
         string[] args,
@@ -69,7 +87,9 @@ internal static class Program
         TextWriter standardError,
         string currentDirectory,
         CancellationToken cancellationToken = default,
-        Func<PackageArtifactRequest, CancellationToken, Task<PackageArtifactValidationReport>>? verifyPackagesAsync = null)
+        Func<PackageArtifactRequest, CancellationToken, Task<PackageArtifactValidationReport>>? verifyPackagesAsync = null,
+        Func<PackagePrereleasePublishRequest, CancellationToken, Task<PackagePublishLedger>>? publishPrereleaseAsync = null,
+        Func<PackageSmokeInstallRequest, CancellationToken, Task<PackageSmokeInstallReport>>? smokeInstallAsync = null)
     {
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(standardOut);
@@ -98,7 +118,12 @@ internal static class Program
             }
 
             var normalizedCommand = command.ToLowerInvariant();
-            if (normalizedCommand is not GenerateCommand and not VerifyCommand and not VerifyPackagesCommand and not GateCommand)
+            if (normalizedCommand is not GenerateCommand
+                and not VerifyCommand
+                and not VerifyPackagesCommand
+                and not GateCommand
+                and not PublishPrereleaseCommand
+                and not SmokeInstallCommand)
             {
                 await standardError.WriteLineAsync($"Unknown command '{command}'.");
                 await standardError.WriteLineAsync(Usage);
@@ -129,6 +154,28 @@ internal static class Program
                 await standardOut.WriteLineAsync(
                     $"Validated {artifactReport.Entries.Count} package artifacts for {packageRequest.PackageVersion}. Report: {reportPath}.");
                 return 0;
+            }
+
+            if (normalizedCommand == PublishPrereleaseCommand)
+            {
+                var publishRequest = options.CreatePackagePrereleasePublishRequest();
+                publishPrereleaseAsync ??= RunPackagePrereleasePublishWorkflowAsync;
+                var ledger = await publishPrereleaseAsync(publishRequest, cancellationToken);
+                var reportPath = FormatDisplayPath(publishRequest.RepositoryRoot, publishRequest.PublishLogPath);
+                await standardOut.WriteLineAsync(
+                    $"Published {ledger.Entries.Count(entry => entry.Status is PackagePublishStatus.Pushed or PackagePublishStatus.DuplicateReported)} package artifacts for {ledger.PackageVersion}. Log: {reportPath}.");
+                return ledger.Entries.Any(entry => entry.Status == PackagePublishStatus.Failed) ? 1 : 0;
+            }
+
+            if (normalizedCommand == SmokeInstallCommand)
+            {
+                var smokeRequest = options.CreatePackageSmokeInstallRequest();
+                smokeInstallAsync ??= RunPackageSmokeInstallWorkflowAsync;
+                var smokeReport = await smokeInstallAsync(smokeRequest, cancellationToken);
+                var reportPath = FormatDisplayPath(smokeRequest.RepositoryRoot, smokeRequest.ReportPath);
+                await standardOut.WriteLineAsync(
+                    $"Smoke installed {smokeReport.Entries.Count(entry => entry.Status == PackageSmokeInstallStatus.Restored)} published prerelease packages for {smokeReport.PackageVersion}. Report: {reportPath}.");
+                return smokeReport.Entries.Any(entry => entry.Status == PackageSmokeInstallStatus.Failed) ? 1 : 0;
             }
 
             if (normalizedCommand == VerifyCommand)
@@ -171,6 +218,39 @@ internal static class Program
         return await workflow.RunAsync(packageRequest, cancellationToken);
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Default CLI dependency wiring is covered by package prerelease workflow tests.")]
+    private static async Task<PackagePublishLedger> RunPackagePrereleasePublishWorkflowAsync(
+        PackagePrereleasePublishRequest request,
+        CancellationToken cancellationToken)
+    {
+        var workflow = new PackagePrereleasePublishWorkflow(
+            new PackagePublishPlanResolver(
+                new PackageProjectScanner(),
+                new DotNetProjectMetadataProvider(),
+                new PackageManifestLoader()),
+            new PackageArtifactManifestReader(),
+            new CliWrapCommandRunner(),
+            new PackagePublishLedgerRenderer());
+        return await workflow.RunAsync(request, cancellationToken);
+    }
+
+    [ExcludeFromCodeCoverage(Justification = "Default CLI dependency wiring is covered by package smoke workflow tests.")]
+    private static async Task<PackageSmokeInstallReport> RunPackageSmokeInstallWorkflowAsync(
+        PackageSmokeInstallRequest request,
+        CancellationToken cancellationToken)
+    {
+        var workflow = new PackageSmokeInstallWorkflow(
+            new PackageArtifactManifestReader(),
+            new PackagePublishPlanResolver(
+                new PackageProjectScanner(),
+                new DotNetProjectMetadataProvider(),
+                new PackageManifestLoader()),
+            new CliWrapCommandRunner(),
+            new PackageSmokeInstallReportRenderer(),
+            Task.Delay);
+        return await workflow.RunAsync(request, cancellationToken);
+    }
+
     private static string FormatDisplayPath(string repositoryRoot, string path)
     {
         var normalizedRoot = Path.GetFullPath(repositoryRoot);
@@ -196,11 +276,25 @@ internal static class Program
 /// <param name="ArtifactsOutputPath">Resolved package artifact output directory.</param>
 /// <param name="ReportPath">Resolved package artifact validation report path.</param>
 /// <param name="PackageVersion">Optional package version supplied for package artifact verification.</param>
+/// <param name="ArtifactsInputPath">Resolved package artifact input directory for protected publish jobs.</param>
+/// <param name="ArtifactManifestPath">Resolved machine-readable package artifact manifest path.</param>
+/// <param name="PublishLogPath">Resolved protected publish ledger path.</param>
+/// <param name="Source">NuGet source URL used for publish and smoke install.</param>
+/// <param name="ApiKeyEnvironmentVariable">Environment variable name that supplies the NuGet API key.</param>
+/// <param name="SmokeWorkDirectory">Resolved isolated smoke install work directory.</param>
+/// <param name="SmokeReportPath">Resolved smoke install report path.</param>
 internal sealed record CommandLineOptions(
     PackageIndexRequest Request,
     string ArtifactsOutputPath,
     string ReportPath,
-    string? PackageVersion)
+    string? PackageVersion,
+    string ArtifactsInputPath,
+    string ArtifactManifestPath,
+    string PublishLogPath,
+    string Source,
+    string ApiKeyEnvironmentVariable,
+    string SmokeWorkDirectory,
+    string SmokeReportPath)
 {
     /// <summary>
     /// Parses path-related CLI options into a resolved chooser request.
@@ -215,8 +309,15 @@ internal sealed record CommandLineOptions(
         string? manifestPath = null;
         string? outputPath = null;
         string? artifactsOutputPath = null;
+        string? artifactsInputPath = null;
+        string? artifactManifestPath = null;
         string? packageVersion = null;
         string? reportPath = null;
+        string? publishLogPath = null;
+        string? source = null;
+        string? apiKeyEnvironmentVariable = null;
+        string? smokeWorkDirectory = null;
+        string? smokeReportPath = null;
 
         for (var index = 0; index < args.Length; index++)
         {
@@ -245,6 +346,18 @@ internal sealed record CommandLineOptions(
                 continue;
             }
 
+            if (string.Equals(argument, "--artifacts-input", StringComparison.Ordinal))
+            {
+                artifactsInputPath = ReadRequiredValue(args, ref index, argument);
+                continue;
+            }
+
+            if (string.Equals(argument, "--artifact-manifest", StringComparison.Ordinal))
+            {
+                artifactManifestPath = ReadRequiredValue(args, ref index, argument);
+                continue;
+            }
+
             if (string.Equals(argument, "--package-version", StringComparison.Ordinal))
             {
                 packageVersion = ReadRequiredValue(args, ref index, argument);
@@ -257,6 +370,36 @@ internal sealed record CommandLineOptions(
                 continue;
             }
 
+            if (string.Equals(argument, "--publish-log", StringComparison.Ordinal))
+            {
+                publishLogPath = ReadRequiredValue(args, ref index, argument);
+                continue;
+            }
+
+            if (string.Equals(argument, "--source", StringComparison.Ordinal))
+            {
+                source = ReadRequiredValue(args, ref index, argument);
+                continue;
+            }
+
+            if (string.Equals(argument, "--api-key-env", StringComparison.Ordinal))
+            {
+                apiKeyEnvironmentVariable = ReadRequiredValue(args, ref index, argument);
+                continue;
+            }
+
+            if (string.Equals(argument, "--smoke-work-dir", StringComparison.Ordinal))
+            {
+                smokeWorkDirectory = ReadRequiredValue(args, ref index, argument);
+                continue;
+            }
+
+            if (string.Equals(argument, "--smoke-report", StringComparison.Ordinal))
+            {
+                smokeReportPath = ReadRequiredValue(args, ref index, argument);
+                continue;
+            }
+
             throw new PackageIndexException($"Unknown option '{argument}'.");
         }
 
@@ -264,13 +407,25 @@ internal sealed record CommandLineOptions(
         var resolvedManifestPath = ResolvePath(manifestPath, repoRoot, Path.Combine(repoRoot, "packages", "package-index.yml"));
         var resolvedOutputPath = ResolvePath(outputPath, repoRoot, Path.Combine(repoRoot, "packages", "README.md"));
         var resolvedArtifactsOutputPath = ResolvePath(artifactsOutputPath, repoRoot, Path.Combine(repoRoot, "artifacts", "packages"));
+        var resolvedArtifactsInputPath = ResolvePath(artifactsInputPath, repoRoot, resolvedArtifactsOutputPath);
+        var resolvedArtifactManifestPath = ResolvePath(artifactManifestPath, repoRoot, Path.Combine(repoRoot, "artifacts", "package-artifact-manifest.json"));
         var resolvedReportPath = ResolvePath(reportPath, repoRoot, Path.Combine(repoRoot, "artifacts", "package-validation-report.md"));
+        var resolvedPublishLogPath = ResolvePath(publishLogPath, repoRoot, Path.Combine(repoRoot, "artifacts", "package-publish-log.md"));
+        var resolvedSmokeWorkDirectory = ResolvePath(smokeWorkDirectory, repoRoot, Path.Combine(repoRoot, "artifacts", "package-smoke"));
+        var resolvedSmokeReportPath = ResolvePath(smokeReportPath, repoRoot, Path.Combine(repoRoot, "artifacts", "package-smoke-report.md"));
 
         return new CommandLineOptions(
             new PackageIndexRequest(repoRoot, resolvedManifestPath, resolvedOutputPath),
             resolvedArtifactsOutputPath,
             resolvedReportPath,
-            packageVersion);
+            packageVersion,
+            resolvedArtifactsInputPath,
+            resolvedArtifactManifestPath,
+            resolvedPublishLogPath,
+            string.IsNullOrWhiteSpace(source) ? "https://api.nuget.org/v3/index.json" : source,
+            string.IsNullOrWhiteSpace(apiKeyEnvironmentVariable) ? "NUGET_API_KEY" : apiKeyEnvironmentVariable,
+            resolvedSmokeWorkDirectory,
+            resolvedSmokeReportPath);
     }
 
     /// <summary>
@@ -290,7 +445,39 @@ internal sealed record CommandLineOptions(
             Request.ManifestPath,
             ArtifactsOutputPath,
             ReportPath,
-            PackageVersion);
+            PackageVersion,
+            ArtifactManifestPath);
+    }
+
+    /// <summary>
+    /// Converts parsed CLI options into a protected prerelease publish request.
+    /// </summary>
+    /// <returns>The prerelease publish request.</returns>
+    internal PackagePrereleasePublishRequest CreatePackagePrereleasePublishRequest()
+    {
+        return new PackagePrereleasePublishRequest(
+            Request.RepositoryRoot,
+            Request.ManifestPath,
+            ArtifactsInputPath,
+            ArtifactManifestPath,
+            PublishLogPath,
+            Source,
+            ApiKeyEnvironmentVariable);
+    }
+
+    /// <summary>
+    /// Converts parsed CLI options into a package smoke install request.
+    /// </summary>
+    /// <returns>The package smoke install request.</returns>
+    internal PackageSmokeInstallRequest CreatePackageSmokeInstallRequest()
+    {
+        return new PackageSmokeInstallRequest(
+            Request.RepositoryRoot,
+            Request.ManifestPath,
+            ArtifactManifestPath,
+            SmokeWorkDirectory,
+            SmokeReportPath,
+            Source);
     }
 
     private static string ReadRequiredValue(string[] args, ref int index, string argument)

--- a/tools/ForgeTrust.AppSurface.PackageIndex/packages.lock.json
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
+      },
       "YamlDotNet": {
         "type": "Direct",
         "requested": "[17.0.1, )",


### PR DESCRIPTION
## Summary

Fixes #253.

Adds the protected NuGet prerelease publishing path for the AppSurface package family:

- Adds `.github/workflows/nuget-prerelease-publish.yml`, tag-only publishing for annotated prerelease tags that resolve to `origin/main`.
- Gates publish on successful source CI for the tagged commit, a protected `nuget-prerelease` environment, required reviewers, and self-review prevention.
- Extends `PackageIndex` with `publish-prerelease` and `smoke-install` commands backed by CliWrap.
- Writes and revalidates a SHA-512 package artifact manifest before publishing or smoke restore.
- Publishes with `dotnet nuget push --skip-duplicate`, redacts publish output, and writes an incremental publish ledger for partial-publish recovery.
- Adds a post-publish smoke install using a clean NuGet configuration pointed only at nuget.org.
- Documents setup, environment requirements, partial publish recovery, and smoke-install behavior in `.github/release-ops.md`.

## Pre-Landing Review

- Standalone `/review` found and fixed one gap: workflow docs required self-review prevention, but the workflow only enforced required reviewers. The workflow now fails closed unless `prevent_self_review == true` on the required-reviewers protection rule.
- Review result was persisted as clean after the fix.

## QA

- `/qa` ran against the local RazorDocs standalone docs host at `http://localhost:5189/docs`.
- Browser QA found 0 issues and applied 0 fixes.
- Health score: `100/100`.
- QA report: `.gstack/qa-reports/qa-report-localhost-5189-2026-05-13.md`.

## Test Coverage

PackageIndex test coverage was expanded around artifact manifest validation, publish ledger behavior, secret redaction, failure handling, smoke install retries, manifest-plan mismatch rejection, and CLI command parsing.

## Verification

- [x] `dotnet test tools/ForgeTrust.AppSurface.PackageIndex.Tests/ForgeTrust.AppSurface.PackageIndex.Tests.csproj --no-restore` - 123 passed
- [x] `dotnet build ForgeTrust.AppSurface.slnx --no-restore` - 0 warnings, 0 errors
- [x] `dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- gate`
- [x] `dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- verify`
- [x] `dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- verify-packages ...` - 17 artifacts plus manifest
- [x] `git diff --check`

## Operational Notes

Before the first prerelease tag, create the GitHub environment `nuget-prerelease` with required reviewers, self-review prevention, and an environment-scoped `NUGET_API_KEY`. The workflow intentionally fails closed if that environment is missing or under-protected.
