### PR TITLE
fix: restrict build workflow token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
 ﻿name: build.yml
+
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -29,6 +29,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 
 - Pull request titles are now expected to follow Conventional Commits so the merge history is machine-readable for future automation.
 - Pull requests are expected to update this page unless maintainers explicitly mark the change as outside the public release story.
+- The primary build workflow now declares explicit read-only `GITHUB_TOKEN` contents permissions, keeping CI aligned with least-privilege GitHub Actions defaults.
 - Markdown-only changes on `main` now republish the docs surface, so release-note and policy edits are treated as first-class product updates.
 - AppSurface now exposes focused GitHub issue forms for bug reports, feature requests, and docs/developer-experience feedback, with the root README and contribution guide pointing developers to that feedback path.
 - Public contribution surfaces now steer suspected vulnerabilities away from issue forms and into a private security reporting path.


### PR DESCRIPTION
## Summary
- Add an explicit workflow-level `GITHUB_TOKEN` permission default to `.github/workflows/build.yml`
- Restrict the default token scope to `contents: read` for the build job
- Preserve existing job-level Pages deployment permissions

## Why
CodeQL reported `actions/missing-workflow-permissions` for the build workflow because the `build` job inherited repository default token permissions instead of declaring least privilege.

Addresses https://github.com/forge-trust/AppSurface/security/code-scanning/1

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "yaml ok"'`
- `git diff --check`