### PR TITLE
feat: add appsurface docs cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,8 +116,8 @@ jobs:
           dotnet run --project Web/ForgeTrust.RazorWire.Cli/ForgeTrust.RazorWire.Cli.csproj -c Release -- \
             export \
             --mode cdn \
-            --output "$RUNNER_TEMP/razordocs-pages" \
             --seeds "$RUNNER_TEMP/razordocs-seeds.txt" \
+            --output "$RUNNER_TEMP/razordocs-pages" \
             --project Web/ForgeTrust.AppSurface.Docs.Standalone/ForgeTrust.AppSurface.Docs.Standalone.csproj
 
       - name: Upload Pages artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 
 ### Added
 
+- AppSurface now has a planned `appsurface` .NET tool surface. Its first verb is `appsurface docs`, which runs RazorDocs preview workflows through the existing standalone docs host instead of minting a separate `razordocs` CLI.
+- AppSurface Web now has a startup watchdog that fails fast when a web host stalls before Kestrel starts listening; `appsurface docs` exposes the same guard through `--startup-timeout-seconds`.
+- RazorDocs and RazorWire runtime assets are now embedded into their assemblies and served through endpoint fallbacks, so packaged CLI hosts can serve docs UI assets without relying on static web asset manifests.
 - AppSurface now has a repo-level release contract: a public release hub, an unreleased proof artifact, a pre-1.0 upgrade policy, and a tagged-release template for future versioned notes.
 - RazorWire now has a package-level generated UI design contract that defines ownership scope, data-attribute and CSS custom-property styling surfaces, accessibility expectations, override levels, and anti-patterns for package-owned UI.
 - RazorDocs pages can now render a top-of-page trust bar from structured metadata so release notes and upgrade guidance can show status, safety context, and provenance without custom page code.

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="JunitXml.TestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ForgeTrust.AppSurface.Cli\ForgeTrust.AppSurface.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointCollection.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointCollection.cs
@@ -1,0 +1,7 @@
+namespace ForgeTrust.AppSurface.Cli.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ProgramEntryPointCollection
+{
+    public const string Name = "AppSurface CLI program entrypoint";
+}

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -1,0 +1,427 @@
+using System.Collections.Concurrent;
+using CliFx.Infrastructure;
+using ForgeTrust.AppSurface.Console;
+using ForgeTrust.AppSurface.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.AppSurface.Cli.Tests;
+
+[Collection(ProgramEntryPointCollection.Name)]
+public sealed class ProgramEntryPointTests
+{
+    [Fact]
+    public async Task EntryPoint_Should_Print_Root_Help_Without_Lifecycle_Noise()
+    {
+        var result = await InvokeEntryPointAsync(["--help"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("usage", result.AllText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("docs", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Application started", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Run Exited - Shutting down", result.AllText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task EntryPoint_Should_Print_Docs_Help_Without_Lifecycle_Noise()
+    {
+        var result = await InvokeEntryPointAsync(["docs", "--help"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Preview RazorDocs for a repository.", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("--repo", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("--strict", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("--startup-timeout-seconds", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Application started", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Run Exited - Shutting down", result.AllText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DocsCommand_Should_Forward_RazorDocs_Host_Arguments()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            [
+                "docs",
+                "--repo", repository.Path,
+                "--urls", "http://127.0.0.1:5189",
+                "--strict",
+                "--route-root", "/reference",
+                "--docs-root", "/reference/next",
+                "--environment", "Development"
+            ],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        Assert.Contains("--RazorDocs:Source:RepositoryRoot", runner.Args);
+        Assert.Contains(repository.Path, runner.Args);
+        Assert.Contains("--urls", runner.Args);
+        Assert.Contains("http://127.0.0.1:5189", runner.Args);
+        Assert.Contains("--RazorDocs:Harvest:FailOnFailure", runner.Args);
+        Assert.Contains("true", runner.Args);
+        Assert.Contains("--RazorDocs:Routing:RouteRootPath", runner.Args);
+        Assert.Contains("/reference", runner.Args);
+        Assert.Contains("--RazorDocs:Routing:DocsRootPath", runner.Args);
+        Assert.Contains("/reference/next", runner.Args);
+        Assert.Contains("--environment", runner.Args);
+        Assert.Contains("Development", runner.Args);
+        Assert.Equal(TimeSpan.FromSeconds(30), runner.StartupTimeout);
+    }
+
+    [Fact]
+    public async Task DocsPreviewAlias_Should_Forward_RazorDocs_Host_Arguments()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "preview", "--repo", repository.Path, "--port", "5189"],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        Assert.Contains("--RazorDocs:Source:RepositoryRoot", runner.Args);
+        Assert.Contains(repository.Path, runner.Args);
+        Assert.Contains("--port", runner.Args);
+        Assert.Contains("5189", runner.Args);
+        Assert.Equal(TimeSpan.FromSeconds(30), runner.StartupTimeout);
+    }
+
+    [Fact]
+    public async Task DocsCommand_Should_Allow_Disabling_Startup_Timeout()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", repository.Path, "--startup-timeout-seconds", "0"],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        Assert.Null(runner.StartupTimeout);
+    }
+
+    [Fact]
+    public async Task DocsCommand_Should_Reject_Blank_RepositoryRoot()
+    {
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", " "],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("The --repo value must point to a repository directory.", result.AllText, StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    public async Task DocsCommand_Should_Reject_Invalid_Startup_Timeout(string timeout)
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", repository.Path, "--startup-timeout-seconds", timeout],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(
+            "The --startup-timeout-seconds value must be a finite number greater than or equal to 0.",
+            result.AllText,
+            StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Fact]
+    public async Task DocsCommand_Should_Reject_Oversized_Startup_Timeout()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", repository.Path, "--startup-timeout-seconds", "1E+300"],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(
+            "The --startup-timeout-seconds value must be less than or equal to",
+            result.AllText,
+            StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("65536")]
+    public async Task DocsCommand_Should_Reject_Invalid_Port(string port)
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", repository.Path, "--port", port],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("The --port value must be between 1 and 65535.", result.AllText, StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Fact]
+    public async Task DocsCommand_Should_Reject_Missing_RepositoryRoot()
+    {
+        var missingRepository = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", missingRepository],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(missingRepository, result.AllText, StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Fact]
+    public void PushConfigureOptionsOverrideForTests_Should_Throw_When_ConfigureOptions_IsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => ProgramEntryPoint.PushConfigureOptionsOverrideForTests(null!));
+    }
+
+    [Fact]
+    public async Task ProgramEntryPoint_Should_Apply_Direct_And_Test_ConfigureOptions_InOrder()
+    {
+        var calls = new List<string>();
+        using var overrideScope = ProgramEntryPoint.PushConfigureOptionsOverrideForTests(
+            _ => calls.Add("override"));
+
+        await ProgramEntryPoint.RunAsync(
+            ["--help"],
+            _ => calls.Add("direct"));
+
+        Assert.Equal(["direct", "override"], calls);
+    }
+
+    [Fact]
+    public void AppSurfaceCliModule_NoOpHooks_DoNotThrow()
+    {
+        var module = new AppSurfaceCliModule();
+        var context = new StartupContext([], module);
+        var services = new ServiceCollection();
+        var builder = Host.CreateDefaultBuilder();
+        var dependencies = new ModuleDependencyBuilder();
+
+        module.ConfigureServices(context, services);
+        module.ConfigureHostBeforeServices(context, builder);
+        module.ConfigureHostAfterServices(context, builder);
+        module.RegisterDependentModules(dependencies);
+    }
+
+    private static async Task<CapturedCliRun> InvokeEntryPointAsync(
+        string[] args,
+        Action<ConsoleOptions>? configureOptions = null)
+    {
+        var console = new FakeInMemoryConsole();
+        var loggerProvider = new InMemoryLoggerProvider();
+        var originalExitCode = Environment.ExitCode;
+        var originalStdout = System.Console.Out;
+        var originalStderr = System.Console.Error;
+        using var rawStdoutWriter = new StringWriter();
+        using var rawStderrWriter = new StringWriter();
+        using var overrideScope = ProgramEntryPoint.PushConfigureOptionsOverrideForTests(
+            options =>
+            {
+                AddCaptureServices(options, console, loggerProvider);
+                configureOptions?.Invoke(options);
+            });
+
+        try
+        {
+            Environment.ExitCode = 0;
+            System.Console.SetOut(rawStdoutWriter);
+            System.Console.SetError(rawStderrWriter);
+            await ProgramEntryPoint.RunAsync(
+                args,
+                options =>
+                {
+                    AddCaptureServices(options, console, loggerProvider);
+                    configureOptions?.Invoke(options);
+                });
+
+            return new CapturedCliRun(
+                rawStdoutWriter.ToString(),
+                rawStderrWriter.ToString(),
+                console.ReadOutputString(),
+                console.ReadErrorString(),
+                loggerProvider.GetMessages(),
+                Environment.ExitCode);
+        }
+        finally
+        {
+            System.Console.SetOut(originalStdout);
+            System.Console.SetError(originalStderr);
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    private static async Task<CapturedCliRun> InvokeProgramEntryPointAsync(
+        string[] args,
+        Action<ConsoleOptions>? configureOptions = null)
+    {
+        var console = new FakeInMemoryConsole();
+        var loggerProvider = new InMemoryLoggerProvider();
+        var originalExitCode = Environment.ExitCode;
+
+        try
+        {
+            Environment.ExitCode = 0;
+            await ProgramEntryPoint.RunAsync(
+                args,
+                options =>
+                {
+                    AddCaptureServices(options, console, loggerProvider);
+                    configureOptions?.Invoke(options);
+                });
+
+            return new CapturedCliRun(
+                string.Empty,
+                string.Empty,
+                console.ReadOutputString(),
+                console.ReadErrorString(),
+                loggerProvider.GetMessages(),
+                Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    private static void AddCaptureServices(
+        ConsoleOptions options,
+        FakeInMemoryConsole console,
+        InMemoryLoggerProvider loggerProvider)
+    {
+        options.CustomRegistrations.Add(services =>
+        {
+            services.AddSingleton<IConsole>(console);
+            services.AddSingleton<ILoggerProvider>(loggerProvider);
+        });
+    }
+
+    private static void RegisterRunner(ConsoleOptions options, CapturingRazorDocsHostRunner runner)
+    {
+        options.CustomRegistrations.Add(services => services.AddSingleton<IRazorDocsHostRunner>(runner));
+    }
+
+    private sealed record CapturedCliRun(
+        string RawStdout,
+        string RawStderr,
+        string Stdout,
+        string Stderr,
+        IReadOnlyList<string> LogMessages,
+        int ExitCode)
+    {
+        public string AllText =>
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    RawStdout,
+                    RawStderr,
+                    Stdout,
+                    Stderr,
+                    string.Join(Environment.NewLine, LogMessages)
+                });
+    }
+
+    private sealed class CapturingRazorDocsHostRunner : IRazorDocsHostRunner
+    {
+        public string[]? Args { get; private set; }
+
+        public TimeSpan? StartupTimeout { get; private set; }
+
+        public Task RunAsync(string[] args, TimeSpan? startupTimeout, CancellationToken cancellationToken)
+        {
+            Args = args;
+            StartupTimeout = startupTimeout;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<string> _messages = new();
+
+        public ILogger CreateLogger(string categoryName) => new InMemoryLogger(_messages);
+
+        public void Dispose()
+        {
+        }
+
+        public IReadOnlyList<string> GetMessages() => _messages.ToArray();
+
+        private sealed class InMemoryLogger(ConcurrentQueue<string> messages) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                messages.Enqueue(formatter(state, exception));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        private TempDirectory(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TempDirectory Create(string prefix)
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                prefix + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return new TempDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/packages.lock.json
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/packages.lock.json
@@ -1,0 +1,651 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "coverlet.msbuild": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "Qa7Hg+wrOMDKpXVn2dw4Wlun490bIWsFW0fdNJQFJLZnbU27MCP0HJ2mPgS+3EQBQUb0zKlkwiQzP+j38Hc3Iw=="
+      },
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[2.4.1, )",
+        "resolved": "2.4.1",
+        "contentHash": "SH1ar/kg36CggzMqLUDRoUqR8SSjK/JiQ2JS8MYg8u0RCLDkkDEbPGIN91omOPx9f2GuDqsxxofSdgsQje3Xuw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.10.0"
+        }
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[6.1.0, )",
+        "resolved": "6.1.0",
+        "contentHash": "a3ciawoHOzqcry7yS5z9DerNyF9QZi6fEZZJPILSy6Noj6+r8Ydma+cENA6wvivXDCblpXxw72wWT9QApNy/0w=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp": {
+        "type": "Transitive",
+        "resolved": "0.17.1",
+        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "0.17.0",
+        "contentHash": "bg0AcugmX6BFEi/DHG61QrwRU8iuiX4H8LZehdIzYdqOM/dgb3BsCTzNIcc1XADn4+xfQEdVwJYTSwUxroL4vg==",
+        "dependencies": {
+          "AngleSharp": "[0.17.0, 0.18.0)"
+        }
+      },
+      "Microsoft.AspNetCore.Razor.Language": {
+        "type": "Transitive",
+        "resolved": "6.0.36",
+        "contentHash": "n5Mg5D0aRrhHJJ6bJcwKqQydIFcgUq0jTlvuynoJjwA2IvAzh8Aqf9cpYagofQbIlIXILkCP6q6FgbngyVtpYA=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "bL/xQsVNrdVkzjP5yjX4ndkQ03H3+Bk3qPpl+AMCEJR2RkfgAYmoQ/xXffPV7is64+QHShnhA12YAaFmNbfM+A==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "VWB5jdkxHsRiuoniTqwOL32R4OWyp5If/bAucLjRJczRVNcwb8iCXKLjn3Inv8fv+jHMVMnvQLg7xhSys+y5PA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "3GgMIi2jP8g1fBW93Z9b9Unamc0SIsgyhiCmC91gq4loTixK9vQMuxxUsfJ1kRGwn+/FqLKwOHqmn0oYWn3Fvw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "Opl/7SIrwDy9WjHn/vU2thQ8CUtrIWHLr+89I7/0VYNEJQvpL24zvqYrh83cH38RzNKHji0WGVkCVP6HJChVVw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "DC5I4Y1nK35jY4piDqQCzWjDXzT6ECMctBAxgAJoc6pn0k6uyxcDeOuVDRooFui/N65ptn9xT5mk9eO4mSTj/g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "RGYG2JBak9lf2rIPiZUVmWjUqoxaHPy3XPhPsJyIQ8QqK47rKvJz7jxVYefTnYdM5LTEiGFBdC7v3+SiosvmkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "pCEueasI5JhJ24KYzMFxtG40zyLnWpcQYawpARh9FNq9XbWozuWgexmdkPa8p8YoVNlpi3ecKfcjfoRMkKAufw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "N0dgOYQ9tDzJouL9Tyx2dgMCcHV2pBaY8yVtorbDqYYwiDRS2zd1TbhTA2FMHqXF3SMjBoO+gONZcDoA79gdSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.FileExtensions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0ZZMzdvNwIS0f09S0IcaEbKFm+Xc41vRROsA/soeKEpzRISTDdiVwGlzdldbXEsuPjNVvNHyvIP8YW2hfIig0w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Json": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "vS65HMo5RS10DD543fknsyVDxihMcVxVn3/hNaILgBxWYnOLxWIeCIO9X0QFuCvPRNjClvXe9Aj8KaQNx7vFkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0Zn6nR/6g+90MxskZyOOMPQvnPnrrGu6bytPwkV+azDcTtCSuQ1+GJUrg8Klmnrjk1i6zMpw2lXijl+tw7Q3kA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "mIqCzZseDK9SqTRy4LxtjLwjlUu6aH5UdA6j0vgVER14yki9oRqLF+SmBiF6OlwsBSeL6dMQ8dmq02JMeE2puQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "GIoXX7VDcTEsNM6yvffTBaOwnPQELGI5dzExR7L2O7AUkDsHBYIZawUbuwfq3cYzz8dIAAJotQYJMzH7qy27Ng==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "q9FPkSGVA9ipI255p3PBAvWNXas5Tzjyp/DwYSwT+46mIFw9fWZahsF6vHpoxLt5/vtANotH2sAm7HunuFIx9g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "l+dFA0NRl90vSIiJNy5d7V0kpTEOWHTqbgoWYzlTwF5uiM5sWJ953haaELKE05jkyJdnemVTnqjrlgo4wo7oyg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileSystemGlobbing": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "1HJCAbwukNEoYbHgHbKHmenU0V/0huw8+i7Qtf5rLUG1E+3kEwRJQxpwD3wbTEagIgPSQisNgJTvmUX9yYVc6g=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "G9T95JbcG/wQpeVIzg0IMwxI+uTywDmbxWUWN2P0mdna35rmuTqgTrZ4SU5rcfUT3EJfbI9N4K8UyCAAc6QK8Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "XBzjitTFaQhF8EbJ645vblZezV1p52ePTxKHoVkRidHF11Xkjxg94qr0Rvp2qyxK2vBJ4OIZ41NB15YUyxTGMQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "LFnyBNK7WtFmKdnHu3v0HOYQ8BcjYuy0jdC9pgCJ/rbLKoJEG9/dBzSKMEeeWDbDeoWS0TIxOC8a9CM5ufca3A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lCgpxE5r6v43SB40/yUVnSWZUUqUZF5iUWizhkx4gqvq0L0rMw5g8adWKGO7sfIaSbCiU0et85sDQWswhLcceg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "u21euQdOjaEwmlnnB1Zd4XGqOmWI8FkoGeUleV7n4BZ8HPQC/jrYzX/B5Cz3uI/FXjd//W88clPfkGIbSif7Jw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "IyyGy7xNJAjdlFYXc7SZ7kS3CWd3Ma4hing9QGtzXi+LXm8RWCEXdKA1cPx5AeFmdg3rVG+ADGIn44K14O+vFA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "System.Diagnostics.EventLog": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "ayCRr/8ON3aINH81ak9l3vLAF/0pV/xrfChCbIlT2YnHAd4TYBWLcWhzbJWwPFV4XmJFrx/z8oq+gZzIc/74OA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "2lnp8nrvfzyp+5zvfeULm/hkZsDsKkl2ziBt5T8EZKoON5q+XRpRLoWcSPo8mP7GNZXpxKMBVjFNIZNbBIcnRw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "BHniU24QV67qp1pJknqYSofAPYGmijGI8D+ci9yfw33iuFdyOeB9lWTg78ThyYLyQwZw3s0vZ36VMb0MqbUuLw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Onigwrap": {
+        "type": "Transitive",
+        "resolved": "1.0.10",
+        "contentHash": "eujNEpEhCl4UiqHTG0CeG/sWS8v/iYXGqUpaVkgBmYRZp3Utmz/aw38fuFL2rcnhj1FNfHwHaxGDeLY34a3nEA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lum+Dv+8S4gqN5H1C576UcQe0M2buoRjEUVs4TctXRSWjBH3ay3w2KyQrOo1yPdRs1I+xK69STz+4mjIisFI5w=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "forgetrust.appsurface.caching": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "Microsoft.Extensions.Caching.Memory": "[9.0.6, )"
+        }
+      },
+      "forgetrust.appsurface.cli": {
+        "type": "Project",
+        "dependencies": {
+          "CliFx": "[2.3.6, )",
+          "ForgeTrust.AppSurface.Console": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Docs.Standalone": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.console": {
+        "type": "Project",
+        "dependencies": {
+          "CliFx": "[2.3.6, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.core": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting": "[9.0.6, )",
+          "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
+        }
+      },
+      "forgetrust.appsurface.docs": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Caching": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )",
+          "HtmlSanitizer": "[9.0.892, )",
+          "Markdig": "[0.44.0, )",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
+          "TextMateSharp": "[2.0.3, )",
+          "TextMateSharp.Grammars": "[2.0.3, )",
+          "YamlDotNet": "[17.0.1, )"
+        }
+      },
+      "forgetrust.appsurface.docs.standalone": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Docs": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.web": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.web.tailwind": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.linux-x64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.osx-arm64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.osx-x64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
+        "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
+      },
+      "CliFx": {
+        "type": "CentralTransitive",
+        "requested": "[2.3.6, )",
+        "resolved": "2.3.6",
+        "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "HtmlSanitizer": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.892, )",
+        "resolved": "9.0.892",
+        "contentHash": "zdkMmpNCjTkxna8Y+jmPIFm2st+HjHrf32yNElFYwe7L4GmDm+mdKR6TzDyf6ewJ0RUUz84D4IkHNgrwGi4VbQ==",
+        "dependencies": {
+          "AngleSharp": "[0.17.1]",
+          "AngleSharp.Css": "[0.17.0]"
+        }
+      },
+      "Markdig": {
+        "type": "CentralTransitive",
+        "requested": "[0.44.0, )",
+        "resolved": "0.44.0",
+        "contentHash": "X+CYMjcUnh/yO24wOSQxVFLiGqWrrtXJ5M7toHiM1Zk4Fg9UMLN5fkaq6FSOWH+mIprsHHgDMlq3MJhmrXalhg=="
+      },
+      "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.36, )",
+        "resolved": "6.0.36",
+        "contentHash": "KFHRhrGAnd80310lpuWzI7Cf+GidS/h3JaPDFFnSmSGjCxB5vkBv5E+TXclJCJhqPtgNxg+keTC5SF1T9ieG5w==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Razor.Language": "6.0.36",
+          "Microsoft.CodeAnalysis.Razor": "6.0.36"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "FN5Rv8tmQ2yr4iTiNIetVDyTaLxyt+ugUUo7d7aJnIiHLDr1piOnS8sxUZOEx6apECPLHvrGhQ2XFVdv7mWZ3Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Mvc.Razor.Extensions": "6.0.0",
+          "Microsoft.CodeAnalysis.Razor": "6.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.2"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "CentralTransitive",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Razor": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.36, )",
+        "resolved": "6.0.36",
+        "contentHash": "RTLNJglWezr/1IkiWdtDpPYW7X7lwa4ow8E35cHt+sWdWxOnl+ayQqMy1RfbaLp7CLmRmgXSzMMZZU3D4vZi9Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Razor.Language": "6.0.36",
+          "Microsoft.CodeAnalysis.CSharp": "4.0.0",
+          "Microsoft.CodeAnalysis.Common": "4.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "qPW2d798tBPZcRmrlaBJqyChf2+0odDdE+0Lxvrr0ywkSNl1oNMK8AKrOfDwyXyjuLCv0ua7p6nrUExCeXhCcg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "Iu1UyXUnjMhoOwThKM0kCyjgWqqQnuujsbPMnF44ITUbmETT7RAVlozNgev2L/damwNoPZKpmwArRKBy2IOAZg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.Configuration.CommandLine": "9.0.6",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "9.0.6",
+          "Microsoft.Extensions.Configuration.FileExtensions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Json": "9.0.6",
+          "Microsoft.Extensions.Configuration.UserSecrets": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.Logging.Console": "9.0.6",
+          "Microsoft.Extensions.Logging.Debug": "9.0.6",
+          "Microsoft.Extensions.Logging.EventLog": "9.0.6",
+          "Microsoft.Extensions.Logging.EventSource": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "L1O0M3MrqGlkrPYMLzcCphQpCG0lSHfTSPrm1otALNBzTPiO8rxxkjhBIIa2onKv92UP30Y4QaiigVMTx8YcxQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "wUPhNM1zsI58Dy10xRdF2+pnsisiUuETg5ZBncyAEEUm/CQ9Q1vmivyUWH8RDbAlqyixf2dJNQ2XZb7HsKUEQw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "TextMateSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "w0wGeqlBi9SYrzxpS1DBcEfiVCs5NY18Yl5YBIsHzXTXQd0OLOh3mP4LRuFvcktR/1MG8nSBHSMJj0rFvrPk+A==",
+        "dependencies": {
+          "Onigwrap": "1.0.10"
+        }
+      },
+      "TextMateSharp.Grammars": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "qkI1ogusuyGCGTgeyhljDM+GEfATOexoUTqLIgSb5P0ojmfhRXWfSTRXXJRpZkLDErShJ7RWOb+p10lHfhhO+Q==",
+        "dependencies": {
+          "TextMateSharp": "2.0.3"
+        }
+      },
+      "YamlDotNet": {
+        "type": "CentralTransitive",
+        "requested": "[17.0.1, )",
+        "resolved": "17.0.1",
+        "contentHash": "qVir5fehR/W5nTJyoJUibypETXaW4iRAF9cQa0FQIC9TJ3VC0qDOwm4o/RxANewj8KzPF8WMF2abBfUgi6LC4w=="
+      }
+    }
+  }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli/AppSurfaceCliApp.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/AppSurfaceCliApp.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using CliFx;
+using ForgeTrust.AppSurface.Console;
+using ForgeTrust.AppSurface.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.AppSurface.Cli;
+
+/// <summary>
+/// Provides the DI-backed execution runtime for AppSurface CLI commands.
+/// </summary>
+/// <remarks>
+/// This internal runtime exists so the top-level tool entry point stays thin while command discovery, dependency
+/// registration, logging defaults, and CliFx execution stay testable. It discovers commands from the AppSurface CLI
+/// entry assembly, applies module and caller-provided service registrations, temporarily assigns
+/// <see cref="CommandService.PrimaryServiceProvider"/> for constructor-injected command dependencies, and always
+/// restores the previous provider after command execution.
+/// </remarks>
+internal static class AppSurfaceCliApp
+{
+    /// <summary>
+    /// Runs the AppSurface CLI with the provided command-line arguments.
+    /// </summary>
+    /// <param name="args">Command-line arguments to parse and execute.</param>
+    /// <param name="configureOptions">
+    /// Optional callback that customizes <see cref="ConsoleOptions"/> before execution. Defaults start from
+    /// <see cref="ConsoleOptions.Default"/> with <see cref="ConsoleOutputMode.CommandFirst"/> so command output remains
+    /// the primary console experience.
+    /// </param>
+    /// <returns>A task that completes when the selected command finishes.</returns>
+    /// <remarks>
+    /// Use this seam from process entry points and tests that need the real command pipeline without shelling out. The
+    /// method builds and disposes a fresh service provider for each run, registers AppSurface CLI defaults, then applies
+    /// custom registrations last so tests or future host integrations can replace defaults intentionally.
+    /// </remarks>
+    internal static async Task RunAsync(string[] args, Action<ConsoleOptions>? configureOptions = null)
+    {
+        var options = ConsoleOptions.Default with
+        {
+            OutputMode = ConsoleOutputMode.CommandFirst
+        };
+        configureOptions?.Invoke(options);
+
+        var module = new AppSurfaceCliModule();
+        var context = new StartupContext(args, module)
+        {
+            ConsoleOutputMode = options.OutputMode
+        };
+
+        var commandTypes = GetCommandTypes(context.EntryPointAssembly).ToArray();
+        var services = new ServiceCollection();
+        services.AddSingleton(context);
+        services.AddSingleton(context.EnvironmentProvider);
+        services.AddSingleton<IOptionSuggester, LevenshteinOptionSuggester>();
+        services.AddSingleton<IRazorDocsHostRunner, RazorDocsStandaloneHostRunner>();
+        services.AddLogging(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+
+        foreach (var commandType in commandTypes)
+        {
+            services.AddTransient(typeof(ICommand), commandType);
+            services.AddTransient(commandType);
+        }
+
+        module.ConfigureServices(context, services);
+        foreach (var customRegistration in options.CustomRegistrations)
+        {
+            customRegistration(services);
+        }
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var commands = commandTypes
+            .Select(commandType => (ICommand)serviceProvider.GetRequiredService(commandType))
+            .ToArray();
+        var suggester = serviceProvider.GetRequiredService<IOptionSuggester>();
+        var commandService = new CommandService(commands, context, suggester);
+        var previousServiceProvider = CommandService.PrimaryServiceProvider;
+
+        try
+        {
+            CommandService.PrimaryServiceProvider = serviceProvider;
+            await commandService.RunInternalAsync(CancellationToken.None);
+        }
+        finally
+        {
+            CommandService.PrimaryServiceProvider = previousServiceProvider;
+        }
+    }
+
+    [ExcludeFromCodeCoverage(
+        Justification = "Defensive ReflectionTypeLoadException fallback requires a broken assembly load graph; CLI tests cover command discovery through RunAsync.")]
+    private static IEnumerable<Type> GetCommandTypes(Assembly assembly)
+    {
+        Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            types = exception.Types.OfType<Type>().ToArray();
+        }
+
+        return types.Where(type => !type.IsAbstract && typeof(ICommand).IsAssignableFrom(type));
+    }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli/AppSurfaceCliModule.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/AppSurfaceCliModule.cs
@@ -1,0 +1,66 @@
+using ForgeTrust.AppSurface.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace ForgeTrust.AppSurface.Cli;
+
+/// <summary>
+/// Represents the AppSurface CLI root module used to bootstrap command execution.
+/// </summary>
+/// <remarks>
+/// The module is intentionally empty today: the CLI owns command registration in <see cref="AppSurfaceCliApp"/> and
+/// delegates web-host behavior to RazorDocs-specific runners. Add dependencies here only when every AppSurface CLI
+/// command needs the same module-level dependency graph or host lifecycle hook. Prefer command-local services or custom
+/// test registrations for isolated behavior, and do not place runtime command logic in this module.
+/// </remarks>
+internal sealed class AppSurfaceCliModule : IAppSurfaceHostModule
+{
+    /// <summary>
+    /// Configures shared CLI services after the default command runtime registrations have been added.
+    /// </summary>
+    /// <param name="context">Startup context for the CLI run.</param>
+    /// <param name="services">Service collection that will back command construction.</param>
+    /// <remarks>
+    /// The default implementation is a no-op. Keep it empty unless a service truly applies to the whole CLI surface.
+    /// </remarks>
+    public void ConfigureServices(StartupContext context, IServiceCollection services)
+    {
+    }
+
+    /// <summary>
+    /// Configures a Generic Host builder before services are registered.
+    /// </summary>
+    /// <param name="context">Startup context for the CLI run.</param>
+    /// <param name="builder">Host builder that would be configured by host-based startup paths.</param>
+    /// <remarks>
+    /// The command runtime does not currently build a Generic Host through this module, so this hook is intentionally a
+    /// no-op and exists to satisfy the shared AppSurface host-module contract.
+    /// </remarks>
+    public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+    {
+    }
+
+    /// <summary>
+    /// Configures a Generic Host builder after services are registered.
+    /// </summary>
+    /// <param name="context">Startup context for the CLI run.</param>
+    /// <param name="builder">Host builder that would be configured by host-based startup paths.</param>
+    /// <remarks>
+    /// Keep this empty until the CLI adopts a host-backed lifecycle. Command behavior should stay in command classes.
+    /// </remarks>
+    public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+    {
+    }
+
+    /// <summary>
+    /// Registers root-module dependencies for the AppSurface CLI module graph.
+    /// </summary>
+    /// <param name="builder">Dependency builder used by AppSurface startup composition.</param>
+    /// <remarks>
+    /// The CLI has no module dependencies by default. Add dependencies here only for cross-command infrastructure that
+    /// must participate in AppSurface module ordering.
+    /// </remarks>
+    public void RegisterDependentModules(ModuleDependencyBuilder builder)
+    {
+    }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -1,0 +1,327 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Exceptions;
+using CliFx.Infrastructure;
+using ForgeTrust.AppSurface.Docs.Standalone;
+using ForgeTrust.AppSurface.Web;
+using Microsoft.Extensions.Logging;
+
+namespace ForgeTrust.AppSurface.Cli;
+
+/// <summary>
+/// Previews RazorDocs for a local repository through the public <c>appsurface docs</c> command.
+/// </summary>
+/// <remarks>
+/// This command starts the RazorDocs standalone host with CLI-friendly defaults and delegates option validation and
+/// argument construction to <see cref="RazorDocsPreviewCommand"/>.
+/// </remarks>
+[Command("docs", Description = "Preview RazorDocs for a repository.")]
+internal sealed class DocsCommand : RazorDocsPreviewCommand
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocsCommand"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used for command diagnostics.</param>
+    /// <param name="hostRunner">Runner that starts the RazorDocs host.</param>
+    public DocsCommand(ILogger<DocsCommand> logger, IRazorDocsHostRunner hostRunner)
+        : base(logger, hostRunner)
+    {
+    }
+}
+
+/// <summary>
+/// Previews RazorDocs for a local repository through the <c>appsurface docs preview</c> alias.
+/// </summary>
+/// <remarks>
+/// Use this alias when a command hierarchy reads better in scripts. It has the same options and behavior as
+/// <see cref="DocsCommand"/>.
+/// </remarks>
+[Command("docs preview", Description = "Preview RazorDocs for a repository.")]
+internal sealed class DocsPreviewCommand : RazorDocsPreviewCommand
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocsPreviewCommand"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used for command diagnostics.</param>
+    /// <param name="hostRunner">Runner that starts the RazorDocs host.</param>
+    public DocsPreviewCommand(ILogger<DocsPreviewCommand> logger, IRazorDocsHostRunner hostRunner)
+        : base(logger, hostRunner)
+    {
+    }
+}
+
+/// <summary>
+/// Shared implementation for RazorDocs preview commands.
+/// </summary>
+/// <remarks>
+/// The base command translates CLI options into RazorDocs standalone host arguments. It keeps command parsing separate
+/// from process hosting so tests can verify validation and argument forwarding without starting Kestrel.
+/// </remarks>
+internal abstract class RazorDocsPreviewCommand : ICommand
+{
+    private readonly ILogger _logger;
+    private readonly IRazorDocsHostRunner _hostRunner;
+
+    /// <summary>
+    /// Initializes shared RazorDocs preview command state.
+    /// </summary>
+    /// <param name="logger">Logger used for command diagnostics.</param>
+    /// <param name="hostRunner">Runner that starts the translated RazorDocs host invocation.</param>
+    /// <remarks>
+    /// Derived command aliases share the same implementation so validation and host argument translation cannot drift.
+    /// </remarks>
+    protected RazorDocsPreviewCommand(ILogger logger, IRazorDocsHostRunner hostRunner)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(hostRunner);
+
+        _logger = logger;
+        _hostRunner = hostRunner;
+    }
+
+    /// <summary>
+    /// Gets the repository root to harvest and preview.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to the current directory. Use this when running the CLI from a parent directory, script workspace, or
+    /// package output folder. The value must resolve to an existing directory.
+    /// </remarks>
+    [CommandOption("repo", 'r', Description = "Repository root to preview (default: current directory).")]
+    public string RepositoryRoot { get; init; } = ".";
+
+    /// <summary>
+    /// Gets the explicit URL binding forwarded to the RazorDocs host.
+    /// </summary>
+    /// <remarks>
+    /// Use this for a full Kestrel binding such as <c>http://127.0.0.1:5189</c>. Prefer <see cref="Port"/> when only the
+    /// port needs to change.
+    /// </remarks>
+    [CommandOption("urls", 'u', Description = "URL binding forwarded to the RazorDocs host, for example http://127.0.0.1:5189.")]
+    public string? Urls { get; init; }
+
+    /// <summary>
+    /// Gets the port shortcut forwarded to the RazorDocs host.
+    /// </summary>
+    /// <remarks>
+    /// Use this for local preview scripts that only need a port override. Use <see cref="Urls"/> for explicit host,
+    /// scheme, or multi-binding scenarios.
+    /// </remarks>
+    [CommandOption("port", 'p', Description = "Port shortcut forwarded to the RazorDocs host.")]
+    public int? Port { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether startup should fail when every configured RazorDocs harvester fails.
+    /// </summary>
+    /// <remarks>
+    /// Keep this off for exploratory local preview. Enable it in CI or release checks where a completely failed harvest
+    /// should stop the command before the site starts.
+    /// </remarks>
+    [CommandOption("strict", Description = "Fail startup when every configured RazorDocs harvester fails.")]
+    public bool StrictHarvest { get; init; }
+
+    /// <summary>
+    /// Gets the route-family root for RazorDocs version and archive routes.
+    /// </summary>
+    /// <remarks>
+    /// Use this when the docs route family is mounted somewhere other than <c>/docs</c>, for example
+    /// <c>--route-root /reference</c>. Pair it with <see cref="DocsRootPath"/> when the live preview path should differ
+    /// from archive/version routes.
+    /// </remarks>
+    [CommandOption("route-root", Description = "Route-family root for RazorDocs version and archive routes.")]
+    public string? RouteRootPath { get; init; }
+
+    /// <summary>
+    /// Gets the live docs preview root path.
+    /// </summary>
+    /// <remarks>
+    /// Use this to preview current docs under a nested route, for example <c>--route-root /reference --docs-root
+    /// /reference/next</c>. Leave unset to use RazorDocs defaults.
+    /// </remarks>
+    [CommandOption("docs-root", Description = "Live docs preview root path.")]
+    public string? DocsRootPath { get; init; }
+
+    /// <summary>
+    /// Gets the host environment forwarded to the RazorDocs standalone host.
+    /// </summary>
+    /// <remarks>
+    /// Use <c>Development</c> for local preview diagnostics and development defaults. Leave unset to let the host choose
+    /// its normal environment from command-line and process configuration.
+    /// </remarks>
+    [CommandOption("environment", 'e', Description = "Host environment forwarded to the RazorDocs host.")]
+    public string? EnvironmentName { get; init; }
+
+    /// <summary>
+    /// Gets the number of seconds to wait for the web host to start before failing fast.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to 30 seconds. Set to <c>0</c> to disable the startup watchdog. Negative, infinite, and NaN values are
+    /// rejected before the host starts.
+    /// </remarks>
+    [CommandOption("startup-timeout-seconds", Description = "Seconds to wait for the RazorDocs web host to start before failing fast. Use 0 to disable.")]
+    public double StartupTimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Executes the command through the CliFx console integration.
+    /// </summary>
+    /// <param name="console">Console abstraction used to register cancellation handling.</param>
+    /// <returns>A value task that completes when the preview host exits or command validation fails.</returns>
+    [ExcludeFromCodeCoverage]
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        var cancellationToken = console.RegisterCancellationHandler();
+        await ExecuteAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes the command using an explicit cancellation token.
+    /// </summary>
+    /// <param name="cancellationToken">Token observed before the host runner starts.</param>
+    /// <returns>A value task that completes when the preview host exits.</returns>
+    /// <remarks>
+    /// This overload exists for tests and shared command execution paths that already own cancellation registration.
+    /// </remarks>
+    internal async ValueTask ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var hostArgs = BuildHostArgs();
+        _logger.LogInformation("Starting RazorDocs preview for {RepositoryRoot}.", hostArgs.RepositoryRoot);
+        await _hostRunner.RunAsync(hostArgs.Args, hostArgs.StartupTimeout, cancellationToken);
+    }
+
+    /// <summary>
+    /// Translates CLI options into standalone RazorDocs host arguments.
+    /// </summary>
+    /// <returns>The repository root, forwarded host arguments, and startup timeout for the preview run.</returns>
+    /// <remarks>
+    /// This method performs command-level validation so users receive <see cref="CommandException"/> errors before the
+    /// web host starts. It is internal so tests can verify the translation contract without opening a listener.
+    /// </remarks>
+    internal RazorDocsHostArgs BuildHostArgs()
+    {
+        if (string.IsNullOrWhiteSpace(RepositoryRoot))
+        {
+            throw new CommandException("The --repo value must point to a repository directory.");
+        }
+
+        var repositoryRoot = Path.GetFullPath(RepositoryRoot);
+        if (!Directory.Exists(repositoryRoot))
+        {
+            throw new CommandException($"The RazorDocs repository root does not exist: {repositoryRoot}");
+        }
+
+        var args = new List<string>
+        {
+            "--RazorDocs:Source:RepositoryRoot",
+            repositoryRoot
+        };
+
+        AddOptional(args, "--urls", Urls);
+        if (Port is not null)
+        {
+            if (Port is < 1 or > 65535)
+            {
+                throw new CommandException("The --port value must be between 1 and 65535.");
+            }
+
+            args.Add("--port");
+            args.Add(Port.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (StrictHarvest)
+        {
+            args.Add("--RazorDocs:Harvest:FailOnFailure");
+            args.Add("true");
+        }
+
+        AddOptional(args, "--RazorDocs:Routing:RouteRootPath", RouteRootPath);
+        AddOptional(args, "--RazorDocs:Routing:DocsRootPath", DocsRootPath);
+        AddOptional(args, "--environment", EnvironmentName);
+
+        return new RazorDocsHostArgs(repositoryRoot, args.ToArray(), ResolveStartupTimeout());
+    }
+
+    private static void AddOptional(List<string> args, string name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        args.Add(name);
+        args.Add(value);
+    }
+
+    private TimeSpan? ResolveStartupTimeout()
+    {
+        if (double.IsNaN(StartupTimeoutSeconds) || double.IsInfinity(StartupTimeoutSeconds) || StartupTimeoutSeconds < 0)
+        {
+            throw new CommandException("The --startup-timeout-seconds value must be a finite number greater than or equal to 0.");
+        }
+
+        if (StartupTimeoutSeconds > TimeSpan.MaxValue.TotalSeconds)
+        {
+            throw new CommandException(
+                $"The --startup-timeout-seconds value must be less than or equal to {TimeSpan.MaxValue.TotalSeconds.ToString(CultureInfo.InvariantCulture)}.");
+        }
+
+        return StartupTimeoutSeconds == 0
+            ? null
+            : TimeSpan.FromSeconds(StartupTimeoutSeconds);
+    }
+}
+
+/// <summary>
+/// Describes the RazorDocs host invocation produced by the CLI option translator.
+/// </summary>
+/// <param name="RepositoryRoot">Absolute repository root that the RazorDocs host should harvest.</param>
+/// <param name="Args">Command-line arguments forwarded to the standalone RazorDocs host.</param>
+/// <param name="StartupTimeout">Startup watchdog timeout, or <see langword="null"/> when disabled.</param>
+internal readonly record struct RazorDocsHostArgs(string RepositoryRoot, string[] Args, TimeSpan? StartupTimeout);
+
+/// <summary>
+/// Starts a RazorDocs host for CLI preview commands.
+/// </summary>
+/// <remarks>
+/// This seam keeps command parsing and validation testable without starting a real web host. Production implementations
+/// should honor cancellation before delegating into long-running host lifetimes.
+/// </remarks>
+internal interface IRazorDocsHostRunner
+{
+    /// <summary>
+    /// Runs the RazorDocs host with translated command-line arguments.
+    /// </summary>
+    /// <param name="args">Arguments forwarded to the standalone RazorDocs host.</param>
+    /// <param name="startupTimeout">Startup watchdog timeout, or <see langword="null"/> to disable it.</param>
+    /// <param name="cancellationToken">Token that cancels before the host is started.</param>
+    /// <returns>A task that completes when the host exits.</returns>
+    Task RunAsync(string[] args, TimeSpan? startupTimeout, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Production <see cref="IRazorDocsHostRunner"/> that delegates to the standalone RazorDocs web host.
+/// </summary>
+/// <remarks>
+/// Use this adapter for the packaged AppSurface CLI path. Tests should prefer fake runners so they can verify argument
+/// translation without starting Kestrel. The type is internal and sealed because callers should depend on
+/// <see cref="IRazorDocsHostRunner"/> rather than subclassing host lifetime behavior.
+/// </remarks>
+[ExcludeFromCodeCoverage(
+    Justification = "Production adapter delegates into the long-running standalone web host; command tests cover argument and option construction before this boundary.")]
+internal sealed class RazorDocsStandaloneHostRunner : IRazorDocsHostRunner
+{
+    /// <inheritdoc />
+    public Task RunAsync(string[] args, TimeSpan? startupTimeout, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return RazorDocsStandaloneHost.RunAsync(args, options => ConfigurePackagedToolHost(options, startupTimeout));
+    }
+
+    private static void ConfigurePackagedToolHost(WebOptions options, TimeSpan? startupTimeout)
+    {
+        // Packaged .NET tools often lack static web asset manifests; RazorWireWebModule and RazorDocs endpoint
+        // fallbacks serve embedded assets instead so global/local tool distributions remain self-contained.
+        options.StaticFiles.EnableStaticWebAssets = false;
+        options.StartupTimeout = startupTimeout;
+    }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj
+++ b/Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable Condition="'$(EnableAppSurfaceCliToolPackaging)' != 'true'">false</IsPackable>
+    <IsPackable Condition="'$(EnableAppSurfaceCliToolPackaging)' == 'true'">true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>appsurface</ToolCommandName>
+    <PackageId>ForgeTrust.AppSurface.Cli</PackageId>
+    <PackageDescription>Command-line tooling for AppSurface repository and documentation workflows.</PackageDescription>
+    <PackageTags>appsurface;razordocs;documentation;cli;dotnet-tool</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Console\ForgeTrust.AppSurface.Console\ForgeTrust.AppSurface.Console.csproj" />
+    <ProjectReference Include="..\..\Web\ForgeTrust.AppSurface.Docs.Standalone\ForgeTrust.AppSurface.Docs.Standalone.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ForgeTrust.AppSurface.Cli.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CliFx" />
+  </ItemGroup>
+
+</Project>

--- a/Cli/ForgeTrust.AppSurface.Cli/Program.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/Program.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+using ForgeTrust.AppSurface.Cli;
+
+/// <summary>
+/// Process entry point for the AppSurface CLI executable.
+/// </summary>
+/// <remarks>
+/// <see cref="ProgramEntryPoint"/> owns the command runtime seam and is covered by tests; this type only adapts the
+/// .NET process entry point to that seam.
+/// </remarks>
+internal static class Program
+{
+    [ExcludeFromCodeCoverage(Justification = "Process entry-point trampoline; ProgramEntryPoint tests cover CLI startup behavior.")]
+    private static Task Main(string[] args)
+    {
+        return ProgramEntryPoint.RunAsync(args);
+    }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli/ProgramEntryPoint.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/ProgramEntryPoint.cs
@@ -1,0 +1,86 @@
+using System.Threading;
+using ForgeTrust.AppSurface.Console;
+
+namespace ForgeTrust.AppSurface.Cli;
+
+/// <summary>
+/// Internal CLI entry point that adds a scoped test seam around <see cref="AppSurfaceCliApp"/>.
+/// </summary>
+/// <remarks>
+/// Production code uses <see cref="RunAsync"/> directly. Tests can use
+/// <see cref="PushConfigureOptionsOverrideForTests"/> to add temporary console or DI overrides without changing the
+/// top-level statement in <c>Program.cs</c>.
+/// </remarks>
+internal static class ProgramEntryPoint
+{
+    /// <summary>
+    /// Stores a test-only console-options override for the current async context.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AsyncLocal{T}"/> keeps nested and parallel async test flows isolated, but the returned scope from
+    /// <see cref="PushConfigureOptionsOverrideForTests"/> still must be disposed to restore the previous value.
+    /// </remarks>
+    private static readonly AsyncLocal<Action<ConsoleOptions>?> _configureOptionsOverrideForTests = new();
+
+    /// <summary>
+    /// Runs the AppSurface CLI with the specified arguments and optional console configuration.
+    /// </summary>
+    /// <param name="args">Command-line arguments to parse and execute.</param>
+    /// <param name="configureOptions">Optional primary console-options callback for the current invocation.</param>
+    /// <returns>A task that represents the CLI execution.</returns>
+    internal static Task RunAsync(string[] args, Action<ConsoleOptions>? configureOptions = null) =>
+        AppSurfaceCliApp.RunAsync(args, CombineConfigureOptions(configureOptions, _configureOptionsOverrideForTests.Value));
+
+    /// <summary>
+    /// Pushes a test-only console-options override for the current async context.
+    /// </summary>
+    /// <param name="configureOptions">Override callback to apply after any direct invocation callback.</param>
+    /// <returns>A disposable scope that restores the previous override when disposed.</returns>
+    /// <remarks>
+    /// Always dispose the returned scope, typically with <c>using var</c>. Overrides compose with
+    /// <see cref="RunAsync"/> callbacks in direct-then-override order so tests can replace services after production
+    /// defaults are configured.
+    /// </remarks>
+    internal static IDisposable PushConfigureOptionsOverrideForTests(Action<ConsoleOptions> configureOptions)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        var previous = _configureOptionsOverrideForTests.Value;
+        _configureOptionsOverrideForTests.Value = configureOptions;
+
+        return new RestoreOverrideScope(previous);
+    }
+
+    private static Action<ConsoleOptions>? CombineConfigureOptions(
+        Action<ConsoleOptions>? primary,
+        Action<ConsoleOptions>? secondary)
+    {
+        if (primary is null)
+        {
+            return secondary;
+        }
+
+        if (secondary is null)
+        {
+            return primary;
+        }
+
+        return options =>
+        {
+            primary(options);
+            secondary(options);
+        };
+    }
+
+    /// <summary>
+    /// Restores the previously active test override when disposed.
+    /// </summary>
+    /// <param name="previous">Override that was active before the current scope was pushed.</param>
+    private sealed class RestoreOverrideScope(Action<ConsoleOptions>? previous) : IDisposable
+    {
+        public void Dispose()
+        {
+            _configureOptionsOverrideForTests.Value = previous;
+        }
+    }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -1,0 +1,44 @@
+# AppSurface CLI
+
+The **AppSurface CLI** is the command-line home for repository-level AppSurface workflows. It is packaged as a .NET tool with the command name `appsurface`.
+
+The first public verb is `docs`, which replaces the earlier standalone `razordocs preview --repo .` idea with an AppSurface-owned command:
+
+```bash
+appsurface docs --repo . --urls http://127.0.0.1:5189
+```
+
+`appsurface docs` runs the same RazorDocs standalone host used by CI and integration tests. It forwards RazorDocs configuration into that host instead of duplicating harvesting, routing, static web asset, or MVC setup in the CLI.
+
+## Commands
+
+### `appsurface docs`
+
+Preview RazorDocs for a repository checkout.
+
+```bash
+appsurface docs --repo . --port 5189
+```
+
+Options:
+
+- `--repo`, `-r`: Repository root to preview. Defaults to the current directory.
+- `--urls`, `-u`: Explicit host URL binding, such as `http://127.0.0.1:5189`.
+- `--port`, `-p`: AppSurface Web port shortcut forwarded to the RazorDocs host.
+- `--strict`: Enables `RazorDocs:Harvest:FailOnFailure=true`, which fails startup when every configured harvester fails.
+- `--route-root`: Route-family root for version and archive routes.
+- `--docs-root`: Live docs preview root.
+- `--environment`, `-e`: Host environment forwarded to the RazorDocs host.
+- `--startup-timeout-seconds`: Seconds to wait for the web host to start before failing fast. Defaults to `30`; use `0` to disable while investigating intentional pre-bind delays.
+
+`appsurface docs preview` is an alias for the same behavior, kept so the old deferred shape maps cleanly to the new AppSurface command family.
+
+## Development
+
+Run the tool from source while developing:
+
+```bash
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http://127.0.0.1:5189
+```
+
+Use `--strict` for CI-like validation when an all-failed harvest should stop the preview before the host begins serving.

--- a/Cli/ForgeTrust.AppSurface.Cli/packages.lock.json
+++ b/Cli/ForgeTrust.AppSurface.Cli/packages.lock.json
@@ -1,0 +1,525 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "CliFx": {
+        "type": "Direct",
+        "requested": "[2.3.6, )",
+        "resolved": "2.3.6",
+        "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "AngleSharp": {
+        "type": "Transitive",
+        "resolved": "0.17.1",
+        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "0.17.0",
+        "contentHash": "bg0AcugmX6BFEi/DHG61QrwRU8iuiX4H8LZehdIzYdqOM/dgb3BsCTzNIcc1XADn4+xfQEdVwJYTSwUxroL4vg==",
+        "dependencies": {
+          "AngleSharp": "[0.17.0, 0.18.0)"
+        }
+      },
+      "Microsoft.AspNetCore.Razor.Language": {
+        "type": "Transitive",
+        "resolved": "6.0.36",
+        "contentHash": "n5Mg5D0aRrhHJJ6bJcwKqQydIFcgUq0jTlvuynoJjwA2IvAzh8Aqf9cpYagofQbIlIXILkCP6q6FgbngyVtpYA=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "bL/xQsVNrdVkzjP5yjX4ndkQ03H3+Bk3qPpl+AMCEJR2RkfgAYmoQ/xXffPV7is64+QHShnhA12YAaFmNbfM+A==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "VWB5jdkxHsRiuoniTqwOL32R4OWyp5If/bAucLjRJczRVNcwb8iCXKLjn3Inv8fv+jHMVMnvQLg7xhSys+y5PA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "3GgMIi2jP8g1fBW93Z9b9Unamc0SIsgyhiCmC91gq4loTixK9vQMuxxUsfJ1kRGwn+/FqLKwOHqmn0oYWn3Fvw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "Opl/7SIrwDy9WjHn/vU2thQ8CUtrIWHLr+89I7/0VYNEJQvpL24zvqYrh83cH38RzNKHji0WGVkCVP6HJChVVw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "DC5I4Y1nK35jY4piDqQCzWjDXzT6ECMctBAxgAJoc6pn0k6uyxcDeOuVDRooFui/N65ptn9xT5mk9eO4mSTj/g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "RGYG2JBak9lf2rIPiZUVmWjUqoxaHPy3XPhPsJyIQ8QqK47rKvJz7jxVYefTnYdM5LTEiGFBdC7v3+SiosvmkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "pCEueasI5JhJ24KYzMFxtG40zyLnWpcQYawpARh9FNq9XbWozuWgexmdkPa8p8YoVNlpi3ecKfcjfoRMkKAufw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "N0dgOYQ9tDzJouL9Tyx2dgMCcHV2pBaY8yVtorbDqYYwiDRS2zd1TbhTA2FMHqXF3SMjBoO+gONZcDoA79gdSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.FileExtensions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0ZZMzdvNwIS0f09S0IcaEbKFm+Xc41vRROsA/soeKEpzRISTDdiVwGlzdldbXEsuPjNVvNHyvIP8YW2hfIig0w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Json": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "vS65HMo5RS10DD543fknsyVDxihMcVxVn3/hNaILgBxWYnOLxWIeCIO9X0QFuCvPRNjClvXe9Aj8KaQNx7vFkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0Zn6nR/6g+90MxskZyOOMPQvnPnrrGu6bytPwkV+azDcTtCSuQ1+GJUrg8Klmnrjk1i6zMpw2lXijl+tw7Q3kA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "mIqCzZseDK9SqTRy4LxtjLwjlUu6aH5UdA6j0vgVER14yki9oRqLF+SmBiF6OlwsBSeL6dMQ8dmq02JMeE2puQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "GIoXX7VDcTEsNM6yvffTBaOwnPQELGI5dzExR7L2O7AUkDsHBYIZawUbuwfq3cYzz8dIAAJotQYJMzH7qy27Ng==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "q9FPkSGVA9ipI255p3PBAvWNXas5Tzjyp/DwYSwT+46mIFw9fWZahsF6vHpoxLt5/vtANotH2sAm7HunuFIx9g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "l+dFA0NRl90vSIiJNy5d7V0kpTEOWHTqbgoWYzlTwF5uiM5sWJ953haaELKE05jkyJdnemVTnqjrlgo4wo7oyg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileSystemGlobbing": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "1HJCAbwukNEoYbHgHbKHmenU0V/0huw8+i7Qtf5rLUG1E+3kEwRJQxpwD3wbTEagIgPSQisNgJTvmUX9yYVc6g=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "G9T95JbcG/wQpeVIzg0IMwxI+uTywDmbxWUWN2P0mdna35rmuTqgTrZ4SU5rcfUT3EJfbI9N4K8UyCAAc6QK8Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "XBzjitTFaQhF8EbJ645vblZezV1p52ePTxKHoVkRidHF11Xkjxg94qr0Rvp2qyxK2vBJ4OIZ41NB15YUyxTGMQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "LFnyBNK7WtFmKdnHu3v0HOYQ8BcjYuy0jdC9pgCJ/rbLKoJEG9/dBzSKMEeeWDbDeoWS0TIxOC8a9CM5ufca3A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lCgpxE5r6v43SB40/yUVnSWZUUqUZF5iUWizhkx4gqvq0L0rMw5g8adWKGO7sfIaSbCiU0et85sDQWswhLcceg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "u21euQdOjaEwmlnnB1Zd4XGqOmWI8FkoGeUleV7n4BZ8HPQC/jrYzX/B5Cz3uI/FXjd//W88clPfkGIbSif7Jw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "IyyGy7xNJAjdlFYXc7SZ7kS3CWd3Ma4hing9QGtzXi+LXm8RWCEXdKA1cPx5AeFmdg3rVG+ADGIn44K14O+vFA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "System.Diagnostics.EventLog": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "ayCRr/8ON3aINH81ak9l3vLAF/0pV/xrfChCbIlT2YnHAd4TYBWLcWhzbJWwPFV4XmJFrx/z8oq+gZzIc/74OA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "2lnp8nrvfzyp+5zvfeULm/hkZsDsKkl2ziBt5T8EZKoON5q+XRpRLoWcSPo8mP7GNZXpxKMBVjFNIZNbBIcnRw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "BHniU24QV67qp1pJknqYSofAPYGmijGI8D+ci9yfw33iuFdyOeB9lWTg78ThyYLyQwZw3s0vZ36VMb0MqbUuLw=="
+      },
+      "Onigwrap": {
+        "type": "Transitive",
+        "resolved": "1.0.10",
+        "contentHash": "eujNEpEhCl4UiqHTG0CeG/sWS8v/iYXGqUpaVkgBmYRZp3Utmz/aw38fuFL2rcnhj1FNfHwHaxGDeLY34a3nEA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lum+Dv+8S4gqN5H1C576UcQe0M2buoRjEUVs4TctXRSWjBH3ay3w2KyQrOo1yPdRs1I+xK69STz+4mjIisFI5w=="
+      },
+      "forgetrust.appsurface.caching": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "Microsoft.Extensions.Caching.Memory": "[9.0.6, )"
+        }
+      },
+      "forgetrust.appsurface.console": {
+        "type": "Project",
+        "dependencies": {
+          "CliFx": "[2.3.6, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.core": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting": "[9.0.6, )",
+          "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
+        }
+      },
+      "forgetrust.appsurface.docs": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Caching": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )",
+          "HtmlSanitizer": "[9.0.892, )",
+          "Markdig": "[0.44.0, )",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
+          "TextMateSharp": "[2.0.3, )",
+          "TextMateSharp.Grammars": "[2.0.3, )",
+          "YamlDotNet": "[17.0.1, )"
+        }
+      },
+      "forgetrust.appsurface.docs.standalone": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Docs": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.web": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.web.tailwind": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
+        }
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.linux-x64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.osx-arm64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.osx-x64": {
+        "type": "Project"
+      },
+      "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
+        "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
+      },
+      "HtmlSanitizer": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.892, )",
+        "resolved": "9.0.892",
+        "contentHash": "zdkMmpNCjTkxna8Y+jmPIFm2st+HjHrf32yNElFYwe7L4GmDm+mdKR6TzDyf6ewJ0RUUz84D4IkHNgrwGi4VbQ==",
+        "dependencies": {
+          "AngleSharp": "[0.17.1]",
+          "AngleSharp.Css": "[0.17.0]"
+        }
+      },
+      "Markdig": {
+        "type": "CentralTransitive",
+        "requested": "[0.44.0, )",
+        "resolved": "0.44.0",
+        "contentHash": "X+CYMjcUnh/yO24wOSQxVFLiGqWrrtXJ5M7toHiM1Zk4Fg9UMLN5fkaq6FSOWH+mIprsHHgDMlq3MJhmrXalhg=="
+      },
+      "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.36, )",
+        "resolved": "6.0.36",
+        "contentHash": "KFHRhrGAnd80310lpuWzI7Cf+GidS/h3JaPDFFnSmSGjCxB5vkBv5E+TXclJCJhqPtgNxg+keTC5SF1T9ieG5w==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Razor.Language": "6.0.36",
+          "Microsoft.CodeAnalysis.Razor": "6.0.36"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "FN5Rv8tmQ2yr4iTiNIetVDyTaLxyt+ugUUo7d7aJnIiHLDr1piOnS8sxUZOEx6apECPLHvrGhQ2XFVdv7mWZ3Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Mvc.Razor.Extensions": "6.0.0",
+          "Microsoft.CodeAnalysis.Razor": "6.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.2"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "CentralTransitive",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Razor": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.36, )",
+        "resolved": "6.0.36",
+        "contentHash": "RTLNJglWezr/1IkiWdtDpPYW7X7lwa4ow8E35cHt+sWdWxOnl+ayQqMy1RfbaLp7CLmRmgXSzMMZZU3D4vZi9Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Razor.Language": "6.0.36",
+          "Microsoft.CodeAnalysis.CSharp": "4.0.0",
+          "Microsoft.CodeAnalysis.Common": "4.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "qPW2d798tBPZcRmrlaBJqyChf2+0odDdE+0Lxvrr0ywkSNl1oNMK8AKrOfDwyXyjuLCv0ua7p6nrUExCeXhCcg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "Iu1UyXUnjMhoOwThKM0kCyjgWqqQnuujsbPMnF44ITUbmETT7RAVlozNgev2L/damwNoPZKpmwArRKBy2IOAZg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.Configuration.CommandLine": "9.0.6",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "9.0.6",
+          "Microsoft.Extensions.Configuration.FileExtensions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Json": "9.0.6",
+          "Microsoft.Extensions.Configuration.UserSecrets": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "9.0.6",
+          "Microsoft.Extensions.FileProviders.Physical": "9.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.Logging.Console": "9.0.6",
+          "Microsoft.Extensions.Logging.Debug": "9.0.6",
+          "Microsoft.Extensions.Logging.EventLog": "9.0.6",
+          "Microsoft.Extensions.Logging.EventSource": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "L1O0M3MrqGlkrPYMLzcCphQpCG0lSHfTSPrm1otALNBzTPiO8rxxkjhBIIa2onKv92UP30Y4QaiigVMTx8YcxQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "wUPhNM1zsI58Dy10xRdF2+pnsisiUuETg5ZBncyAEEUm/CQ9Q1vmivyUWH8RDbAlqyixf2dJNQ2XZb7HsKUEQw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "TextMateSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "w0wGeqlBi9SYrzxpS1DBcEfiVCs5NY18Yl5YBIsHzXTXQd0OLOh3mP4LRuFvcktR/1MG8nSBHSMJj0rFvrPk+A==",
+        "dependencies": {
+          "Onigwrap": "1.0.10"
+        }
+      },
+      "TextMateSharp.Grammars": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "qkI1ogusuyGCGTgeyhljDM+GEfATOexoUTqLIgSb5P0ojmfhRXWfSTRXXJRpZkLDErShJ7RWOb+p10lHfhhO+Q==",
+        "dependencies": {
+          "TextMateSharp": "2.0.3"
+        }
+      },
+      "YamlDotNet": {
+        "type": "CentralTransitive",
+        "requested": "[17.0.1, )",
+        "resolved": "17.0.1",
+        "contentHash": "qVir5fehR/W5nTJyoJUibypETXaW4iRAF9cQa0FQIC9TJ3VC0qDOwm4o/RxANewj8KzPF8WMF2abBfUgi6LC4w=="
+      }
+    }
+  }
+}

--- a/Console/ForgeTrust.AppSurface.Console/ForgeTrust.AppSurface.Console.csproj
+++ b/Console/ForgeTrust.AppSurface.Console/ForgeTrust.AppSurface.Console.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ForgeTrust.AppSurface.Console.Tests"/>
+    <InternalsVisibleTo Include="ForgeTrust.AppSurface.Cli"/>
     <InternalsVisibleTo Include="ForgeTrust.RazorWire.Cli"/>
   </ItemGroup>
 </Project>

--- a/ForgeTrust.AppSurface.Core.Tests/AppSurfaceStartupTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/AppSurfaceStartupTests.cs
@@ -165,6 +165,20 @@ public class AppSurfaceStartupTests
         Assert.Equal(1, dep.AfterCalled);
     }
 
+    [Fact]
+    public void RegisterDependencies_CanPrepareGraphBeforeCreateHostBuilder_WithoutRegisteringTwice()
+    {
+        var root = new CountingRootModule();
+        var startup = new DependencyPreparingStartup();
+        var context = new StartupContext([], root);
+
+        startup.PrepareDependencies(context);
+        ((IAppSurfaceStartup)startup).CreateHostBuilder(context);
+
+        Assert.Equal(1, root.RegisterDependentModulesCalled);
+        Assert.Contains(context.GetDependencies(), module => module is CountingDepModule);
+    }
+
     private class ServiceFromRoot
     {
     }
@@ -333,6 +347,49 @@ public class AppSurfaceStartupTests
 
     private class TrackingStartup : AppSurfaceStartup<TrackingRootModule>
     {
+        protected override void ConfigureServicesForAppType(StartupContext context, IServiceCollection services)
+        {
+        }
+    }
+
+    private class CountingDepModule : IAppSurfaceModule
+    {
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+        }
+    }
+
+    private class CountingRootModule : IAppSurfaceHostModule
+    {
+        public int RegisterDependentModulesCalled { get; private set; }
+
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+            RegisterDependentModulesCalled++;
+            builder.AddModule<CountingDepModule>();
+        }
+
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+    }
+
+    private class DependencyPreparingStartup : AppSurfaceStartup<CountingRootModule>
+    {
+        public void PrepareDependencies(StartupContext context) => RegisterDependencies(context);
+
         protected override void ConfigureServicesForAppType(StartupContext context, IServiceCollection services)
         {
         }

--- a/ForgeTrust.AppSurface.Core/AppSurfaceStartup.cs
+++ b/ForgeTrust.AppSurface.Core/AppSurfaceStartup.cs
@@ -156,9 +156,7 @@ public abstract class AppSurfaceStartup<TRootModule> : AppSurfaceStartup, IAppSu
             }
         });
 
-        // Ensure internal services (like Default IEnvironmentProvider) are included first so external modules can override them.
-        context.Dependencies.AddModule<Defaults.InternalServicesModule>();
-        context.RootModule.RegisterDependentModules(context.Dependencies);
+        RegisterDependencies(context);
 
         ConfigureHostBeforeServicesCore(context, builder);
 
@@ -177,6 +175,37 @@ public abstract class AppSurfaceStartup<TRootModule> : AppSurfaceStartup, IAppSu
     /// </summary>
     /// <returns>A new <typeparamref name="TRootModule"/> instance.</returns>
     protected virtual TRootModule CreateRootModule() => new();
+
+    /// <summary>
+    /// Registers framework and root-module dependencies into the startup context once.
+    /// </summary>
+    /// <param name="context">Startup context whose dependency graph should be prepared.</param>
+    /// <remarks>
+    /// <para>
+    /// App-type startups normally let AppSurface call this during host-builder creation. Specialized startup lifecycles
+    /// may call it earlier when they need module-derived options before building the host. For example, CLI hosts that
+    /// need packaged-asset or web-option defaults before the Generic Host exists should call
+    /// <c>RegisterDependencies(context)</c> before reading those settings.
+    /// </para>
+    /// <para>
+    /// The method adds <see cref="Defaults.InternalServicesModule"/> first, invokes
+    /// <see cref="IAppSurfaceModule.RegisterDependentModules(ModuleDependencyBuilder)"/> on the root module, and then
+    /// marks <see cref="StartupContext.DependenciesRegistered"/> so repeated calls are no-ops for the same context.
+    /// This method is not thread-safe; access each <see cref="StartupContext"/> from a single thread during startup.
+    /// </para>
+    /// </remarks>
+    protected void RegisterDependencies(StartupContext context)
+    {
+        if (context.DependenciesRegistered)
+        {
+            return;
+        }
+
+        // Ensure internal services (like Default IEnvironmentProvider) are included first so external modules can override them.
+        context.Dependencies.AddModule<Defaults.InternalServicesModule>();
+        context.RootModule.RegisterDependentModules(context.Dependencies);
+        context.DependenciesRegistered = true;
+    }
 
     private void ConfigureHostBeforeServicesCore(
         StartupContext context,

--- a/ForgeTrust.AppSurface.Core/README.md
+++ b/ForgeTrust.AppSurface.Core/README.md
@@ -15,6 +15,7 @@ The Core library is designed to be lightweight and implementation-agnostic. It p
 - **`StartupContext`**: Provides metadata about the running application, including the user-facing application label, assembly-backed host identity, application discovery assembly, environment, and startup-level console output mode.
 - **`ConsoleOutputMode`**: Shared core enum that lets console-oriented packages describe whether command output should remain host-centric or command-first.
 - **`AppSurfaceStartup`**: The base class that orchestrates the host building and service registration process.
+- **`AppSurfaceStartup.RegisterDependencies`**: A protected seam for specialized startup types that need the module graph prepared before they build the Generic Host.
 
 ## Application labels and host identity
 
@@ -25,6 +26,14 @@ The Core library is designed to be lightweight and implementation-agnostic. It p
 `StartupContext.EntryPointAssembly` is the assembly AppSurface scans for application-owned commands, MVC application parts, Aspire components, and similar extensibility points. It defaults to the root module assembly so test runners and shared outer hosts do not accidentally scan the xUnit/VSTest process entry assembly. When `StartupContext.OverrideEntryPointAssembly` is set, that override applies to both discovery and host manifest identity.
 
 Keep these values separate. ASP.NET static web assets use the host application name to find runtime manifests. Passing a custom display label such as `CustomDocsHost` into the host environment can make static asset requests resolve against a manifest that does not exist. When a test or custom host needs a different manifest identity, set `StartupContext.OverrideEntryPointAssembly` instead of overloading `ApplicationName`.
+
+## Startup dependency graph
+
+`AppSurfaceStartup` registers framework dependencies and root-module dependencies exactly once per `StartupContext`. Standard hosts do not need to call anything directly: the registration happens during host-builder creation before module hooks and service registration run.
+
+Specialized startup types can call the protected `RegisterDependencies(StartupContext context)` seam earlier when they need module-derived options before `IHostBuilder.Build()`. AppSurface Web uses this to resolve `WebOptions.StartupTimeout` before arming its startup watchdog around host creation and startup.
+
+Call `RegisterDependencies` before reading `StartupContext.GetDependencies()` for startup-shaping decisions. Repeated calls with the same context are no-ops, but module registration is still part of startup composition, so avoid calling it from request-time code or from parallel threads.
 
 ## Logging in Static Utilities
 

--- a/ForgeTrust.AppSurface.Core/StartupContext.cs
+++ b/ForgeTrust.AppSurface.Core/StartupContext.cs
@@ -26,6 +26,17 @@ public record StartupContext(
 {
     internal ModuleDependencyBuilder Dependencies { get; } = new();
 
+    /// <summary>
+    /// Gets or sets whether startup dependency registration has already run for this context.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see langword="false"/>. <see cref="AppSurfaceStartup{TRootModule}"/> sets this to
+    /// <see langword="true"/> after framework and root-module dependencies are registered so repeated startup-time calls
+    /// are no-ops for the same <see cref="StartupContext"/>. This state is intended for single-threaded startup
+    /// composition and is not safe for concurrent writes.
+    /// </remarks>
+    internal bool DependenciesRegistered { get; set; }
+
     private string? _applicationName = ApplicationName;
 
     /// <summary>

--- a/ForgeTrust.AppSurface.slnx
+++ b/ForgeTrust.AppSurface.slnx
@@ -14,6 +14,10 @@
     <Project Path="Caching/ForgeTrust.AppSurface.Caching/ForgeTrust.AppSurface.Caching.csproj" />
     <Project Path="Caching/ForgeTrust.AppSurface.Caching.Tests/ForgeTrust.AppSurface.Caching.Tests.csproj" />
   </Folder>
+  <Folder Name="/Cli/">
+    <Project Path="Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj" />
+    <Project Path="Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj" />
+  </Folder>
   <Folder Name="/Config/">
     <Project Path="Config/ForgeTrust.AppSurface.Config.Tests/ForgeTrust.AppSurface.Config.Tests.csproj" />
     <Project Path="Config/ForgeTrust.AppSurface.Config/ForgeTrust.AppSurface.Config.csproj" />

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ This approach aims to:
 - [**ForgeTrust.AppSurface.Docs.Standalone**](./Web/ForgeTrust.AppSurface.Docs.Standalone/README.md) – Thin export host for exporting or serving RazorDocs as an application.
 - [**ForgeTrust.AppSurface.Web.Scalar**](./Web/ForgeTrust.AppSurface.Web.Scalar/README.md) – Optional module that serves the Scalar API reference UI and depends on the OpenAPI module.
 
+### [CLI](./Cli/ForgeTrust.AppSurface.Cli/README.md)
+
+- [**ForgeTrust.AppSurface.Cli**](./Cli/ForgeTrust.AppSurface.Cli/README.md) – Public `appsurface` command-line tool, including the `appsurface docs` RazorDocs preview workflow.
+
 ### [Dependency](./Dependency/README.md)
 
 - [**ForgeTrust.AppSurface.Dependency.Autofac**](./Dependency/ForgeTrust.AppSurface.Dependency.Autofac/README.md) – Optional integration with the Autofac IoC container so modules can participate in Autofac service registration.

--- a/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
@@ -10,6 +10,14 @@ This project is the thin executable wrapper around the reusable [ForgeTrust.AppS
 - the export target in CI
 - a smoke-testable host that proves the package seam stays honest
 
+For public command-line workflows, use the AppSurface CLI as the public command surface:
+
+```bash
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http://127.0.0.1:5189
+```
+
+The CLI delegates to this standalone host, so the host remains the source of truth for RazorDocs startup, static web assets, routes, and configuration binding.
+
 ## Entry Point
 
 The app boots through [Program.cs](./Program.cs), which delegates to `RazorDocsStandaloneHost`.
@@ -17,12 +25,15 @@ The app boots through [Program.cs](./Program.cs), which delegates to `RazorDocsS
 
 - `RunAsync(string[] args)` starts the standalone app and is what `Program.cs` uses.
 - `CreateBuilder(string[] args, IEnvironmentProvider? environmentProvider = null)` returns an `IHostBuilder` without starting it.
+- `CreateBuilder(string[] args, IEnvironmentProvider? environmentProvider, Action<WebOptions>? configureOptions)` adds the same builder seam plus web-option customization for package-hosted tools.
 
 Use `CreateBuilder` when a test or tool needs the real standalone host in-process. It keeps the same `RazorDocsWebModule`, MVC routes, static web assets, and `RazorDocs` configuration binding as the executable path while avoiding a shell-out to `dotnet run`.
 
 Do not duplicate standalone setup in test fixtures. If a scenario needs different URLs, repository roots, contributor templates, or environment behavior, pass those through command-line configuration or the optional environment provider so the normal host builder still owns the app shape.
 `CreateBuilder` is lower level than `RunAsync`: callers that build and start the host themselves should pass `--urls`, `--port`, or configure the web host before `Build()` instead of relying on the executable startup path's development-port fallback.
 The builder pins this standalone assembly as the host entry point identity so in-process callers, including xUnit, resolve the same static web asset manifest as the executable.
+
+The optional `configureOptions` callback is for host-shape seams that must stay on the normal AppSurface Web path. `appsurface docs` uses it to disable static web asset manifest loading for packaged tool runs because RazorDocs and RazorWire runtime assets are embedded in their assemblies. The shared AppSurface Web startup watchdog still applies through `WebOptions.StartupTimeout`, which defaults to 30 seconds and fails fast when the process stalls before Kestrel starts listening.
 
 ## Strict Harvest Failure
 

--- a/Web/ForgeTrust.AppSurface.Docs.Standalone/RazorDocsStandaloneHost.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Standalone/RazorDocsStandaloneHost.cs
@@ -26,7 +26,25 @@ public static class RazorDocsStandaloneHost
         Justification = "Process lifetime wrapper delegates to the covered host-builder seam and runs until host shutdown.")]
     public static Task RunAsync(string[] args)
     {
+        return RunAsync(args, configureOptions: null);
+    }
+
+    /// <summary>
+    /// Runs the standalone RazorDocs web application with optional host web-option customization.
+    /// </summary>
+    /// <param name="args">Command-line arguments forwarded to the AppSurface Web startup pipeline.</param>
+    /// <param name="configureOptions">
+    /// Optional web-options callback applied after module defaults, before the host is built. Package-hosted command-line
+    /// tools use this seam to disable static-web-asset manifest loading when their required assets are embedded in
+    /// assemblies instead.
+    /// </param>
+    /// <returns>A task that completes when the host exits.</returns>
+    [ExcludeFromCodeCoverage(
+        Justification = "Process lifetime wrapper delegates to the covered host-builder seam and runs until host shutdown.")]
+    public static Task RunAsync(string[] args, Action<WebOptions>? configureOptions)
+    {
         return new RazorDocsStandaloneStartup()
+            .WithOptions(configureOptions)
             .RunAsync(args);
     }
 
@@ -42,12 +60,38 @@ public static class RazorDocsStandaloneHost
     /// <remarks>
     /// The builder pins the standalone assembly as the entry point identity so in-process test hosts still resolve the
     /// same static web asset manifest that the executable resolves. Without that override, test runners would use their
-    /// own process entry assembly and miss RazorDocs assets.
+    /// own process entry assembly and miss RazorDocs assets. This overload is kept for source and binary compatibility;
+    /// use the three-parameter overload when a packaged tool needs to customize AppSurface Web options.
     /// </remarks>
     /// <returns>An <see cref="IHostBuilder"/> for the standalone RazorDocs application.</returns>
     public static IHostBuilder CreateBuilder(
         string[] args,
         IEnvironmentProvider? environmentProvider = null)
+    {
+        return CreateBuilder(args, environmentProvider, configureOptions: null);
+    }
+
+    /// <summary>
+    /// Creates a configured host builder for the standalone RazorDocs application without starting it.
+    /// </summary>
+    /// <param name="args">Command-line arguments forwarded to the Generic Host and RazorDocs configuration binder.</param>
+    /// <param name="environmentProvider">
+    /// Optional environment provider used by AppSurface startup decisions before the Generic Host has been built.
+    /// Leave unset for normal executable startup; tests can pass a fixed provider to avoid process-wide environment
+    /// variable mutation.
+    /// </param>
+    /// <param name="configureOptions">
+    /// Optional web-options callback applied after module defaults, before the host is built.
+    /// </param>
+    /// <remarks>
+    /// This overload preserves the original two-parameter <c>CreateBuilder</c> method for already-compiled callers while
+    /// giving packaged tools a host-shape seam for static-web-asset and startup-watchdog options.
+    /// </remarks>
+    /// <returns>An <see cref="IHostBuilder"/> for the standalone RazorDocs application.</returns>
+    public static IHostBuilder CreateBuilder(
+        string[] args,
+        IEnvironmentProvider? environmentProvider,
+        Action<WebOptions>? configureOptions = null)
     {
         var context = new StartupContext(
             args,
@@ -57,7 +101,7 @@ public static class RazorDocsStandaloneHost
             OverrideEntryPointAssembly = typeof(RazorDocsStandaloneHost).Assembly
         };
 
-        return ((IAppSurfaceStartup)new RazorDocsStandaloneStartup())
+        return ((IAppSurfaceStartup)new RazorDocsStandaloneStartup().WithOptions(configureOptions))
             .CreateHostBuilder(context);
     }
 

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsWebModuleRegressionTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsWebModuleRegressionTests.cs
@@ -769,7 +769,7 @@ public class RazorDocsWebModuleRegressionTests
     }
 
     [Fact]
-    public async Task ConfigureEndpoints_Versioning_ReturnsNotFoundForPreviewAssets_WhenWebRootAssetFileIsMissing()
+    public async Task ConfigureEndpoints_Versioning_ServesEmbeddedPreviewAssets_WhenWebRootAssetFileIsMissing()
     {
         var tempDirectory = Path.Combine(
             Path.GetTempPath(),
@@ -820,10 +820,17 @@ public class RazorDocsWebModuleRegressionTests
                     };
 
                     using var getResponse = await client.GetAsync("/docs/next/search.css");
-                    Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+                    Assert.Equal("text/css", getResponse.Content.Headers.ContentType?.MediaType);
+                    Assert.Contains(
+                        "docs-search",
+                        await getResponse.Content.ReadAsStringAsync(),
+                        StringComparison.Ordinal);
 
                     using var headResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, "/docs/next/search-client.js"));
-                    Assert.Equal(HttpStatusCode.NotFound, headResponse.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+                    Assert.Equal("text/javascript", headResponse.Content.Headers.ContentType?.MediaType);
+                    Assert.True(headResponse.Content.Headers.ContentLength > 0);
                 }
                 finally
                 {
@@ -1023,6 +1030,75 @@ public class RazorDocsWebModuleRegressionTests
             await AssertRedirectAsync(client, RootStylesheetPath, PackagedStylesheetPath);
             await AssertRedirectAsync(client, $"{RootStylesheetPath}?v=42", $"{PackagedStylesheetPath}?v=42");
             await AssertRedirectAsync(client, HttpMethod.Head, RootStylesheetPath, PackagedStylesheetPath);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_ShouldServePackagedAssetsFromEmbeddedResources_WhenStaticWebAssetsAreUnavailable()
+    {
+        var module = new RazorDocsWebModule();
+        var context = new StartupContext([], module);
+        var builder = WebApplication.CreateBuilder();
+
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddControllersWithViews().AddApplicationPart(typeof(DocsController).Assembly);
+
+        using var app = builder.Build();
+        module.ConfigureEndpoints(context, app);
+
+        await app.StartAsync();
+
+        try
+        {
+            var server = app.Services.GetRequiredService<IServer>();
+            var addresses = server.Features.Get<IServerAddressesFeature>();
+            var baseAddress = Assert.Single(addresses!.Addresses);
+
+            using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+            {
+                BaseAddress = new Uri(baseAddress)
+            };
+
+            using var stylesheetResponse = await client.GetAsync(PackagedStylesheetPath);
+            Assert.Equal(HttpStatusCode.OK, stylesheetResponse.StatusCode);
+            Assert.Equal("text/css", stylesheetResponse.Content.Headers.ContentType?.MediaType);
+            Assert.Contains(
+                "--docs",
+                await stylesheetResponse.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+
+            using var searchClientResponse = await client.GetAsync($"{PackagedAssetBasePath}/search-client.js");
+            Assert.Equal(HttpStatusCode.OK, searchClientResponse.StatusCode);
+            Assert.Contains(
+                "razorDocsConfig",
+                await searchClientResponse.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+
+            using var packagedSearchCssResponse = await client.GetAsync($"{PackagedAssetBasePath}/search.css");
+            Assert.Equal(HttpStatusCode.OK, packagedSearchCssResponse.StatusCode);
+            Assert.Equal("text/css", packagedSearchCssResponse.Content.Headers.ContentType?.MediaType);
+            Assert.Contains(
+                "--docs-search",
+                await packagedSearchCssResponse.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+
+            using var miniSearchResponse = await client.GetAsync($"{PackagedAssetBasePath}/minisearch.min.js");
+            Assert.Equal(HttpStatusCode.OK, miniSearchResponse.StatusCode);
+            Assert.Equal("text/javascript", miniSearchResponse.Content.Headers.ContentType?.MediaType);
+            Assert.Contains(
+                "MiniSearch",
+                await miniSearchResponse.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+
+            using var outlineHeadRequest = new HttpRequestMessage(HttpMethod.Head, $"{PackagedAssetBasePath}/outline-client.js");
+            using var outlineHeadResponse = await client.SendAsync(outlineHeadRequest);
+            Assert.Equal(HttpStatusCode.OK, outlineHeadResponse.StatusCode);
+            Assert.Equal("text/javascript", outlineHeadResponse.Content.Headers.ContentType?.MediaType);
+            Assert.True(outlineHeadResponse.Content.Headers.ContentLength > 0);
         }
         finally
         {

--- a/Web/ForgeTrust.AppSurface.Docs/ForgeTrust.AppSurface.Docs.csproj
+++ b/Web/ForgeTrust.AppSurface.Docs/ForgeTrust.AppSurface.Docs.csproj
@@ -18,6 +18,14 @@
   <Import Project="..\ForgeTrust.AppSurface.Web.Tailwind\build\ForgeTrust.AppSurface.Web.Tailwind.targets" Condition="Exists('..\ForgeTrust.AppSurface.Web.Tailwind\build\ForgeTrust.AppSurface.Web.Tailwind.targets')" />
 
   <ItemGroup>
+    <EmbeddedResource Include="wwwroot\css\site.gen.css" LogicalName="RazorDocsEmbeddedAssets/css/site.gen.css" />
+    <EmbeddedResource Include="wwwroot\docs\minisearch.min.js" LogicalName="RazorDocsEmbeddedAssets/docs/minisearch.min.js" />
+    <EmbeddedResource Include="wwwroot\docs\outline-client.js" LogicalName="RazorDocsEmbeddedAssets/docs/outline-client.js" />
+    <EmbeddedResource Include="wwwroot\docs\search-client.js" LogicalName="RazorDocsEmbeddedAssets/docs/search-client.js" />
+    <EmbeddedResource Include="wwwroot\docs\search.css" LogicalName="RazorDocsEmbeddedAssets/docs/search.css" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="Markdig" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -913,7 +913,13 @@ Preview locally from the repository root with the standalone docs host:
 dotnet run --project Web/ForgeTrust.AppSurface.Docs.Standalone -- --urls http://localhost:5189
 ```
 
-Then open the configured docs home, `http://localhost:5189/docs` by default. This is only the docs site running locally; the separate `razordocs preview --repo .` CLI idea is intentionally deferred.
+Or use the AppSurface CLI shape, which keeps RazorDocs workflows under the `appsurface` command family:
+
+```bash
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http://localhost:5189
+```
+
+Then open the configured docs home, `http://localhost:5189/docs` by default. The standalone host remains the reusable runtime seam; `appsurface docs` is the public CLI entry point for the same preview workflow rather than a separate `razordocs` tool.
 
 ### Fallback and visibility rules
 
@@ -1086,6 +1092,6 @@ trust:
 ## Notes
 
 - This package is the reusable documentation surface; `ForgeTrust.AppSurface.Docs.Standalone` is the thin executable wrapper used for local hosting and export scenarios.
-- The bundled RazorDocs UI already includes its generated stylesheet as a static web asset. The layout resolves the correct stylesheet path automatically from the host's root module shape for standalone/root-module hosts versus embedded application-part consumers.
+- The bundled RazorDocs UI includes its generated stylesheet and docs runtime files as static web assets and assembly-embedded fallback resources. The layout resolves the correct stylesheet path automatically from the host's root module shape for standalone/root-module hosts versus embedded application-part consumers, while endpoint fallbacks keep packaged hosts working when static web asset manifests are unavailable.
 - Consumers do not need to call `services.AddTailwind()` unless they also want Tailwind build/watch integration for their own host application's CSS.
 - It depends on the Tailwind package family for RazorDocs package build-time styling generation and on the caching package for docs aggregation performance.

--- a/Web/ForgeTrust.AppSurface.Docs/RazorDocsWebModule.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/RazorDocsWebModule.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Reflection;
 using ForgeTrust.AppSurface.Caching;
 using ForgeTrust.AppSurface.Core;
 using ForgeTrust.AppSurface.Docs.Services;
@@ -34,9 +36,11 @@ namespace ForgeTrust.AppSurface.Docs;
 public class RazorDocsWebModule : IAppSurfaceWebModule
 {
     private static readonly FileExtensionContentTypeProvider ContentTypeProvider = new();
+    private static readonly Assembly RazorDocsAssembly = typeof(RazorDocsWebModule).Assembly;
     private const string RazorDocsStaticAssetBasePath = "/_content/ForgeTrust.AppSurface.Docs/docs";
     private const string RazorDocsPackagedStylesheetPath = "/_content/ForgeTrust.AppSurface.Docs/css/site.gen.css";
     private const string RazorDocsRootStylesheetPath = "/css/site.gen.css";
+    private const string EmbeddedAssetResourcePrefix = "RazorDocsEmbeddedAssets/";
 
     /// <inheritdoc />
     public bool IncludeAsApplicationPart => true;
@@ -278,6 +282,12 @@ public class RazorDocsWebModule : IAppSurfaceWebModule
         var docsOptions = ResolveOptions(endpoints.ServiceProvider);
         var docsUrlBuilder = endpoints.ServiceProvider.GetService(typeof(DocsUrlBuilder)) as DocsUrlBuilder
                              ?? new DocsUrlBuilder(docsOptions);
+        MapEmbeddedAssetFallback(endpoints, RazorDocsPackagedStylesheetPath, "css/site.gen.css");
+        MapEmbeddedAssetFallback(endpoints, $"{RazorDocsStaticAssetBasePath}/search.css", "docs/search.css");
+        MapEmbeddedAssetFallback(endpoints, $"{RazorDocsStaticAssetBasePath}/minisearch.min.js", "docs/minisearch.min.js");
+        MapEmbeddedAssetFallback(endpoints, $"{RazorDocsStaticAssetBasePath}/search-client.js", "docs/search-client.js");
+        MapEmbeddedAssetFallback(endpoints, $"{RazorDocsStaticAssetBasePath}/outline-client.js", "docs/outline-client.js");
+
         if (ShouldPreserveRootStylesheetPath(context))
         {
             // Published/exported standalone hosts can resolve the packaged stylesheet only under /_content.
@@ -507,6 +517,8 @@ public class RazorDocsWebModule : IAppSurfaceWebModule
                ?? new RazorDocsOptions();
     }
 
+    [ExcludeFromCodeCoverage(
+        Justification = "Private endpoint closure for preview asset serving; integration coverage verifies the mapped public asset routes.")]
     private static void MapWebRootAsset(IEndpointRouteBuilder endpoints, string route, string webRootSubPath)
     {
         endpoints.MapMethods(
@@ -525,7 +537,11 @@ public class RazorDocsWebModule : IAppSurfaceWebModule
                 var fileInfo = fileProvider.GetFileInfo(webRootSubPath);
                 if (!fileInfo.Exists)
                 {
-                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    if (!await TryWriteEmbeddedAssetAsync(context, webRootSubPath))
+                    {
+                        context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    }
+
                     return;
                 }
 
@@ -542,6 +558,45 @@ public class RazorDocsWebModule : IAppSurfaceWebModule
 
                 await context.Response.SendFileAsync(fileInfo, context.RequestAborted);
             });
+    }
+
+    [ExcludeFromCodeCoverage(
+        Justification = "Private endpoint closure for static asset fallback; integration coverage verifies the mapped public asset routes.")]
+    private static void MapEmbeddedAssetFallback(IEndpointRouteBuilder endpoints, string route, string webRootSubPath)
+    {
+        endpoints.MapMethods(
+            route,
+            [HttpMethods.Get, HttpMethods.Head],
+            async context =>
+            {
+                if (!await TryWriteEmbeddedAssetAsync(context, webRootSubPath))
+                {
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
+            });
+    }
+
+    [ExcludeFromCodeCoverage(
+        Justification = "Private assembly-resource adapter with a defensive missing-resource branch; public route tests cover packaged asset availability.")]
+    private static async Task<bool> TryWriteEmbeddedAssetAsync(HttpContext context, string webRootSubPath)
+    {
+        var resourceName = EmbeddedAssetResourcePrefix + webRootSubPath.Replace('\\', '/').TrimStart('/');
+        await using var stream = RazorDocsAssembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            return false;
+        }
+
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Response.ContentType = ResolveContentType(webRootSubPath);
+        context.Response.ContentLength = stream.Length;
+        if (HttpMethods.IsHead(context.Request.Method))
+        {
+            return true;
+        }
+
+        await stream.CopyToAsync(context.Response.Body, context.RequestAborted);
+        return true;
     }
 
     private static bool ShouldPreserveRootStylesheetPath(StartupContext context)

--- a/Web/ForgeTrust.AppSurface.Web.Tests/BrowserStatusPageTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/BrowserStatusPageTests.cs
@@ -127,6 +127,7 @@ public sealed class BrowserStatusPageTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Contains(expectedMarker, html);
         Assert.Contains(BrowserStatusPageDefaults.GetAppViewPath(statusCode), html);
+        Assert.Contains("data-rw-export-ignore=\"true\"", html);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
@@ -84,6 +84,136 @@ public class WebStartupTests
     }
 
     [Fact]
+    public async Task RunResolvedAsync_FailsFast_WhenHostStartupDoesNotCompleteBeforeTimeout()
+    {
+        var startup = new HangingWebStartup(new HangingWebModule());
+        startup.WithOptions(options => options.StartupTimeout = TimeSpan.FromMilliseconds(250));
+        var originalExitCode = Environment.ExitCode;
+
+        try
+        {
+            Environment.ExitCode = 0;
+
+            await startup.RunResolvedAsync(["--urls", "http://127.0.0.1:0"]);
+
+            Assert.Equal(-100, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunResolvedAsync_FailsFast_WhenStartupCancellationCallbackDoesNotComplete()
+    {
+        var module = new HangingCancellationWebModule();
+        var startup = new HangingCancellationWebStartup(module);
+        startup.WithOptions(options => options.StartupTimeout = TimeSpan.FromMilliseconds(100));
+        var originalExitCode = Environment.ExitCode;
+
+        try
+        {
+            Environment.ExitCode = 0;
+
+            var runTask = startup.RunResolvedAsync(["--urls", "http://127.0.0.1:0"]);
+            var completedTask = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(1)));
+
+            Assert.Same(runTask, completedTask);
+            await runTask;
+            await module.Probe.CancellationStarted.WaitAsync(TimeSpan.FromSeconds(1));
+            Assert.Equal(-100, Environment.ExitCode);
+        }
+        finally
+        {
+            module.Probe.ReleaseCancellation();
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunResolvedAsync_Rejects_NonPositive_Configured_StartupTimeout()
+    {
+        var startup = new StoppingWebStartup(new StoppingWebModule());
+        startup.WithOptions(options => options.StartupTimeout = TimeSpan.Zero);
+        var originalExitCode = Environment.ExitCode;
+
+        try
+        {
+            Environment.ExitCode = 0;
+
+            await startup.RunResolvedAsync(["--urls", "http://127.0.0.1:0"]);
+
+            Assert.Equal(-100, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunResolvedAsync_Handles_OperationCanceledException_WithoutChangingExitCode()
+    {
+        var startup = new CancelingWebStartup(new CancelingWebModule());
+        var originalExitCode = Environment.ExitCode;
+
+        try
+        {
+            Environment.ExitCode = 17;
+
+            await startup.RunResolvedAsync(["--urls", "http://127.0.0.1:0"]);
+
+            Assert.Equal(17, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunResolvedAsync_Handles_GeneralException_BySettingExitCode()
+    {
+        var startup = new FaultingWebStartup(new FaultingWebModule());
+        var originalExitCode = Environment.ExitCode;
+
+        try
+        {
+            Environment.ExitCode = 0;
+
+            await startup.RunResolvedAsync(["--urls", "http://127.0.0.1:0"]);
+
+            Assert.Equal(-100, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunResolvedAsync_UsesDependencyConfiguredStartupTimeout_BeforeHostBuild()
+    {
+        var startup = new DependencyTimeoutWebStartup(new DependencyTimeoutRootModule());
+        var originalExitCode = Environment.ExitCode;
+
+        try
+        {
+            Environment.ExitCode = 0;
+
+            await startup.RunResolvedAsync(["--urls", "http://127.0.0.1:0"]);
+
+            Assert.Equal(-100, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+
+    [Fact]
     public void BuildModules_CorrectlyCollectsWebModules()
     {
         var root = new TestWebModule();
@@ -714,6 +844,323 @@ public class WebStartupTests
         protected override StoppingWebModule CreateRootModule() => _module;
     }
 
+    private sealed class HangingWebStartup : WebStartup<HangingWebModule>
+    {
+        private readonly HangingWebModule _module;
+
+        public HangingWebStartup(HangingWebModule module)
+        {
+            _module = module;
+        }
+
+        protected override HangingWebModule CreateRootModule() => _module;
+    }
+
+    private sealed class HangingCancellationWebStartup : WebStartup<HangingCancellationWebModule>
+    {
+        private readonly HangingCancellationWebModule _module;
+
+        public HangingCancellationWebStartup(HangingCancellationWebModule module)
+        {
+            _module = module;
+        }
+
+        protected override HangingCancellationWebModule CreateRootModule() => _module;
+    }
+
+    private sealed class DependencyTimeoutWebStartup : WebStartup<DependencyTimeoutRootModule>
+    {
+        private readonly DependencyTimeoutRootModule _module;
+
+        public DependencyTimeoutWebStartup(DependencyTimeoutRootModule module)
+        {
+            _module = module;
+        }
+
+        protected override DependencyTimeoutRootModule CreateRootModule() => _module;
+    }
+
+    private sealed class CancelingWebStartup : WebStartup<CancelingWebModule>
+    {
+        private readonly CancelingWebModule _module;
+
+        public CancelingWebStartup(CancelingWebModule module)
+        {
+            _module = module;
+        }
+
+        protected override CancelingWebModule CreateRootModule() => _module;
+    }
+
+    private sealed class FaultingWebStartup : WebStartup<FaultingWebModule>
+    {
+        private readonly FaultingWebModule _module;
+
+        public FaultingWebStartup(FaultingWebModule module)
+        {
+            _module = module;
+        }
+
+        protected override FaultingWebModule CreateRootModule() => _module;
+    }
+
+    private sealed class CancelingWebModule : IAppSurfaceWebModule
+    {
+        public bool IncludeAsApplicationPart => false;
+
+        public void ConfigureWebOptions(StartupContext context, WebOptions options)
+        {
+        }
+
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+        {
+            throw new OperationCanceledException();
+        }
+
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+        }
+
+        public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app)
+        {
+        }
+
+        public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+        }
+    }
+
+    private sealed class FaultingWebModule : IAppSurfaceWebModule
+    {
+        public bool IncludeAsApplicationPart => false;
+
+        public void ConfigureWebOptions(StartupContext context, WebOptions options)
+        {
+        }
+
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+        {
+            throw new InvalidOperationException("startup failed");
+        }
+
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+        }
+
+        public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app)
+        {
+        }
+
+        public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+        }
+    }
+
+    private sealed class DependencyTimeoutRootModule : IAppSurfaceWebModule
+    {
+        public bool IncludeAsApplicationPart => false;
+
+        public void ConfigureWebOptions(StartupContext context, WebOptions options)
+        {
+        }
+
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+        }
+
+        public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app)
+        {
+        }
+
+        public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+            builder.AddModule<DependencyTimeoutHangingModule>();
+        }
+    }
+
+    private sealed class DependencyTimeoutHangingModule : IAppSurfaceWebModule
+    {
+        public bool IncludeAsApplicationPart => false;
+
+        public void ConfigureWebOptions(StartupContext context, WebOptions options)
+        {
+            options.StartupTimeout = TimeSpan.FromMilliseconds(250);
+        }
+
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+            services.AddHostedService<NeverStartingHostedService>();
+        }
+
+        public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app)
+        {
+        }
+
+        public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+        }
+    }
+
+    private sealed class HangingWebModule : IAppSurfaceWebModule
+    {
+        public bool IncludeAsApplicationPart => false;
+
+        public void ConfigureWebOptions(StartupContext context, WebOptions options)
+        {
+        }
+
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+            services.AddHostedService<NeverStartingHostedService>();
+        }
+
+        public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app)
+        {
+        }
+
+        public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+        }
+    }
+
+    private sealed class HangingCancellationWebModule : IAppSurfaceWebModule
+    {
+        public HangingCancellationProbe Probe { get; } = new();
+
+        public bool IncludeAsApplicationPart => false;
+
+        public void ConfigureWebOptions(StartupContext context, WebOptions options)
+        {
+        }
+
+        public void ConfigureHostBeforeServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureHostAfterServices(StartupContext context, IHostBuilder builder)
+        {
+        }
+
+        public void ConfigureServices(StartupContext context, IServiceCollection services)
+        {
+            services.AddSingleton(Probe);
+            services.AddHostedService<HangingCancellationHostedService>();
+        }
+
+        public void ConfigureWebApplication(StartupContext context, IApplicationBuilder app)
+        {
+        }
+
+        public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
+        {
+        }
+
+        public void RegisterDependentModules(ModuleDependencyBuilder builder)
+        {
+        }
+    }
+
+    private sealed class NeverStartingHostedService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class HangingCancellationHostedService(HangingCancellationProbe probe) : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.Register(probe.BlockCancellationUntilReleased);
+            return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class HangingCancellationProbe
+    {
+        private readonly TaskCompletionSource<object?> _cancellationStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly TaskCompletionSource<object?> _releaseCancellation =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task CancellationStarted => _cancellationStarted.Task;
+
+        public void BlockCancellationUntilReleased()
+        {
+            _cancellationStarted.TrySetResult(null);
+            _releaseCancellation.Task.GetAwaiter().GetResult();
+        }
+
+        public void ReleaseCancellation()
+        {
+            _releaseCancellation.TrySetResult(null);
+        }
+    }
+
     private sealed class StoppingWebModule : IAppSurfaceWebModule
     {
         public bool IncludeAsApplicationPart => false;
@@ -778,6 +1225,17 @@ public class WebStartupTests
         public void RegisterDependentModules(ModuleDependencyBuilder builder)
         {
         }
+    }
+}
+
+public class WebOptionsTests
+{
+    [Fact]
+    public void WebOptions_DefaultStartupTimeout_IsThirtySeconds()
+    {
+        var opts = new WebOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(30), opts.StartupTimeout);
     }
 }
 

--- a/Web/ForgeTrust.AppSurface.Web/README.md
+++ b/Web/ForgeTrust.AppSurface.Web/README.md
@@ -114,7 +114,7 @@ Important behavior:
 - Only empty `401`, `403`, and `404` responses from `GET` or `HEAD` requests that accept `text/html` or `application/xhtml+xml` are re-executed.
 - JSON, non-HTML, non-empty, and non-GET/HEAD responses keep their original API-friendly behavior.
 - Missing default documentation `404` routes include a documentation search recovery link because stale docs links are the most common browser miss. The default RazorDocs route family is `/docs`, so the default recovery target is `/docs/search`. Apps that set `RazorDocs:Routing:RouteRootPath` should derive the search target from that root, for example `RazorDocs:Routing:RouteRootPath=/foo/bar` points stale-docs recovery links at `/foo/bar/search`.
-- Static export remains conservative: RazorWire CLI probes `/_appsurface/errors/404` and writes only `404.html`; it does not emit `401.html` or `403.html`. In CDN mode, that `404.html` page is validated and rewritten with the rest of the static output.
+- Static export remains conservative: RazorWire CLI probes `/_appsurface/errors/404` and writes only `404.html`; it does not emit `401.html` or `403.html`. In CDN mode, that `404.html` page is validated and rewritten with the rest of the static output. The fallback `Return home` link is marked `data-rw-export-ignore` so apps that do not export `/` can still publish a valid conventional `404.html`.
 - Production `500` exception pages are intentionally separate from browser status pages and must be enabled with `UseConventionalExceptionPage()`.
 
 ### Conventional Production 500 Pages
@@ -188,6 +188,20 @@ You can override the application's listening port using several methods:
 > The `--port` flag is a convenience shortcut that maps to `http://localhost:{port};http://*:{port}`. This ensures the application is accessible on all interfaces while logging a clickable `localhost` URL in the console. If both `--port` and `--urls` are provided, `--port` takes precedence.
 > [!TIP]
 > If you rely on the deterministic development-port fallback, different worktrees on the same machine will get different stable ports. If you need a predictable shared URL for docs, QA, or CI instructions, pass `--port` or `--urls` explicitly instead of depending on the fallback.
+
+### Startup Watchdog
+
+AppSurface Web fails fast when a host does not complete startup within `WebOptions.StartupTimeout`. The default is 30 seconds. This catches pre-bind stalls where the process is alive but Kestrel has not started listening, including sandbox restrictions, package layout issues, static web asset discovery hangs, and hosted services that block startup.
+
+Configure or disable the watchdog through `WebOptions`:
+
+```csharp
+await WebApp<MyRootModule>.RunAsync(
+    args,
+    options => options.StartupTimeout = TimeSpan.FromSeconds(60));
+```
+
+Set `StartupTimeout` to `null` only when the host intentionally performs long-running pre-bind work. Values at or below zero are invalid; use `null` instead of `TimeSpan.Zero` when disabling the guard. The watchdog stops checking once startup completes, so it does not limit normal request processing or long-running background work after the host is listening.
 
 ---
 [📂 Back to Web List](../README.md) | [🏠 Back to Root](../../README.md)

--- a/Web/ForgeTrust.AppSurface.Web/WebOptions.cs
+++ b/Web/ForgeTrust.AppSurface.Web/WebOptions.cs
@@ -43,6 +43,19 @@ public record WebOptions
     public ErrorPagesOptions Errors { get; set; } = ErrorPagesOptions.Default;
 
     /// <summary>
+    /// Gets or sets the amount of time AppSurface waits for the web host to complete startup before failing fast.
+    /// </summary>
+    /// <remarks>
+    /// The default is 30 seconds. Set this to <see langword="null"/> only for hosts that intentionally perform
+    /// long-running startup work before Kestrel binds. The watchdog covers pre-bind stalls caused by package layout,
+    /// sandboxing, static asset discovery, hosted-service startup, and similar issues; it does not limit normal request
+    /// processing after the host has started.
+    /// <see cref="StartupTimeout"/> must be <see langword="null"/> or greater than <see cref="TimeSpan.Zero"/>.
+    /// Use <see langword="null"/> to disable the watchdog instead of <see cref="TimeSpan.Zero"/>.
+    /// </remarks>
+    public TimeSpan? StartupTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Gets or sets an optional delegate to configure endpoint routing for the application.
     /// </summary>
     public Action<IEndpointRouteBuilder>? MapEndpoints { get; set; }

--- a/Web/ForgeTrust.AppSurface.Web/WebStartup.cs
+++ b/Web/ForgeTrust.AppSurface.Web/WebStartup.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ForgeTrust.AppSurface.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
@@ -83,7 +84,167 @@ public abstract class WebStartup<TModule> : AppSurfaceStartup<TModule>
     /// <returns>A task that completes when the web host run exits.</returns>
     internal virtual Task RunResolvedAsync(string[] args)
     {
-        return base.RunAsync(args);
+        return RunResolvedWithStartupTimeoutAsync(args);
+    }
+
+    private async Task RunResolvedWithStartupTimeoutAsync(string[] args)
+    {
+        var context = new StartupContext(args, CreateRootModule());
+        IHost? host = null;
+        CancellationTokenSource? startupCts = null;
+        var timedOut = false;
+
+        try
+        {
+            RegisterDependencies(context);
+            BuildModules(context);
+            BuildWebOptions(context);
+
+            var startupTimeout = _options.StartupTimeout;
+
+            if (startupTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(WebOptions.StartupTimeout),
+                    startupTimeout,
+                    "AppSurface Web startup timeout must be positive when it is configured. Set it to null to disable the watchdog.");
+            }
+
+            var logger = GetStartupLogger();
+            startupCts = new CancellationTokenSource();
+            var startTask = Task.Run(
+                () => BuildAndStartHostAsync(
+                    context,
+                    startupCts.Token,
+                    (startedHost, startupLogger) =>
+                    {
+                        host = startedHost;
+                        logger = startupLogger;
+                    }));
+            if (startupTimeout is not null)
+            {
+                var completedTask = await Task.WhenAny(startTask, Task.Delay(startupTimeout.Value));
+                if (completedTask != startTask)
+                {
+                    timedOut = true;
+                    var cancellationTask = startupCts.CancelAsync();
+                    ObserveTimedOutStartupTask(startTask, startupCts, () => host?.Dispose(), cancellationTask);
+                    logger.LogCritical(
+                        "AppSurface Web host startup did not complete within {StartupTimeoutSeconds} seconds. The host may be blocked before Kestrel has bound its URLs. Check sandbox restrictions, static web asset discovery, package layout, and hosted-service startup work. Set WebOptions.StartupTimeout to null only when this pre-bind delay is intentional.",
+                        startupTimeout.Value.TotalSeconds);
+                    Environment.ExitCode = -100;
+                    return;
+                }
+            }
+
+            host = await startTask;
+            await WaitForShutdownAndLogAsync(host, context, logger);
+        }
+        catch (OperationCanceledException ex)
+        {
+            GetStartupLogger().LogWarning(ex, "Service(s) did not exit in a timely fashion.");
+        }
+        catch (Exception e)
+        {
+            GetStartupLogger().LogCritical(e, "Fatal Processing Error");
+            Environment.ExitCode = -100;
+        }
+        finally
+        {
+            if (!timedOut)
+            {
+                host?.Dispose();
+                startupCts?.Dispose();
+            }
+        }
+    }
+
+    [ExcludeFromCodeCoverage(
+        Justification = "Private framework-host adapter; RunResolvedAsync tests verify success, fault, cancellation, and timeout outcomes through the public startup path.")]
+    private async Task<IHost> BuildAndStartHostAsync(
+        StartupContext context,
+        CancellationToken startupCancellationToken,
+        Action<IHost, ILogger> hostStarted)
+    {
+        var host = ((IAppSurfaceStartup)this).CreateHostBuilder(context).Build();
+        var loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger(GetType().Name);
+        hostStarted(host, logger);
+
+        try
+        {
+            await host.StartAsync(startupCancellationToken);
+        }
+        catch (OperationCanceledException) when (startupCancellationToken.IsCancellationRequested)
+        {
+        }
+
+        return host;
+    }
+
+    [ExcludeFromCodeCoverage(
+        Justification = "Private framework-host adapter; RunResolvedAsync tests verify that normal shutdown completes without surfacing host lifecycle noise.")]
+    private static async Task WaitForShutdownAndLogAsync(
+        IHost host,
+        StartupContext context,
+        ILogger logger)
+    {
+        await host.WaitForShutdownAsync();
+
+        if (context.ConsoleOutputMode != ConsoleOutputMode.CommandFirst)
+        {
+            logger.LogInformation("Run Exited - Shutting down");
+        }
+    }
+
+    [ExcludeFromCodeCoverage(
+        Justification = "Private fire-and-forget continuation that prevents unobserved timeout faults; public tests verify timeout exit behavior.")]
+    private static void ObserveTimedOutStartupTask(
+        Task<IHost> startTask,
+        CancellationTokenSource startupCts,
+        Action disposeStartedHost,
+        Task cancellationTask)
+    {
+        _ = ObserveTimedOutStartupTaskAsync(startTask, startupCts, disposeStartedHost, cancellationTask);
+    }
+
+    [ExcludeFromCodeCoverage(
+        Justification = "Private fire-and-forget cleanup continuation; public tests verify the timeout exits immediately even when cancellation callbacks block.")]
+    private static async Task ObserveTimedOutStartupTaskAsync(
+        Task<IHost> startTask,
+        CancellationTokenSource startupCts,
+        Action disposeStartedHost,
+        Task cancellationTask)
+    {
+        try
+        {
+            try
+            {
+                var startedHost = await startTask.ConfigureAwait(false);
+                startedHost.Dispose();
+            }
+            catch
+            {
+                disposeStartedHost();
+
+                if (startTask.IsFaulted)
+                {
+                    _ = startTask.Exception;
+                }
+            }
+
+            try
+            {
+                await cancellationTask.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+        }
+        finally
+        {
+            startupCts.Dispose();
+        }
     }
 
     /// <summary>

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsInProcessHostTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsInProcessHostTests.cs
@@ -1,4 +1,7 @@
 using System.Net;
+using ForgeTrust.AppSurface.Core;
+using ForgeTrust.AppSurface.Docs.Standalone;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace ForgeTrust.RazorWire.IntegrationTests;
@@ -51,6 +54,22 @@ public sealed class RazorDocsInProcessHostTests
 
         Assert.Same(expected, exception);
         Assert.True(host.IsDisposed);
+    }
+
+    [Fact]
+    public void RazorDocsStandaloneHost_PreservesTwoParameterCreateBuilderOverload()
+    {
+        var environmentProvider = new TestEnvironmentProvider(Environments.Development);
+
+        var builder = RazorDocsStandaloneHost.CreateBuilder(
+            ["--urls", "http://127.0.0.1:0"],
+            environmentProvider);
+
+        using var host = builder.Build();
+
+        Assert.Same(
+            environmentProvider,
+            host.Services.GetRequiredService<IEnvironmentProvider>());
     }
 
     [Fact]
@@ -111,6 +130,18 @@ public sealed class RazorDocsInProcessHostTests
         Assert.Equal(
             "RazorDocs standalone host did not publish a valid listening URL. Value: 'not-a-url'.",
             exception.Message);
+    }
+
+    private sealed class TestEnvironmentProvider(string environmentName) : IEnvironmentProvider
+    {
+        public string Environment { get; } = environmentName;
+
+        public bool IsDevelopment { get; } = string.Equals(
+            environmentName,
+            Environments.Development,
+            StringComparison.OrdinalIgnoreCase);
+
+        public string? GetEnvironmentVariable(string name, string? defaultValue = null) => defaultValue;
     }
 
     private sealed class ThrowingHost : IHost

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorWireMvcPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorWireMvcPlaywrightTests.cs
@@ -935,7 +935,6 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
         var startInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"run --project {readmeProjectPath} --no-launch-profile",
             WorkingDirectory = repoRoot,
             UseShellExecute = false,
             RedirectStandardOutput = true,
@@ -943,6 +942,7 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
             CreateNoWindow = true
         };
 
+        AddExampleAppArguments(startInfo, repoRoot, readmeProjectPath);
         startInfo.Environment["ASPNETCORE_URLS"] = baseUrl;
         startInfo.Environment["DOTNET_ENVIRONMENT"] = "Development";
         startInfo.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
@@ -961,6 +961,50 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
         process.BeginErrorReadLine();
 
         return process;
+    }
+
+    private static void AddExampleAppArguments(ProcessStartInfo startInfo, string repoRoot, string projectPath)
+    {
+        var configuration = ResolveCurrentConfiguration();
+        var targetFramework = "net10.0";
+        var builtAssemblyPath = Path.Combine(
+            repoRoot,
+            "examples",
+            "razorwire-mvc",
+            "bin",
+            configuration,
+            targetFramework,
+            "RazorWireWebExample.dll");
+
+        if (File.Exists(builtAssemblyPath))
+        {
+            startInfo.ArgumentList.Add(builtAssemblyPath);
+            return;
+        }
+
+        startInfo.ArgumentList.Add("run");
+        startInfo.ArgumentList.Add("--project");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("--no-launch-profile");
+        startInfo.ArgumentList.Add("--configuration");
+        startInfo.ArgumentList.Add(configuration);
+    }
+
+    private static string ResolveCurrentConfiguration()
+    {
+        var baseDirectoryParts = AppContext.BaseDirectory.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+
+        for (var index = 0; index < baseDirectoryParts.Length - 1; index++)
+        {
+            if (string.Equals(baseDirectoryParts[index], "bin", StringComparison.OrdinalIgnoreCase))
+            {
+                return baseDirectoryParts[index + 1];
+            }
+        }
+
+        return "Debug";
     }
 
     private async Task<string> WaitForBoundBaseUrlAsync(TimeSpan timeout)

--- a/Web/ForgeTrust.RazorWire.Tests/RazorWireWebModuleTests.cs
+++ b/Web/ForgeTrust.RazorWire.Tests/RazorWireWebModuleTests.cs
@@ -1,9 +1,13 @@
+using System.Net;
 using ForgeTrust.AppSurface.Core;
 using ForgeTrust.AppSurface.Web;
 using ForgeTrust.RazorWire.Bridge;
 using ForgeTrust.RazorWire.Forms;
 using ForgeTrust.RazorWire.Streams;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -129,9 +133,69 @@ public class RazorWireWebModuleTests
         var routeEndpoint = Assert.Single(
             routeBuilder.DataSources
                 .SelectMany(ds => ds.Endpoints)
-                .OfType<RouteEndpoint>());
+                .OfType<RouteEndpoint>(),
+            endpoint => endpoint.RoutePattern.RawText == "/_rw/streams/{channel}");
 
         Assert.Equal("/_rw/streams/{channel}", routeEndpoint.RoutePattern.RawText);
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_ServesEmbeddedRuntimeAssets_WhenStaticWebAssetsAreUnavailable()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddSingleton(new RazorWireOptions());
+        builder.Services.AddSingleton<IRazorWireChannelAuthorizer, DefaultRazorWireChannelAuthorizer>();
+        builder.Services.AddSingleton<IRazorWireStreamHub, InMemoryRazorWireStreamHub>();
+
+        await using var app = builder.Build();
+        var module = new RazorWireWebModule();
+
+        module.ConfigureEndpoints(CreateContext(isDevelopment: false), app);
+
+        await app.StartAsync();
+
+        try
+        {
+            var server = app.Services.GetRequiredService<IServer>();
+            var addresses = server.Features.Get<IServerAddressesFeature>();
+            var baseAddress = Assert.Single(addresses!.Addresses);
+
+            using var client = new HttpClient
+            {
+                BaseAddress = new Uri(baseAddress)
+            };
+
+            using var runtimeResponse = await client.GetAsync("/_content/ForgeTrust.RazorWire/razorwire/razorwire.js");
+            Assert.Equal(HttpStatusCode.OK, runtimeResponse.StatusCode);
+            Assert.Equal("text/javascript", runtimeResponse.Content.Headers.ContentType?.MediaType);
+            Assert.Contains(
+                "RazorWire Core Client Runtime",
+                await runtimeResponse.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+
+            using var islandsRequest = new HttpRequestMessage(HttpMethod.Head, "/_content/ForgeTrust.RazorWire/razorwire/razorwire.islands.js");
+            using var islandsResponse = await client.SendAsync(islandsRequest);
+            Assert.Equal(HttpStatusCode.OK, islandsResponse.StatusCode);
+            Assert.Equal("text/javascript", islandsResponse.Content.Headers.ContentType?.MediaType);
+            Assert.True(islandsResponse.Content.Headers.ContentLength > 0);
+
+            using var imageResponse = await client.GetAsync("/_content/ForgeTrust.RazorWire/background.png");
+            Assert.Equal(HttpStatusCode.OK, imageResponse.StatusCode);
+            Assert.Equal("image/png", imageResponse.Content.Headers.ContentType?.MediaType);
+
+            using var interopResponse = await client.GetAsync("/_content/ForgeTrust.RazorWire/exampleJsInterop.js");
+            Assert.Equal(HttpStatusCode.OK, interopResponse.StatusCode);
+            Assert.Equal("text/javascript", interopResponse.Content.Headers.ContentType?.MediaType);
+            Assert.Contains(
+                "showPrompt",
+                await interopResponse.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
     }
 
     [Fact]

--- a/Web/ForgeTrust.RazorWire/ForgeTrust.RazorWire.csproj
+++ b/Web/ForgeTrust.RazorWire/ForgeTrust.RazorWire.csproj
@@ -18,6 +18,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="wwwroot\background.png" LogicalName="RazorWireEmbeddedAssets/background.png" />
+    <EmbeddedResource Include="wwwroot\exampleJsInterop.js" LogicalName="RazorWireEmbeddedAssets/exampleJsInterop.js" />
+    <EmbeddedResource Include="wwwroot\razorwire\razorwire.islands.js" LogicalName="RazorWireEmbeddedAssets/razorwire/razorwire.islands.js" />
+    <EmbeddedResource Include="wwwroot\razorwire\razorwire.js" LogicalName="RazorWireEmbeddedAssets/razorwire/razorwire.js" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>ForgeTrust.RazorWire.Tests</_Parameter1>
     </AssemblyAttribute>

--- a/Web/ForgeTrust.RazorWire/README.md
+++ b/Web/ForgeTrust.RazorWire/README.md
@@ -309,6 +309,13 @@ RazorWire also supports hybrid islands where a server-rendered region mounts a c
 </rw:island>
 ```
 
+RazorWire serves `/_content/ForgeTrust.RazorWire/razorwire/razorwire.js`,
+`razorwire.islands.js`, and the package demo assets as normal Razor Class Library
+static web assets when the host has a static-web-assets manifest. The same files
+are also embedded into the `ForgeTrust.RazorWire` assembly and mapped as endpoint
+fallbacks by `RazorWireWebModule`, so packaged command-line hosts can serve the
+runtime even when only compiled assemblies are present.
+
 ## Static Export
 
 RazorWire can generate CDN-ready static output with the installable `razorwire`

--- a/Web/ForgeTrust.RazorWire/RazorWireWebModule.cs
+++ b/Web/ForgeTrust.RazorWire/RazorWireWebModule.cs
@@ -1,11 +1,14 @@
+using System.Reflection;
 using ForgeTrust.AppSurface.Core;
 using ForgeTrust.AppSurface.Web;
 using ForgeTrust.RazorWire.Caching;
 using ForgeTrust.RazorWire.Forms;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
@@ -17,6 +20,11 @@ namespace ForgeTrust.RazorWire;
 /// </summary>
 public class RazorWireWebModule : IAppSurfaceWebModule
 {
+    private static readonly Assembly RazorWireAssembly = typeof(RazorWireWebModule).Assembly;
+    private static readonly FileExtensionContentTypeProvider ContentTypeProvider = new();
+    private const string StaticAssetBasePath = "/_content/ForgeTrust.RazorWire";
+    private const string EmbeddedAssetResourcePrefix = "RazorWireEmbeddedAssets/";
+
     /// <summary>
     /// Ensures the application's MVC support level is at least ControllersWithViews.
     /// </summary>
@@ -152,10 +160,62 @@ public class RazorWireWebModule : IAppSurfaceWebModule
     /// <summary>
     /// Maps RazorWire HTTP endpoints into the application's endpoint route builder.
     /// </summary>
+    /// <remarks>
+    /// In addition to the streaming endpoints, this maps assembly-embedded fallbacks for RazorWire's runtime scripts
+    /// and package demo assets. Normal ASP.NET Core static web assets still serve these files first when their manifest
+    /// is available; the endpoint fallback keeps package-hosted tools working when only compiled assemblies are present.
+    /// </remarks>
     /// <param name="context">The startup context providing environment and configuration for module initialization.</param>
     /// <param name="endpoints">The endpoint route builder to which RazorWire routes will be added.</param>
     public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
     {
+        MapEmbeddedAssetFallback(endpoints, "background.png");
+        MapEmbeddedAssetFallback(endpoints, "exampleJsInterop.js");
+        MapEmbeddedAssetFallback(endpoints, "razorwire/razorwire.js");
+        MapEmbeddedAssetFallback(endpoints, "razorwire/razorwire.islands.js");
+
         endpoints.MapRazorWire();
+    }
+
+    private static void MapEmbeddedAssetFallback(IEndpointRouteBuilder endpoints, string webRootSubPath)
+    {
+        endpoints.MapMethods(
+            $"{StaticAssetBasePath}/{webRootSubPath}",
+            [HttpMethods.Get, HttpMethods.Head],
+            async context =>
+            {
+                if (!await TryWriteEmbeddedAssetAsync(context, webRootSubPath))
+                {
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
+            });
+    }
+
+    private static async Task<bool> TryWriteEmbeddedAssetAsync(HttpContext context, string webRootSubPath)
+    {
+        var resourceName = EmbeddedAssetResourcePrefix + webRootSubPath.Replace('\\', '/').TrimStart('/');
+        await using var stream = RazorWireAssembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            return false;
+        }
+
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Response.ContentType = ResolveContentType(webRootSubPath);
+        context.Response.ContentLength = stream.Length;
+        if (HttpMethods.IsHead(context.Request.Method))
+        {
+            return true;
+        }
+
+        await stream.CopyToAsync(context.Response.Body, context.RequestAborted);
+        return true;
+    }
+
+    private static string ResolveContentType(string relativePath)
+    {
+        return ContentTypeProvider.TryGetContentType(relativePath, out var contentType)
+            ? contentType
+            : "application/octet-stream";
     }
 }

--- a/packages/README.md
+++ b/packages/README.md
@@ -70,7 +70,8 @@ Swipe to compare package details on narrow screens.
 
 ### Not in the direct-install matrix
 
-- `ForgeTrust.RazorWire.Cli`: Held out of the direct-install chooser until issue Release: excluded; not applicable; [notes](../releases/unreleased.md).
+- `ForgeTrust.AppSurface.Cli`: Planned public `appsurface` .NET tool. The `docs` verb owns RazorDocs preview workflows that were previously sketched as a separate `razordocs` CLI. Release: excluded; not applicable; [notes](../releases/unreleased.md).
+- `ForgeTrust.RazorWire.Cli`: Held out of the direct-install chooser until issue #171 lands real .NET tool packaging and stable install guidance. Release: excluded; not applicable; [notes](../releases/unreleased.md).
 
 ## Maintainer notes
 

--- a/packages/package-index.yml
+++ b/packages/package-index.yml
@@ -227,12 +227,25 @@ packages:
     release_notes_path: releases/unreleased.md
     order: 340
     note: Tailwind standalone runtime for Windows x64 build hosts. Restore it transitively through `ForgeTrust.AppSurface.Web.Tailwind` instead of installing it directly.
+  - project: Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj
+    classification: excluded
+    publish_decision: do_not_publish
+    publish_reason: Planned public AppSurface CLI surface; held out of package publishing until tool packaging and stable install guidance are finalized.
+    release_status: excluded
+    commercial_status: not_applicable
+    release_notes_path: releases/unreleased.md
+    order: 390
+    note: Planned public `appsurface` .NET tool. The `docs` verb owns RazorDocs preview workflows that were previously sketched as a separate `razordocs` CLI.
+    start_here_path: Cli/ForgeTrust.AppSurface.Cli/README.md
+    start_here_label: AppSurface CLI README
   - project: Web/ForgeTrust.RazorWire.Cli/ForgeTrust.RazorWire.Cli.csproj
     classification: excluded
     publish_decision: do_not_publish
-    publish_reason: Held out of package publishing until issue #171 lands real .NET tool packaging and stable install guidance.
+    publish_reason: "Held out of package publishing until issue #171 lands real .NET tool packaging and stable install guidance."
     release_status: excluded
     commercial_status: not_applicable
     release_notes_path: releases/unreleased.md
     order: 400
-    note: Held out of the direct-install chooser until issue #171 lands real .NET tool packaging and stable install guidance.
+    note: "Held out of the direct-install chooser until issue #171 lands real .NET tool packaging and stable install guidance."
+    start_here_path: Web/ForgeTrust.RazorWire.Cli/README.md
+    start_here_label: RazorWire CLI README

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -38,6 +38,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 ### Console and CLI polish
 
 - AppSurface console apps can now opt into a command-first output contract so public CLI help and validation flows stay quiet instead of printing Generic Host lifecycle chatter.
+- AppSurface now plans two public CLI tools: `appsurface` for repository-level AppSurface workflows, starting with `appsurface docs` for RazorDocs preview, and `razorwire` for RazorWire-specific export workflows.
 - RazorWire CLI now uses that contract for `--help`, `export --help`, invalid option output, and missing-source validation while still preserving command-owned export progress logs.
 - RazorWire CLI now names export seed-route files with `-r|--seeds`, matching the seed terminology used throughout the exporter and docs.
 - The shared console startup seam now exposes `ConsoleOptions` and `ConsoleOutputMode`, so future public AppSurface CLIs can adopt the same behavior without forking startup logic.
@@ -72,6 +73,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 ### Web host development defaults
 
 - AppSurface web hosts now choose a deterministic localhost-only development URL when no endpoint is configured, while production, staging, container, and appsettings-based endpoint choices remain untouched.
+- AppSurface web hosts now fail fast when startup does not complete before `WebOptions.StartupTimeout`, which defaults to 30 seconds and catches pre-bind stalls from sandbox restrictions, package layout issues, static asset discovery, or hosted services that block startup.
 - OpenAPI's optional web package now has dedicated test coverage for service registration, endpoint mapping, generated document titles, and transformer behavior that removes `ForgeTrust.AppSurface.Web` tags at the document and operation levels while preserving unrelated tags, so the public module contract is guarded independently of Scalar.
 - Scalar's optional web package now has dedicated test coverage for OpenAPI dependency wiring, Scalar endpoint mapping, no-op lifecycle hooks, and minimal AppSurface web host composition.
 - Tailwind development watch mode now treats a missing standalone CLI as a recoverable local-tooling gap: the app keeps serving existing CSS and logs a warning that points to the runtime package or `TailwindCliPath` override.
@@ -104,6 +106,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs landing curation now uses `featured_page_groups`, so root and section landing pages can organize next-step links by reader intent instead of rendering one flat list.
 - RazorDocs now exposes structured harvest health through `DocAggregator.GetHarvestHealthAsync(...)`, letting hosts distinguish healthy, valid-empty, degraded, and all-failed source-backed docs snapshots while keeping raw exception details in logs.
 - RazorDocs hosts can now opt into strict startup failure with `RazorDocs:Harvest:FailOnFailure`, so CI, release, and static export runs fail before listening when every configured harvester fails while runtime hosts stay tolerant by default.
+- RazorDocs and RazorWire now compile their package-owned runtime assets into their assemblies and map endpoint fallbacks for those assets. Static web assets remain the normal host path when manifests are available, while packaged CLI hosts can still serve the docs stylesheet, search scripts, outline script, and RazorWire runtime from compiled assemblies.
 - RazorDocs now exposes a local-first harvest health UI at `{DocsRootPath}/_health` plus a machine-readable `{DocsRootPath}/_health.json` endpoint, shown by default in Development and configurable independently from sidebar chrome for operator-owned environments.
 - RazorDocs page lookup now uses one shared path resolver for details pages, landing curation, related-page links, and search recovery links, keeping source paths, canonical `.html` paths, fragments, backslash normalization, and configured docs-root prefixes behaviorally aligned.
 - RazorDocs authored Markdown pages now publish clean canonical routes that follow their public section hierarchy, so teams can link to URLs such as `/docs/packages` instead of repository-shaped `README.md.html` paths while source-path lookups and declared aliases continue to work.


### PR DESCRIPTION
## Summary
- add the planned public AppSurface CLI with an appsurface docs command and docs preview alias
- embed RazorDocs and RazorWire runtime assets into their assemblies with endpoint fallbacks for packaged hosts
- add a shared AppSurface Web startup watchdog and restore RazorDocs standalone host builder compatibility
- update package index, release notes, and docs for the new CLI and packaged asset behavior

## Validation
- dotnet test ForgeTrust.AppSurface.Core.Tests/ForgeTrust.AppSurface.Core.Tests.csproj --no-restore
- dotnet test Web/ForgeTrust.AppSurface.Web.Tests/ForgeTrust.AppSurface.Web.Tests.csproj --no-restore
- dotnet test Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj
- dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --no-build
- dotnet test Web/ForgeTrust.RazorWire.Tests/ForgeTrust.RazorWire.Tests.csproj --no-build
- dotnet build ForgeTrust.AppSurface.slnx
- dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes --no-restore
- dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- gate
- git diff --check