### PR TITLE
feat(razordocs): add section deep-link copy actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - RazorWire now has a package-level generated UI design contract that defines ownership scope, data-attribute and CSS custom-property styling surfaces, accessibility expectations, override levels, and anti-patterns for package-owned UI.
 - RazorDocs pages can now render a top-of-page trust bar from structured metadata so release notes and upgrade guidance can show status, safety context, and provenance without custom page code.
 - RazorDocs now supports metadata-driven page wayfinding: harvested outlines, explicit proof-path previous/next links, related pages, and sidebar anchor navigation.
+- RazorDocs detail pages now expose copy-link actions for outline rows and section headers so readers can share deep links without navigating away from their current position.
 - RazorDocs now exposes `DocAggregator.GetHarvestHealthAsync(...)` plus structured harvest health models so hosts can distinguish healthy, empty, degraded, and all-failed source harvest snapshots without parsing logs.
 - RazorWire forms now have convention-based failed-submission UX with default form-local fallbacks, server helpers for handled validation errors, development anti-forgery diagnostics, runtime events, and sample coverage.
 - The root README now includes a single hello-world web quickstart with an explicit local port and a concrete expected response.

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
@@ -168,7 +168,7 @@ public class RazorDocsViewsTests
         Assert.Contains(".docs-outline-context-row[data-outline-empty=\"true\"]", tailwindEntryStylesheet);
         Assert.Contains(".docs-outline-toggle-context--rolling", tailwindEntryStylesheet);
         Assert.Contains("@media (prefers-reduced-motion: reduce)", tailwindEntryStylesheet);
-        Assert.Contains(".docs-outline-copy", tailwindEntryStylesheet);
+        Assert.Contains("#docs-page-outline .docs-section-copy", tailwindEntryStylesheet);
         Assert.Contains(".docs-section-copy", tailwindEntryStylesheet);
         Assert.Contains(".docs-section-copy-fallback", tailwindEntryStylesheet);
         Assert.Contains(".docs-outline-shell[data-outline-enhanced=\"true\"] .docs-outline-toggle", tailwindEntryStylesheet);

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
@@ -168,6 +168,9 @@ public class RazorDocsViewsTests
         Assert.Contains(".docs-outline-context-row[data-outline-empty=\"true\"]", tailwindEntryStylesheet);
         Assert.Contains(".docs-outline-toggle-context--rolling", tailwindEntryStylesheet);
         Assert.Contains("@media (prefers-reduced-motion: reduce)", tailwindEntryStylesheet);
+        Assert.Contains(".docs-outline-copy", tailwindEntryStylesheet);
+        Assert.Contains(".docs-section-copy", tailwindEntryStylesheet);
+        Assert.Contains(".docs-section-copy-fallback", tailwindEntryStylesheet);
         Assert.Contains(".docs-outline-shell[data-outline-enhanced=\"true\"] .docs-outline-toggle", tailwindEntryStylesheet);
         Assert.Contains(".docs-outline-shell[data-outline-enhanced=\"true\"] .docs-outline-label", tailwindEntryStylesheet);
         Assert.Contains("@media (max-width: 79.999rem)", tailwindEntryStylesheet);
@@ -194,6 +197,7 @@ public class RazorDocsViewsTests
         Assert.DoesNotContain(".docs-outline-shell", searchStylesheet);
         Assert.DoesNotContain(".docs-outline-link", searchStylesheet);
         Assert.DoesNotContain(".docs-outline-toggle-context", searchStylesheet);
+        Assert.DoesNotContain(".docs-section-copy", searchStylesheet);
     }
 
     [Fact]
@@ -266,6 +270,11 @@ public class RazorDocsViewsTests
         Assert.Contains("function addLifecycleEventListener", outlineClient);
         Assert.Contains("removeEventListener", outlineClient);
         Assert.Contains("addListener", outlineClient);
+        Assert.Contains("navigator.clipboard.writeText", outlineClient);
+        Assert.Contains("function enhanceContentCopyTargets", outlineClient);
+        Assert.Contains("function clearCopyArtifacts", outlineClient);
+        Assert.Contains("data-doc-section-copy-inserted", outlineClient);
+        Assert.Contains("data-doc-section-copy-fallback", outlineClient);
     }
 
     [Fact]
@@ -2406,7 +2415,12 @@ public class RazorDocsViewsTests
         Assert.NotNull(document.QuerySelector("#docs-page-outline-panel[aria-label='On this page']"));
         Assert.NotNull(document.QuerySelector("a.docs-outline-link[href='#install']"));
         Assert.NotNull(document.QuerySelector("a.docs-outline-link--level-3[href='#verify']"));
+        Assert.NotNull(document.QuerySelector(".docs-section-copy-status[data-doc-section-copy-status][aria-live='polite']"));
+        Assert.NotNull(document.QuerySelector(".docs-outline-item > button.docs-outline-copy[data-doc-section-copy='install'][data-doc-section-copy-title='Install'][aria-label='Copy link to Install']"));
+        Assert.NotNull(document.QuerySelector(".docs-outline-item > button.docs-outline-copy[data-doc-section-copy='verify'][data-doc-section-copy-title='Verify'][aria-label='Copy link to Verify']"));
+        Assert.Equal(2, document.QuerySelectorAll("#docs-page-outline button[data-doc-section-copy]").Length);
         Assert.Null(document.QuerySelector("a.docs-outline-link[href='#missing-title']"));
+        Assert.Null(document.QuerySelector("button[data-doc-section-copy='missing-title']"));
         Assert.DoesNotContain("Missing fragment", html);
         Assert.Single(document.QuerySelectorAll("#docs-page-outline nav"));
         Assert.True(

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
@@ -2418,6 +2418,10 @@ public class RazorDocsViewsTests
         Assert.NotNull(document.QuerySelector(".docs-section-copy-status[data-doc-section-copy-status][aria-live='polite']"));
         Assert.NotNull(document.QuerySelector(".docs-outline-item > button.docs-outline-copy[data-doc-section-copy='install'][data-doc-section-copy-title='Install'][aria-label='Copy link to Install']"));
         Assert.NotNull(document.QuerySelector(".docs-outline-item > button.docs-outline-copy[data-doc-section-copy='verify'][data-doc-section-copy-title='Verify'][aria-label='Copy link to Verify']"));
+        Assert.Equal(2, document.QuerySelectorAll("#docs-page-outline .docs-section-copy-icon[aria-hidden='true'][viewBox='0 0 24 24']").Length);
+        Assert.DoesNotContain(
+            "#",
+            document.QuerySelector(".docs-outline-item > button.docs-outline-copy[data-doc-section-copy='install']")!.TextContent);
         Assert.Equal(2, document.QuerySelectorAll("#docs-page-outline button[data-doc-section-copy]").Length);
         Assert.Null(document.QuerySelector("a.docs-outline-link[href='#missing-title']"));
         Assert.Null(document.QuerySelector("button[data-doc-section-copy='missing-title']"));

--- a/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
+++ b/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
@@ -186,6 +186,10 @@ Visual rules:
 Interaction rules:
 
 - The active outline link uses `aria-current="location"`.
+- Each outline row includes a small copy-link action that writes the absolute section URL to the clipboard without changing scroll position, browser history, or the current hash.
+- Matching copy-link actions are added beside rendered Markdown headings and generated API type/member headers. Do not insert copy controls inside `summary`, signature blocks, `code`, `pre`, or source-link placeholders.
+- Clipboard writes must run directly from the user's click or tap. If the browser denies clipboard access, show a focused manual-copy field and keep it open while focus remains inside the fallback.
+- Turbo frame reloads must remove generated section-copy buttons, fallback popovers, status text, and timers before re-enhancing the new document.
 - Mobile outline links collapse the outline after navigation so the reader returns to content.
 - Compact context rows can use a subtle vertical rolling cue when the active section changes. Animate text rows only, keep the shell fixed-height, and disable the cue under `prefers-reduced-motion: reduce`.
 - JavaScript enhances server-rendered hash links. It must not create a hidden-only outline when scripts fail.

--- a/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
+++ b/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
@@ -187,6 +187,7 @@ Interaction rules:
 
 - The active outline link uses `aria-current="location"`.
 - Each outline row includes a small copy-link action that writes the absolute section URL to the clipboard without changing scroll position, browser history, or the current hash.
+- Copy-link actions use conventional copy iconography, remain visible without hover, and may highlight on hover or focus. Do not use `#` as the action glyph.
 - Matching copy-link actions are added beside rendered Markdown headings and generated API type/member headers. Do not insert copy controls inside `summary`, signature blocks, `code`, `pre`, or source-link placeholders.
 - Clipboard writes must run directly from the user's click or tap. If the browser denies clipboard access, show a focused manual-copy field and keep it open while focus remains inside the fallback.
 - Turbo frame reloads must remove generated section-copy buttons, fallback popovers, status text, and timers before re-enhancing the new document.

--- a/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
+++ b/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
@@ -187,7 +187,7 @@ Interaction rules:
 
 - The active outline link uses `aria-current="location"`.
 - Each outline row includes a small copy-link action that writes the absolute section URL to the clipboard without changing scroll position, browser history, or the current hash.
-- Copy-link actions use conventional copy iconography, remain visible without hover, and may highlight on hover or focus. Do not use `#` as the action glyph.
+- Copy-link actions use conventional unframed copy iconography, remain visible without hover, and may highlight on hover or focus. Do not use `#` as the action glyph.
 - Matching copy-link actions are added beside rendered Markdown headings and generated API type/member headers. Do not insert copy controls inside `summary`, signature blocks, `code`, `pre`, or source-link placeholders.
 - Clipboard writes must run directly from the user's click or tap. If the browser denies clipboard access, show a focused manual-copy field and keep it open while focus remains inside the fallback.
 - Turbo frame reloads must remove generated section-copy buttons, fallback popovers, status text, and timers before re-enhancing the new document.

--- a/Web/ForgeTrust.AppSurface.Docs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.AppSurface.Docs/Views/Docs/Details.cshtml
@@ -514,7 +514,13 @@
                                     data-doc-section-copy="@item.Id"
                                     data-doc-section-copy-title="@item.Title"
                                     aria-label="Copy link to @item.Title">
-                                <span aria-hidden="true">#</span>
+                                <svg class="docs-section-copy-icon"
+                                     aria-hidden="true"
+                                     focusable="false"
+                                     viewBox="0 0 24 24">
+                                    <rect x="9" y="9" width="11" height="11" rx="2" ry="2"></rect>
+                                    <path d="M5 15V6a2 2 0 0 1 2-2h9"></path>
+                                </svg>
                             </button>
                         </li>
                     }

--- a/Web/ForgeTrust.AppSurface.Docs/Views/Docs/Details.cshtml
+++ b/Web/ForgeTrust.AppSurface.Docs/Views/Docs/Details.cshtml
@@ -496,18 +496,26 @@
                  class="docs-outline-panel"
                  aria-label="On this page">
                 <div class="docs-outline-label">On this page</div>
+                <span class="docs-section-copy-status" data-doc-section-copy-status aria-live="polite"></span>
                 <ol class="docs-outline-list">
                     @foreach (var item in outlineItems)
                     {
                         var linkClass = item.Level > 2
                             ? "docs-outline-link docs-outline-link--level-3"
                             : "docs-outline-link";
-                        <li>
+                        <li class="docs-outline-item">
                             <a href="#@item.Id"
                                data-doc-outline-link="true"
                                class="@linkClass">
                                 @item.Title
                             </a>
+                            <button type="button"
+                                    class="docs-section-copy docs-outline-copy"
+                                    data-doc-section-copy="@item.Id"
+                                    data-doc-section-copy-title="@item.Title"
+                                    aria-label="Copy link to @item.Title">
+                                <span aria-hidden="true">#</span>
+                            </button>
                         </li>
                     }
                 </ol>

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
@@ -804,7 +804,7 @@ body {
 }
 
 @media (hover: none) {
-    .docs-outline-copy,
+    #docs-page-outline .docs-section-copy,
     .docs-content-copy {
         opacity: 1;
     }

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
@@ -621,15 +621,15 @@ body {
     flex: 0 0 auto;
     align-items: center;
     justify-content: center;
-    border: 1px solid var(--docs-color-border-default-heavier);
+    border: 0;
     border-radius: 0.45rem;
-    background: var(--docs-color-surface-panel-raised);
+    background: transparent;
     color: var(--docs-color-text-subtle);
     cursor: pointer;
     font: inherit;
     line-height: 1;
     opacity: 0.78;
-    transition: color 140ms ease, border-color 140ms ease, background-color 140ms ease, box-shadow 140ms ease, opacity 140ms ease;
+    transition: color 140ms ease, opacity 140ms ease;
 }
 
 .docs-section-copy-icon {
@@ -646,9 +646,6 @@ body {
 .docs-section-copy:focus-visible,
 .docs-section-copy[data-copy-state="copied"],
 .docs-section-copy[data-copy-state="fallback"] {
-    border-color: var(--docs-color-border-accent-strong);
-    background: var(--docs-color-state-outline-fill);
-    box-shadow: 0 0 0 1px var(--docs-color-border-accent-subtle);
     color: var(--docs-color-accent-soft);
     opacity: 1;
 }

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
@@ -627,10 +627,19 @@ body {
     color: var(--docs-color-text-subtle);
     cursor: pointer;
     font: inherit;
-    font-size: 0.86rem;
-    font-weight: 800;
     line-height: 1;
-    transition: color 140ms ease, border-color 140ms ease, background-color 140ms ease, opacity 140ms ease;
+    opacity: 0.78;
+    transition: color 140ms ease, border-color 140ms ease, background-color 140ms ease, box-shadow 140ms ease, opacity 140ms ease;
+}
+
+.docs-section-copy-icon {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.9;
 }
 
 .docs-section-copy:hover,
@@ -639,7 +648,9 @@ body {
 .docs-section-copy[data-copy-state="fallback"] {
     border-color: var(--docs-color-border-accent-strong);
     background: var(--docs-color-state-outline-fill);
+    box-shadow: 0 0 0 1px var(--docs-color-border-accent-subtle);
     color: var(--docs-color-accent-soft);
+    opacity: 1;
 }
 
 .docs-section-copy:focus-visible {
@@ -666,32 +677,15 @@ body {
     pointer-events: none;
 }
 
-.docs-outline-copy {
-    opacity: 0.62;
-}
-
-.docs-outline-item:hover .docs-outline-copy,
-.docs-outline-copy:focus-visible,
-.docs-outline-copy[data-copy-state] {
-    opacity: 1;
-}
-
 .docs-content-copy {
     width: 1.95rem;
     height: 1.95rem;
     margin-left: 0.25rem;
     vertical-align: 0.08em;
-    opacity: 0;
 }
 
 .docs-section-copy-target {
     position: relative;
-}
-
-.docs-section-copy-target:hover > .docs-content-copy,
-.docs-content-copy:focus-visible,
-.docs-content-copy[data-copy-state] {
-    opacity: 1;
 }
 
 .docs-section-copy-fallback {

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
@@ -82,6 +82,8 @@
     --docs-color-skeleton-mid: rgba(51, 65, 85, 0.55);
     --docs-focus-ring-inset: 0 0 0 1px var(--docs-color-accent-strong) inset;
     --docs-focus-outline: 2px solid var(--docs-color-accent-strong);
+    --docs-shadow-copy-feedback: 0 14px 34px rgba(2, 6, 23, 0.32);
+    --docs-shadow-copy-fallback: 0 18px 46px rgba(2, 6, 23, 0.46);
 }
 
 body {
@@ -551,10 +553,19 @@ body {
     list-style: none;
 }
 
+.docs-outline-item {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.25rem;
+}
+
 .docs-outline-link {
     position: relative;
     display: block;
     max-width: 100%;
+    min-width: 0;
     min-height: 2rem;
     padding: 0.38rem 0.65rem 0.38rem 0.8rem;
     overflow-wrap: anywhere;
@@ -600,6 +611,156 @@ body {
     width: 2px;
     border-radius: 9999px;
     background: var(--docs-color-accent-strong);
+}
+
+.docs-section-copy {
+    position: relative;
+    display: inline-flex;
+    width: 1.85rem;
+    height: 1.85rem;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--docs-color-border-default-heavier);
+    border-radius: 0.45rem;
+    background: var(--docs-color-surface-panel-raised);
+    color: var(--docs-color-text-subtle);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.86rem;
+    font-weight: 800;
+    line-height: 1;
+    transition: color 140ms ease, border-color 140ms ease, background-color 140ms ease, opacity 140ms ease;
+}
+
+.docs-section-copy:hover,
+.docs-section-copy:focus-visible,
+.docs-section-copy[data-copy-state="copied"],
+.docs-section-copy[data-copy-state="fallback"] {
+    border-color: var(--docs-color-border-accent-strong);
+    background: var(--docs-color-state-outline-fill);
+    color: var(--docs-color-accent-soft);
+}
+
+.docs-section-copy:focus-visible {
+    outline: var(--docs-focus-outline);
+    outline-offset: 2px;
+}
+
+.docs-section-copy[data-doc-section-copy-message]::after {
+    content: attr(data-doc-section-copy-message);
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 0.35rem);
+    z-index: 30;
+    min-width: max-content;
+    padding: 0.28rem 0.45rem;
+    border: 1px solid var(--docs-color-border-accent-active);
+    border-radius: 0.45rem;
+    background: var(--docs-color-surface-overlay-strong);
+    box-shadow: var(--docs-shadow-copy-feedback);
+    color: var(--docs-color-accent-soft);
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1.1;
+    pointer-events: none;
+}
+
+.docs-outline-copy {
+    opacity: 0.62;
+}
+
+.docs-outline-item:hover .docs-outline-copy,
+.docs-outline-copy:focus-visible,
+.docs-outline-copy[data-copy-state] {
+    opacity: 1;
+}
+
+.docs-content-copy {
+    width: 1.95rem;
+    height: 1.95rem;
+    margin-left: 0.25rem;
+    vertical-align: 0.08em;
+    opacity: 0;
+}
+
+.docs-section-copy-target {
+    position: relative;
+}
+
+.docs-section-copy-target:hover > .docs-content-copy,
+.docs-content-copy:focus-visible,
+.docs-content-copy[data-copy-state] {
+    opacity: 1;
+}
+
+.docs-section-copy-fallback {
+    position: absolute;
+    right: 0;
+    z-index: 40;
+    width: min(22rem, calc(100vw - 2rem));
+    margin-top: 0.45rem;
+    padding: 0.75rem;
+    border: 1px solid var(--docs-color-border-accent);
+    border-radius: 0.55rem;
+    background: var(--docs-color-surface-overlay-strong);
+    box-shadow: var(--docs-shadow-copy-fallback);
+}
+
+.docs-section-copy-fallback-label {
+    display: grid;
+    gap: 0.35rem;
+    color: var(--docs-color-text-muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+}
+
+.docs-section-copy-fallback-input {
+    width: 100%;
+    min-width: 0;
+    padding: 0.48rem 0.55rem;
+    border: 1px solid var(--docs-color-border-default);
+    border-radius: 0.42rem;
+    background: var(--docs-color-surface-panel-heavy);
+    color: var(--docs-color-text-default);
+    font: inherit;
+    font-size: 0.78rem;
+}
+
+.docs-section-copy-fallback-input:focus-visible {
+    outline: var(--docs-focus-outline);
+    outline-offset: 2px;
+}
+
+.docs-section-copy-fallback-close {
+    margin-top: 0.55rem;
+    padding: 0.42rem 0.65rem;
+    border: 1px solid var(--docs-color-border-default);
+    border-radius: 0.42rem;
+    background: var(--docs-color-surface-panel-elevated);
+    color: var(--docs-color-text-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.docs-section-copy-fallback-close:hover,
+.docs-section-copy-fallback-close:focus-visible {
+    border-color: var(--docs-color-border-accent-strong);
+    color: var(--docs-color-accent-soft);
+}
+
+.docs-section-copy-status {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+    white-space: nowrap;
 }
 
 .docs-outline-shell[data-outline-enhanced="true"][data-outline-expanded="false"] .docs-outline-panel {
@@ -648,6 +809,13 @@ body {
 @media (min-width: 64rem) and (max-width: 79.999rem) {
     .docs-outline-shell[data-outline-enhanced="true"] {
         --docs-outline-compact-bleed: 2rem;
+    }
+}
+
+@media (hover: none) {
+    .docs-outline-copy,
+    .docs-content-copy {
+        opacity: 1;
     }
 }
 

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
@@ -636,7 +636,7 @@ body {
     width: 1rem;
     height: 1rem;
     fill: none;
-    stroke: currentColor;
+    stroke: currentcolor;
     stroke-linecap: round;
     stroke-linejoin: round;
     stroke-width: 1.9;
@@ -749,7 +749,7 @@ body {
     margin: -1px;
     padding: 0;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
     border: 0;
     white-space: nowrap;
 }

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
@@ -11,9 +11,14 @@
 
     const outlineSelector = "#docs-page-outline";
     const outlineLinkSelector = "a[data-doc-outline-link='true']";
+    const copyButtonSelector = "button[data-doc-section-copy]";
+    const insertedCopyButtonSelector = "button[data-doc-section-copy-inserted='true']";
+    const copyStatusSelector = "[data-doc-section-copy-status]";
+    const copyFallbackSelector = "[data-doc-section-copy-fallback='true']";
     const compactMediaQuery = "(max-width: 79.999rem)";
     const outlineClickScrollDurationMs = 620;
     const outlineContextRollDurationMs = 180;
+    const copyFeedbackDurationMs = 1800;
 
     let lifecycleController = null;
     let activeObserver = null;
@@ -25,6 +30,10 @@
     let turboLoadHandler = null;
     let turboFrameLoadHandler = null;
     let domContentLoadedHandler = null;
+    let copyFeedbackTimers = [];
+    let activeCopyFallback = null;
+    let activeCopyFallbackButton = null;
+    let activeCopyFallbackShell = null;
 
     function decodeHash(hash) {
         if (!hash) {
@@ -240,6 +249,230 @@
             .filter(entry => entry !== null);
     }
 
+    function buildSectionUrl(targetId) {
+        const url = new URL(window.location.href);
+        url.hash = targetId;
+        return url.toString();
+    }
+
+    function getSectionTitle(button) {
+        return button.dataset.docSectionCopyTitle?.trim() || "section";
+    }
+
+    function setCopyStatus(shell, message) {
+        const status = shell.querySelector(copyStatusSelector);
+        if (status) {
+            status.textContent = message;
+        }
+    }
+
+    function clearCopyFeedback(button) {
+        button.removeAttribute("data-copy-state");
+        button.removeAttribute("data-doc-section-copy-message");
+
+        const title = getSectionTitle(button);
+        button.setAttribute("aria-label", `Copy link to ${title}`);
+    }
+
+    function showCopiedFeedback(button, shell) {
+        hideCopyFallback();
+
+        const title = getSectionTitle(button);
+        button.dataset.copyState = "copied";
+        button.dataset.docSectionCopyMessage = "Copied";
+        button.setAttribute("aria-label", `Copied link to ${title}`);
+        setCopyStatus(shell, `Copied link to ${title}.`);
+
+        const timer = window.setTimeout(() => {
+            copyFeedbackTimers = copyFeedbackTimers.filter(candidate => candidate !== timer);
+            clearCopyFeedback(button);
+        }, copyFeedbackDurationMs);
+
+        copyFeedbackTimers.push(timer);
+    }
+
+    function createCopyButton(targetId, title, className) {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = `docs-section-copy ${className}`;
+        button.dataset.docSectionCopy = targetId;
+        button.dataset.docSectionCopyTitle = title;
+        button.dataset.docSectionCopyInserted = "true";
+        button.setAttribute("aria-label", `Copy link to ${title}`);
+
+        const icon = document.createElement("span");
+        icon.setAttribute("aria-hidden", "true");
+        icon.textContent = "#";
+        button.append(icon);
+
+        return button;
+    }
+
+    function getHeaderForCopyTarget(target) {
+        if (!(target instanceof HTMLElement)) {
+            return null;
+        }
+
+        if (/^H[1-6]$/u.test(target.tagName)) {
+            return target;
+        }
+
+        return Array.from(target.children).find(child =>
+            child instanceof HTMLElement
+            && (child.classList.contains("doc-type-header")
+                || child.classList.contains("doc-method-group-header"))) ?? null;
+    }
+
+    function getTitleForCopyTarget(entry) {
+        return entry.link.textContent?.trim() || entry.target.id || "section";
+    }
+
+    function enhanceContentCopyTargets(entries, shell) {
+        for (const entry of entries) {
+            const targetId = entry.target.id;
+            if (!targetId) {
+                continue;
+            }
+
+            const header = getHeaderForCopyTarget(entry.target);
+            if (!header || header.querySelector(`:scope > ${copyButtonSelector}`)) {
+                continue;
+            }
+
+            const title = getTitleForCopyTarget(entry);
+            const button = createCopyButton(targetId, title, "docs-content-copy");
+            header.classList.add("docs-section-copy-target");
+            header.append(button);
+            enhanceCopyButton(button, shell);
+        }
+    }
+
+    function enhanceCopyButtons(shell) {
+        const buttons = Array.from(document.querySelectorAll(copyButtonSelector))
+            .filter(button => button instanceof HTMLButtonElement);
+
+        for (const button of buttons) {
+            enhanceCopyButton(button, shell);
+        }
+    }
+
+    function enhanceCopyButton(button, shell) {
+        if (!(button instanceof HTMLButtonElement)
+            || button.dataset.docSectionCopyEnhanced === "true") {
+            return;
+        }
+
+        button.dataset.docSectionCopyEnhanced = "true";
+        addLifecycleEventListener(button, "click", event => {
+            event.preventDefault();
+            event.stopPropagation();
+            copySectionLink(button, shell);
+        });
+    }
+
+    function copySectionLink(button, shell) {
+        const targetId = button.dataset.docSectionCopy?.trim();
+        if (!targetId) {
+            return;
+        }
+
+        const sectionUrl = buildSectionUrl(targetId);
+
+        if (navigator.clipboard?.writeText) {
+            navigator.clipboard.writeText(sectionUrl)
+                .then(() => showCopiedFeedback(button, shell))
+                .catch(() => showCopyFallback(button, shell, sectionUrl));
+            return;
+        }
+
+        showCopyFallback(button, shell, sectionUrl);
+    }
+
+    function hideCopyFallback() {
+        const button = activeCopyFallbackButton;
+        const shell = activeCopyFallbackShell;
+        activeCopyFallback?.remove();
+        activeCopyFallback = null;
+        activeCopyFallbackButton = null;
+        activeCopyFallbackShell = null;
+
+        if (button) {
+            clearCopyFeedback(button);
+        }
+
+        if (shell) {
+            setCopyStatus(shell, "");
+        }
+    }
+
+    function showCopyFallback(button, shell, sectionUrl) {
+        hideCopyFallback();
+
+        const title = getSectionTitle(button);
+        const fallback = document.createElement("span");
+        fallback.className = "docs-section-copy-fallback";
+        fallback.dataset.docSectionCopyFallback = "true";
+        fallback.setAttribute("role", "dialog");
+        fallback.setAttribute("aria-label", `Copy link to ${title}`);
+
+        const label = document.createElement("label");
+        label.className = "docs-section-copy-fallback-label";
+        label.textContent = "Section link";
+
+        const input = document.createElement("input");
+        input.className = "docs-section-copy-fallback-input";
+        input.type = "text";
+        input.readOnly = true;
+        input.value = sectionUrl;
+
+        const close = document.createElement("button");
+        close.className = "docs-section-copy-fallback-close";
+        close.type = "button";
+        close.textContent = "Close";
+
+        label.append(input);
+        fallback.append(label, close);
+        button.after(fallback);
+        activeCopyFallback = fallback;
+        activeCopyFallbackButton = button;
+        activeCopyFallbackShell = shell;
+
+        button.dataset.copyState = "fallback";
+        button.dataset.docSectionCopyMessage = "Copy";
+        setCopyStatus(shell, `Copy link to ${title} from the open text field.`);
+
+        addLifecycleEventListener(close, "click", hideCopyFallback);
+        addLifecycleEventListener(fallback, "keydown", event => {
+            if (event.key === "Escape") {
+                hideCopyFallback();
+                button.focus();
+            }
+        });
+        addLifecycleEventListener(fallback, "focusout", event => {
+            const nextTarget = event.relatedTarget;
+            if (nextTarget instanceof Node && fallback.contains(nextTarget)) {
+                return;
+            }
+
+            window.setTimeout(() => {
+                if (!fallback.contains(document.activeElement)) {
+                    hideCopyFallback();
+                }
+            }, 0);
+        });
+        addLifecycleEventListener(document, "pointerdown", event => {
+            const target = event.target;
+            if (target instanceof Node
+                && !fallback.contains(target)
+                && target !== button) {
+                hideCopyFallback();
+            }
+        });
+
+        input.focus();
+        input.select();
+    }
+
     function getActiveEntryFromScrollPosition(entries, root) {
         const rootTop = root.getBoundingClientRect().top;
         const activationTop = rootTop + 64;
@@ -399,6 +632,36 @@
         }
     }
 
+    function clearCopyArtifacts() {
+        for (const timer of copyFeedbackTimers) {
+            window.clearTimeout(timer);
+        }
+
+        copyFeedbackTimers = [];
+        hideCopyFallback();
+
+        for (const button of document.querySelectorAll(copyButtonSelector)) {
+            button.removeAttribute("data-doc-section-copy-enhanced");
+            clearCopyFeedback(button);
+        }
+
+        for (const button of document.querySelectorAll(insertedCopyButtonSelector)) {
+            button.remove();
+        }
+
+        for (const fallback of document.querySelectorAll(copyFallbackSelector)) {
+            fallback.remove();
+        }
+
+        for (const target of document.querySelectorAll(".docs-section-copy-target")) {
+            target.classList.remove("docs-section-copy-target");
+        }
+
+        for (const status of document.querySelectorAll(copyStatusSelector)) {
+            status.textContent = "";
+        }
+    }
+
     function syncOutlinePlacement(shell, primary, compact) {
         const layout = shell.parentElement;
         if (!layout || !primary || primary.parentElement !== layout) {
@@ -428,6 +691,7 @@
         lifecycleController?.abort();
         lifecycleController = null;
         lastActiveIndex = -1;
+        clearCopyArtifacts();
     }
 
     function removeDocumentLifecycleEventListeners() {
@@ -495,6 +759,8 @@
         lifecycleController = createLifecycleController();
         shell.dataset.outlineEnhanced = "true";
         shell.dataset.outlineClientVersion = clientVersion;
+        enhanceContentCopyTargets(entries, shell);
+        enhanceCopyButtons(shell);
 
         const compactMedia = window.matchMedia ? window.matchMedia(compactMediaQuery) : null;
         const syncViewportState = () => {

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
@@ -34,6 +34,7 @@
     let activeCopyFallback = null;
     let activeCopyFallbackButton = null;
     let activeCopyFallbackShell = null;
+    let activeCopyFallbackPointerDown = null;
 
     function decodeHash(hash) {
         if (!hash) {
@@ -409,6 +410,11 @@
     }
 
     function hideCopyFallback() {
+        if (activeCopyFallbackPointerDown) {
+            document.removeEventListener("pointerdown", activeCopyFallbackPointerDown);
+            activeCopyFallbackPointerDown = null;
+        }
+
         const button = activeCopyFallbackButton;
         const shell = activeCopyFallbackShell;
         activeCopyFallback?.remove();
@@ -480,14 +486,15 @@
                 }
             }, 0);
         });
-        addLifecycleEventListener(document, "pointerdown", event => {
+        activeCopyFallbackPointerDown = event => {
             const target = event.target;
             if (target instanceof Node
                 && !fallback.contains(target)
                 && target !== button) {
                 hideCopyFallback();
             }
-        });
+        };
+        document.addEventListener("pointerdown", activeCopyFallbackPointerDown);
 
         input.focus();
         input.select();

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
@@ -274,6 +274,29 @@
         button.setAttribute("aria-label", `Copy link to ${title}`);
     }
 
+    function createCopyIcon() {
+        const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svg.classList.add("docs-section-copy-icon");
+        svg.setAttribute("aria-hidden", "true");
+        svg.setAttribute("focusable", "false");
+        svg.setAttribute("viewBox", "0 0 24 24");
+
+        const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        rect.setAttribute("x", "9");
+        rect.setAttribute("y", "9");
+        rect.setAttribute("width", "11");
+        rect.setAttribute("height", "11");
+        rect.setAttribute("rx", "2");
+        rect.setAttribute("ry", "2");
+        svg.append(rect);
+
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        path.setAttribute("d", "M5 15V6a2 2 0 0 1 2-2h9");
+        svg.append(path);
+
+        return svg;
+    }
+
     function showCopiedFeedback(button, shell) {
         hideCopyFallback();
 
@@ -300,10 +323,7 @@
         button.dataset.docSectionCopyInserted = "true";
         button.setAttribute("aria-label", `Copy link to ${title}`);
 
-        const icon = document.createElement("span");
-        icon.setAttribute("aria-hidden", "true");
-        icon.textContent = "#";
-        button.append(icon);
+        button.append(createCopyIcon());
 
         return button;
     }

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/outline-client.js
@@ -267,7 +267,18 @@
         }
     }
 
+    function clearCopyFeedbackTimer(button) {
+        const timer = Number.parseInt(button.dataset.docSectionCopyTimer ?? "", 10);
+        if (Number.isFinite(timer) && timer > 0) {
+            window.clearTimeout(timer);
+            copyFeedbackTimers = copyFeedbackTimers.filter(candidate => candidate !== timer);
+        }
+
+        button.removeAttribute("data-doc-section-copy-timer");
+    }
+
     function clearCopyFeedback(button) {
+        clearCopyFeedbackTimer(button);
         button.removeAttribute("data-copy-state");
         button.removeAttribute("data-doc-section-copy-message");
 
@@ -300,6 +311,7 @@
 
     function showCopiedFeedback(button, shell) {
         hideCopyFallback();
+        clearCopyFeedbackTimer(button);
 
         const title = getSectionTitle(button);
         button.dataset.copyState = "copied";
@@ -309,9 +321,12 @@
 
         const timer = window.setTimeout(() => {
             copyFeedbackTimers = copyFeedbackTimers.filter(candidate => candidate !== timer);
+            button.removeAttribute("data-doc-section-copy-timer");
             clearCopyFeedback(button);
+            setCopyStatus(shell, "");
         }, copyFeedbackDurationMs);
 
+        button.dataset.docSectionCopyTimer = String(timer);
         copyFeedbackTimers.push(timer);
     }
 

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -327,6 +327,19 @@ public sealed class RazorDocsWayfindingPlaywrightTests
 
         Assert.True(await page.Locator(".doc-type > .doc-type-header > button[data-doc-section-copy]").CountAsync() > 0);
         Assert.True(await page.Locator(".doc-method-group > .doc-method-group-header > button[data-doc-section-copy]").CountAsync() > 0);
+        Assert.True(await page.Locator(".docs-content button[data-doc-section-copy] .docs-section-copy-icon").CountAsync() > 0);
+        Assert.Equal(
+            string.Empty,
+            await page.Locator(".docs-content button[data-doc-section-copy]").First.TextContentAsync());
+        Assert.True(await page.Locator(".docs-content button[data-doc-section-copy]").First.EvaluateAsync<bool>(
+            """
+            button => {
+              const style = getComputedStyle(button);
+              return style.visibility === 'visible'
+                && style.display !== 'none'
+                && Number.parseFloat(style.opacity) > 0.7;
+            }
+            """));
         Assert.Equal(0, await page.Locator("summary button[data-doc-section-copy]").CountAsync());
         Assert.Equal(0, await page.Locator(".doc-signature button[data-doc-section-copy]").CountAsync());
         Assert.Equal(0, await page.Locator("pre button[data-doc-section-copy], code button[data-doc-section-copy]").CountAsync());

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -148,6 +148,236 @@ public sealed class RazorDocsWayfindingPlaywrightTests
 
         Assert.Equal(1, await page.Locator("#docs-page-outline").CountAsync());
         Assert.Equal("true", await page.GetAttributeAsync("#docs-page-outline", "data-outline-enhanced"));
+        Assert.Equal(
+            await page.Locator("#docs-page-outline a[data-doc-outline-link='true']").CountAsync(),
+            await page.Locator("#docs-page-outline button[data-doc-section-copy]").CountAsync());
+
+        await page.EvaluateAsync(
+            """
+            () => document
+              .getElementById('doc-content')
+              ?.dispatchEvent(new Event('turbo:frame-load', { bubbles: true }))
+            """);
+        Assert.Equal(
+            await page.Locator("#docs-page-outline a[data-doc-outline-link='true']").CountAsync(),
+            await page.Locator("#docs-page-outline button[data-doc-section-copy]").CountAsync());
+        Assert.Equal(
+            1,
+            await page.Locator(".docs-content button[data-doc-section-copy='files-behind-the-hero-flow']").CountAsync());
+    }
+
+    [Fact]
+    public async Task SectionCopyButtons_CopyDeepLinks_WithoutNavigatingOrMutatingHash()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 1440,
+                Height = 900
+            }
+        });
+        await GrantSectionClipboardPermissionsAsync(context);
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/Namespaces/ForgeTrust.AppSurface.Aspire.html");
+        await page.WaitForSelectorAsync("#docs-page-outline", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        await page.WaitForSelectorAsync(
+            ".docs-content button[data-doc-section-copy]",
+            new PageWaitForSelectorOptions { Timeout = 30_000, State = WaitForSelectorState.Attached });
+        var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").First.GetAttributeAsync("data-doc-section-copy")
+            ?? throw new InvalidOperationException("Expected a section copy target.");
+
+        var expectedUrl = await page.EvaluateAsync<string>(
+            """
+            targetId => {
+              const url = new URL(window.location.href);
+              url.hash = targetId;
+              return url.toString();
+            }
+            """,
+            targetId);
+        await page.EvaluateAsync(
+            """
+            () => {
+              history.replaceState(null, "", window.location.pathname);
+              window.__sectionCopyPushStateCalls = 0;
+              const originalPushState = history.pushState.bind(history);
+              history.pushState = (...args) => {
+                window.__sectionCopyPushStateCalls += 1;
+                return originalPushState(...args);
+              };
+            }
+            """);
+
+        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
+        await page.WaitForSelectorAsync(
+            $"#docs-page-outline button[data-doc-section-copy='{targetId}'][data-copy-state='copied']",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Attached });
+
+        Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
+        Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
+        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyPushStateCalls"));
+
+        await page.ClickAsync($".docs-content button[data-doc-section-copy='{targetId}']");
+        await page.WaitForSelectorAsync(
+            $".docs-content button[data-doc-section-copy='{targetId}'][data-copy-state='copied']",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Attached });
+
+        Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
+        Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
+        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyPushStateCalls"));
+    }
+
+    [Fact]
+    public async Task SectionCopyButtons_ShowManualCopyFallback_WhenClipboardWriteIsDenied()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 1440,
+                Height = 900
+            }
+        });
+        var page = await context.NewPageAsync();
+        await page.AddInitScriptAsync(
+            """
+            Object.defineProperty(navigator, "clipboard", {
+              configurable: true,
+              value: {
+                writeText: () => Promise.reject(new DOMException("Denied", "NotAllowedError"))
+              }
+            });
+            """);
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/Namespaces/ForgeTrust.AppSurface.Aspire.html");
+        await page.WaitForSelectorAsync("#docs-page-outline", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").First.GetAttributeAsync("data-doc-section-copy")
+            ?? throw new InvalidOperationException("Expected a section copy target.");
+
+        var expectedUrl = await page.EvaluateAsync<string>(
+            """
+            targetId => {
+              const url = new URL(window.location.href);
+              url.hash = targetId;
+              return url.toString();
+            }
+            """,
+            targetId);
+
+        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
+        await page.WaitForSelectorAsync(
+            "[data-doc-section-copy-fallback='true'] input",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
+
+        Assert.Equal(expectedUrl, await page.InputValueAsync("[data-doc-section-copy-fallback='true'] input"));
+        Assert.True(await page.Locator("[data-doc-section-copy-fallback='true']").EvaluateAsync<bool>(
+            """
+            fallback => {
+              const input = fallback.querySelector("input");
+              return document.activeElement === input
+                && input.selectionStart === 0
+                && input.selectionEnd === input.value.length;
+            }
+            """));
+
+        await page.ClickAsync("[data-doc-section-copy-fallback='true'] input");
+        Assert.Equal(1, await page.Locator("[data-doc-section-copy-fallback='true']").CountAsync());
+
+        await page.Keyboard.PressAsync("Escape");
+        await page.WaitForSelectorAsync(
+            "[data-doc-section-copy-fallback='true']",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Detached });
+        Assert.Null(await page.GetAttributeAsync(
+            $"#docs-page-outline button[data-doc-section-copy='{targetId}']",
+            "data-copy-state"));
+    }
+
+    [Fact]
+    public async Task SectionCopyButtons_AttachToApiHeaders_AndAvoidCodeOrSummaryBlocks()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 1440,
+                Height = 900
+            }
+        });
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/Namespaces/ForgeTrust.AppSurface.Aspire.html");
+        await page.WaitForSelectorAsync("#docs-page-outline", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        await page.WaitForSelectorAsync(
+            ".doc-type > .doc-type-header > button[data-doc-section-copy]",
+            new PageWaitForSelectorOptions { Timeout = 30_000, State = WaitForSelectorState.Attached });
+
+        Assert.True(await page.Locator(".doc-type > .doc-type-header > button[data-doc-section-copy]").CountAsync() > 0);
+        Assert.True(await page.Locator(".doc-method-group > .doc-method-group-header > button[data-doc-section-copy]").CountAsync() > 0);
+        Assert.Equal(0, await page.Locator("summary button[data-doc-section-copy]").CountAsync());
+        Assert.Equal(0, await page.Locator(".doc-signature button[data-doc-section-copy]").CountAsync());
+        Assert.Equal(0, await page.Locator("pre button[data-doc-section-copy], code button[data-doc-section-copy]").CountAsync());
+    }
+
+    [Fact]
+    public async Task MobileSectionCopyButton_CopiesDeepLinkWithoutCollapsingOutline()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 390,
+                Height = 844
+            }
+        });
+        await GrantSectionClipboardPermissionsAsync(context);
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/Namespaces/ForgeTrust.AppSurface.Aspire.html");
+        await page.WaitForSelectorAsync("#docs-page-outline", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        await page.ClickAsync("#docs-page-outline [data-doc-outline-toggle]");
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#docs-page-outline [data-doc-outline-toggle]')?.getAttribute('aria-expanded') === 'true'",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").First.GetAttributeAsync("data-doc-section-copy")
+            ?? throw new InvalidOperationException("Expected a section copy target.");
+        var expectedUrl = await page.EvaluateAsync<string>(
+            """
+            targetId => {
+              const url = new URL(window.location.href);
+              url.hash = targetId;
+              return url.toString();
+            }
+            """,
+            targetId);
+
+        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
+        await page.WaitForSelectorAsync(
+            $"#docs-page-outline button[data-doc-section-copy='{targetId}'][data-copy-state='copied']",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Attached });
+
+        Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
+        Assert.Equal("true", await page.GetAttributeAsync("#docs-page-outline [data-doc-outline-toggle]", "aria-expanded"));
+        Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
     }
 
     [Fact]
@@ -1218,6 +1448,22 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         public bool ToggleVisible { get; init; }
 
         public bool PanelVisible { get; init; }
+    }
+
+    private Task GrantSectionClipboardPermissionsAsync(IBrowserContext context)
+    {
+        var origin = new Uri(_fixture.DocsUrl).GetLeftPart(UriPartial.Authority);
+        return context.GrantPermissionsAsync(
+            ["clipboard-read", "clipboard-write"],
+            new BrowserContextGrantPermissionsOptions
+            {
+                Origin = origin
+            });
+    }
+
+    private static Task<string> ReadClipboardTextAsync(IPage page)
+    {
+        return page.EvaluateAsync<string>("() => navigator.clipboard.readText()");
     }
 
     private const string ScrollMainContentToBottomScript =

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -337,6 +337,8 @@ public sealed class RazorDocsWayfindingPlaywrightTests
               const style = getComputedStyle(button);
               return style.visibility === 'visible'
                 && style.display !== 'none'
+                && style.borderTopWidth === '0px'
+                && style.backgroundColor === 'rgba(0, 0, 0, 0)'
                 && Number.parseFloat(style.opacity) > 0.7;
             }
             """));

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -1545,12 +1545,18 @@ public sealed class RazorDocsWayfindingPlaywrightTests
 
     private static async Task AssertSectionCopyFallbackAsync(IPage page, string targetId, string expectedUrl)
     {
+        await InstallSectionCopyHistoryCountersAsync(page);
+        await SetMainContentScrollTopAsync(page, 260);
+        var initialScrollTop = await GetMainContentScrollTopAsync(page);
+        Assert.True(initialScrollTop > 0);
+
         await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
         await page.WaitForSelectorAsync(
             "[data-doc-section-copy-fallback='true'] input",
             new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
 
         Assert.Equal(expectedUrl, await page.InputValueAsync("[data-doc-section-copy-fallback='true'] input"));
+        await AssertSectionCopyPreservedNavigationAsync(page, initialScrollTop);
         Assert.True(await page.Locator("[data-doc-section-copy-fallback='true']").EvaluateAsync<bool>(
             """
             fallback => {
@@ -1571,6 +1577,7 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         Assert.Null(await page.GetAttributeAsync(
             $"#docs-page-outline button[data-doc-section-copy='{targetId}']",
             "data-copy-state"));
+        await AssertSectionCopyPreservedNavigationAsync(page, initialScrollTop);
 
         await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
         await page.WaitForSelectorAsync(
@@ -1578,8 +1585,22 @@ public sealed class RazorDocsWayfindingPlaywrightTests
             new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
 
         Assert.Equal(expectedUrl, await page.InputValueAsync("[data-doc-section-copy-fallback='true'] input"));
+        await AssertSectionCopyPreservedNavigationAsync(page, initialScrollTop);
         await page.ClickAsync("[data-doc-section-copy-fallback='true'] input");
         Assert.Equal(1, await page.Locator("[data-doc-section-copy-fallback='true']").CountAsync());
+
+        await page.Keyboard.PressAsync("Escape");
+        await page.WaitForSelectorAsync(
+            "[data-doc-section-copy-fallback='true']",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Detached });
+        await AssertSectionCopyPreservedNavigationAsync(page, initialScrollTop);
+    }
+
+    private static async Task AssertSectionCopyPreservedNavigationAsync(IPage page, int initialScrollTop)
+    {
+        Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
+        Assert.Equal(initialScrollTop, await GetMainContentScrollTopAsync(page));
+        await AssertSectionCopyDidNotMutateHistoryAsync(page);
     }
 
     private const string ScrollMainContentToBottomScript =

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -206,10 +206,16 @@ public sealed class RazorDocsWayfindingPlaywrightTests
             () => {
               history.replaceState(null, "", window.location.pathname);
               window.__sectionCopyPushStateCalls = 0;
+              window.__sectionCopyReplaceStateCalls = 0;
               const originalPushState = history.pushState.bind(history);
+              const originalReplaceState = history.replaceState.bind(history);
               history.pushState = (...args) => {
                 window.__sectionCopyPushStateCalls += 1;
                 return originalPushState(...args);
+              };
+              history.replaceState = (...args) => {
+                window.__sectionCopyReplaceStateCalls += 1;
+                return originalReplaceState(...args);
               };
             }
             """);
@@ -222,6 +228,7 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
         Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
         Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyPushStateCalls"));
+        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyReplaceStateCalls"));
 
         await page.ClickAsync($".docs-content button[data-doc-section-copy='{targetId}']");
         await page.WaitForSelectorAsync(
@@ -231,6 +238,7 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
         Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
         Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyPushStateCalls"));
+        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyReplaceStateCalls"));
     }
 
     [Fact]
@@ -300,6 +308,14 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         Assert.Null(await page.GetAttributeAsync(
             $"#docs-page-outline button[data-doc-section-copy='{targetId}']",
             "data-copy-state"));
+
+        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
+        await page.WaitForSelectorAsync(
+            "[data-doc-section-copy-fallback='true'] input",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
+
+        await page.ClickAsync("[data-doc-section-copy-fallback='true'] input");
+        Assert.Equal(1, await page.Locator("[data-doc-section-copy-fallback='true']").CountAsync());
     }
 
     [Fact]
@@ -344,6 +360,7 @@ public sealed class RazorDocsWayfindingPlaywrightTests
             """));
         Assert.Equal(0, await page.Locator("summary button[data-doc-section-copy]").CountAsync());
         Assert.Equal(0, await page.Locator(".doc-signature button[data-doc-section-copy]").CountAsync());
+        Assert.Equal(0, await page.Locator(".doc-symbol-source-link button[data-doc-section-copy]").CountAsync());
         Assert.Equal(0, await page.Locator("pre button[data-doc-section-copy], code button[data-doc-section-copy]").CountAsync());
     }
 

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -189,36 +189,16 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         await page.WaitForSelectorAsync(
             ".docs-content button[data-doc-section-copy]",
             new PageWaitForSelectorOptions { Timeout = 30_000, State = WaitForSelectorState.Attached });
-        var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").First.GetAttributeAsync("data-doc-section-copy")
+        await WaitForSectionCopyTargetCountAsync(page, 3);
+        var contentCopyButton = page.Locator(".docs-content button[data-doc-section-copy]").Nth(2);
+        var targetId = await contentCopyButton.GetAttributeAsync("data-doc-section-copy")
             ?? throw new InvalidOperationException("Expected a section copy target.");
 
-        var expectedUrl = await page.EvaluateAsync<string>(
-            """
-            targetId => {
-              const url = new URL(window.location.href);
-              url.hash = targetId;
-              return url.toString();
-            }
-            """,
-            targetId);
-        await page.EvaluateAsync(
-            """
-            () => {
-              history.replaceState(null, "", window.location.pathname);
-              window.__sectionCopyPushStateCalls = 0;
-              window.__sectionCopyReplaceStateCalls = 0;
-              const originalPushState = history.pushState.bind(history);
-              const originalReplaceState = history.replaceState.bind(history);
-              history.pushState = (...args) => {
-                window.__sectionCopyPushStateCalls += 1;
-                return originalPushState(...args);
-              };
-              history.replaceState = (...args) => {
-                window.__sectionCopyReplaceStateCalls += 1;
-                return originalReplaceState(...args);
-              };
-            }
-            """);
+        var expectedUrl = await BuildSectionCopyExpectedUrlAsync(page, targetId);
+        await InstallSectionCopyHistoryCountersAsync(page);
+        await SetMainContentScrollTopAsync(page, 320);
+        var outlineInitialScrollTop = await GetMainContentScrollTopAsync(page);
+        Assert.True(outlineInitialScrollTop > 0);
 
         await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
         await page.WaitForSelectorAsync(
@@ -227,18 +207,20 @@ public sealed class RazorDocsWayfindingPlaywrightTests
 
         Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
         Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
-        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyPushStateCalls"));
-        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyReplaceStateCalls"));
+        Assert.Equal(outlineInitialScrollTop, await GetMainContentScrollTopAsync(page));
+        await AssertSectionCopyDidNotMutateHistoryAsync(page);
 
-        await page.ClickAsync($".docs-content button[data-doc-section-copy='{targetId}']");
+        await contentCopyButton.ScrollIntoViewIfNeededAsync();
+        var contentInitialScrollTop = await GetMainContentScrollTopAsync(page);
+        await contentCopyButton.ClickAsync();
         await page.WaitForSelectorAsync(
             $".docs-content button[data-doc-section-copy='{targetId}'][data-copy-state='copied']",
             new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Attached });
 
         Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
         Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
-        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyPushStateCalls"));
-        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyReplaceStateCalls"));
+        Assert.Equal(contentInitialScrollTop, await GetMainContentScrollTopAsync(page));
+        await AssertSectionCopyDidNotMutateHistoryAsync(page);
     }
 
     [Fact]
@@ -272,50 +254,43 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").First.GetAttributeAsync("data-doc-section-copy")
             ?? throw new InvalidOperationException("Expected a section copy target.");
 
-        var expectedUrl = await page.EvaluateAsync<string>(
-            """
-            targetId => {
-              const url = new URL(window.location.href);
-              url.hash = targetId;
-              return url.toString();
+        var expectedUrl = await BuildSectionCopyExpectedUrlAsync(page, targetId);
+
+        await AssertSectionCopyFallbackAsync(page, targetId, expectedUrl);
+    }
+
+    [Fact]
+    public async Task SectionCopyButtons_ShowManualCopyFallback_WhenClipboardUnavailable()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 1440,
+                Height = 900
             }
-            """,
-            targetId);
-
-        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
-        await page.WaitForSelectorAsync(
-            "[data-doc-section-copy-fallback='true'] input",
-            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
-
-        Assert.Equal(expectedUrl, await page.InputValueAsync("[data-doc-section-copy-fallback='true'] input"));
-        Assert.True(await page.Locator("[data-doc-section-copy-fallback='true']").EvaluateAsync<bool>(
+        });
+        var page = await context.NewPageAsync();
+        await page.AddInitScriptAsync(
             """
-            fallback => {
-              const input = fallback.querySelector("input");
-              return document.activeElement === input
-                && input.selectionStart === 0
-                && input.selectionEnd === input.value.length;
-            }
-            """));
+            Object.defineProperty(navigator, "clipboard", {
+              configurable: true,
+              value: undefined
+            });
+            """);
 
-        await page.ClickAsync("[data-doc-section-copy-fallback='true'] input");
-        Assert.Equal(1, await page.Locator("[data-doc-section-copy-fallback='true']").CountAsync());
+        await page.GotoAsync($"{_fixture.DocsUrl}/Namespaces/ForgeTrust.AppSurface.Aspire.html");
+        await page.WaitForSelectorAsync("#docs-page-outline", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").First.GetAttributeAsync("data-doc-section-copy")
+            ?? throw new InvalidOperationException("Expected a section copy target.");
 
-        await page.Keyboard.PressAsync("Escape");
-        await page.WaitForSelectorAsync(
-            "[data-doc-section-copy-fallback='true']",
-            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Detached });
-        Assert.Null(await page.GetAttributeAsync(
-            $"#docs-page-outline button[data-doc-section-copy='{targetId}']",
-            "data-copy-state"));
+        var expectedUrl = await BuildSectionCopyExpectedUrlAsync(page, targetId);
 
-        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
-        await page.WaitForSelectorAsync(
-            "[data-doc-section-copy-fallback='true'] input",
-            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
-
-        await page.ClickAsync("[data-doc-section-copy-fallback='true'] input");
-        Assert.Equal(1, await page.Locator("[data-doc-section-copy-fallback='true']").CountAsync());
+        await AssertSectionCopyFallbackAsync(page, targetId, expectedUrl);
     }
 
     [Fact]
@@ -389,18 +364,15 @@ public sealed class RazorDocsWayfindingPlaywrightTests
             "() => document.querySelector('#docs-page-outline [data-doc-outline-toggle]')?.getAttribute('aria-expanded') === 'true'",
             null,
             new PageWaitForFunctionOptions { Timeout = 15_000 });
+        await WaitForSectionCopyTargetCountAsync(page, 3);
 
-        var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").First.GetAttributeAsync("data-doc-section-copy")
+        var targetId = await page.Locator(".docs-content button[data-doc-section-copy]").Nth(2).GetAttributeAsync("data-doc-section-copy")
             ?? throw new InvalidOperationException("Expected a section copy target.");
-        var expectedUrl = await page.EvaluateAsync<string>(
-            """
-            targetId => {
-              const url = new URL(window.location.href);
-              url.hash = targetId;
-              return url.toString();
-            }
-            """,
-            targetId);
+        var expectedUrl = await BuildSectionCopyExpectedUrlAsync(page, targetId);
+        await InstallSectionCopyHistoryCountersAsync(page);
+        await SetMainContentScrollTopAsync(page, 260);
+        var initialScrollTop = await GetMainContentScrollTopAsync(page);
+        Assert.True(initialScrollTop > 0);
 
         await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
         await page.WaitForSelectorAsync(
@@ -410,6 +382,8 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         Assert.Equal(expectedUrl, await ReadClipboardTextAsync(page));
         Assert.Equal("true", await page.GetAttributeAsync("#docs-page-outline [data-doc-outline-toggle]", "aria-expanded"));
         Assert.Equal(string.Empty, await page.EvaluateAsync<string>("() => window.location.hash"));
+        Assert.Equal(initialScrollTop, await GetMainContentScrollTopAsync(page));
+        await AssertSectionCopyDidNotMutateHistoryAsync(page);
     }
 
     [Fact]
@@ -1496,6 +1470,116 @@ public sealed class RazorDocsWayfindingPlaywrightTests
     private static Task<string> ReadClipboardTextAsync(IPage page)
     {
         return page.EvaluateAsync<string>("() => navigator.clipboard.readText()");
+    }
+
+    private static async Task WaitForSectionCopyTargetCountAsync(IPage page, int minimumCount)
+    {
+        await page.WaitForFunctionAsync(
+            """
+            minimumCount => document.querySelectorAll('.docs-content button[data-doc-section-copy]').length >= minimumCount
+            """,
+            minimumCount,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+    }
+
+    private static Task<string> BuildSectionCopyExpectedUrlAsync(IPage page, string targetId)
+    {
+        return page.EvaluateAsync<string>(
+            """
+            targetId => {
+              const url = new URL(window.location.href);
+              url.hash = targetId;
+              return url.toString();
+            }
+            """,
+            targetId);
+    }
+
+    private static Task InstallSectionCopyHistoryCountersAsync(IPage page)
+    {
+        return page.EvaluateAsync(
+            """
+            () => {
+              history.replaceState(null, "", window.location.pathname);
+              window.__sectionCopyPushStateCalls = 0;
+              window.__sectionCopyReplaceStateCalls = 0;
+              const originalPushState = history.pushState.bind(history);
+              const originalReplaceState = history.replaceState.bind(history);
+              history.pushState = (...args) => {
+                window.__sectionCopyPushStateCalls += 1;
+                return originalPushState(...args);
+              };
+              history.replaceState = (...args) => {
+                window.__sectionCopyReplaceStateCalls += 1;
+                return originalReplaceState(...args);
+              };
+            }
+            """);
+    }
+
+    private static Task SetMainContentScrollTopAsync(IPage page, int scrollTop)
+    {
+        return page.EvaluateAsync(
+            """
+            scrollTop => {
+              const main = document.getElementById('main-content');
+              if (main) {
+                main.scrollTo(0, scrollTop);
+              }
+            }
+            """,
+            scrollTop);
+    }
+
+    private static Task<int> GetMainContentScrollTopAsync(IPage page)
+    {
+        return page.EvaluateAsync<int>(
+            "() => Math.round(document.getElementById('main-content')?.scrollTop ?? -1)");
+    }
+
+    private static async Task AssertSectionCopyDidNotMutateHistoryAsync(IPage page)
+    {
+        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyPushStateCalls"));
+        Assert.Equal(0, await page.EvaluateAsync<int>("() => window.__sectionCopyReplaceStateCalls"));
+    }
+
+    private static async Task AssertSectionCopyFallbackAsync(IPage page, string targetId, string expectedUrl)
+    {
+        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
+        await page.WaitForSelectorAsync(
+            "[data-doc-section-copy-fallback='true'] input",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
+
+        Assert.Equal(expectedUrl, await page.InputValueAsync("[data-doc-section-copy-fallback='true'] input"));
+        Assert.True(await page.Locator("[data-doc-section-copy-fallback='true']").EvaluateAsync<bool>(
+            """
+            fallback => {
+              const input = fallback.querySelector("input");
+              return document.activeElement === input
+                && input.selectionStart === 0
+                && input.selectionEnd === input.value.length;
+            }
+            """));
+
+        await page.ClickAsync("[data-doc-section-copy-fallback='true'] input");
+        Assert.Equal(1, await page.Locator("[data-doc-section-copy-fallback='true']").CountAsync());
+
+        await page.Keyboard.PressAsync("Escape");
+        await page.WaitForSelectorAsync(
+            "[data-doc-section-copy-fallback='true']",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Detached });
+        Assert.Null(await page.GetAttributeAsync(
+            $"#docs-page-outline button[data-doc-section-copy='{targetId}']",
+            "data-copy-state"));
+
+        await page.ClickAsync($"#docs-page-outline button[data-doc-section-copy='{targetId}']");
+        await page.WaitForSelectorAsync(
+            "[data-doc-section-copy-fallback='true'] input",
+            new PageWaitForSelectorOptions { Timeout = 15_000, State = WaitForSelectorState.Visible });
+
+        Assert.Equal(expectedUrl, await page.InputValueAsync("[data-doc-section-copy-fallback='true'] input"));
+        await page.ClickAsync("[data-doc-section-copy-fallback='true'] input");
+        Assert.Equal(1, await page.Locator("[data-doc-section-copy-fallback='true']").CountAsync());
     }
 
     private const string ScrollMainContentToBottomScript =

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -100,6 +100,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs details pages now render those `On this page` outlines as a page-local navigation surface, using a sticky desktop rail, a compact narrow-viewport drawer, and active-section state that keeps the reader oriented without competing with the global sidebar.
 - RazorDocs compact `On this page` outlines now stay visible while reading on narrow viewports, showing smaller previous/next context around the current section with reduced-motion-safe rolling label updates.
 - RazorDocs compact `On this page` outlines now contain their own scrolling while expanded, preventing touch or wheel input over the outline from scrolling the article behind it.
+- RazorDocs detail-page outlines and section headers now include copy-link actions for deep section URLs, with a manual-copy fallback when clipboard writes are unavailable or denied.
 - RazorDocs details pages now emit the outline client as a normal deferred script asset, so static exports publish `/docs/outline-client.js` through the existing asset crawler instead of depending on an inline loader.
 - RazorDocs detail-page outlines now keep long-section active states and the desktop right rail aligned, including the full-height rail rule, active-item visibility on long pages, and animated section jumps.
 - Public docs navigation now groups pages by intent-first sections, preserves authored editorial breadcrumbs, and keeps Start Here recovery links hidden when that section is unavailable.


### PR DESCRIPTION
## Summary
- Add copy-link actions for RazorDocs outline rows and rendered section headers so readers can copy deep section URLs without changing their scroll position or hash.
- Use visible conventional copy icons instead of # glyphs for both content and outline controls.
- Add manual-copy fallback behavior when clipboard writes are unavailable or denied.
- Document the interaction contract in RazorDocs design notes and release notes.

## QA
- Browser QA on /docs/releases/unreleased and /docs/Namespaces/ForgeTrust.AppSurface.Aspire.html.
- Confirmed copy buttons are visible at rest, use copy icons, have no # text glyph, and preserve window.location.hash.
- Console clean on tested routes.
- dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --filter FullyQualifiedName~RazorDocsViewsTests, 127 passed.
- dotnet test Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj --filter FullyQualifiedName~RazorDocsWayfindingPlaywrightTests, 18 passed.
- dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes --no-restore, passed.

QA report: .gstack/qa-reports/qa-report-127-0-0-1-6163-2026-05-15.md