### PR TITLE
fix(docs): contain mobile outline scrolling

### DIFF
--- a/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
+++ b/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
@@ -181,6 +181,7 @@ Visual rules:
 - Use small row radii only. Do not wrap the whole rail in a large rounded card.
 - Preserve the existing RazorDocs global sidebar; do not replace it with icon-only chrome for this pattern.
 - On compact viewports, the collapsed outline may show previous, current, and next section context. The current section is dominant; previous and next stay smaller and quieter so the control remains a reader aid instead of a second header.
+- When the compact outline is expanded, it is a bounded scroll surface with contained overscroll. Readers should be able to inspect a long `On this page` list without accidentally moving the article behind it.
 
 Interaction rules:
 

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -962,6 +962,7 @@ The outline client enhances the server-rendered links by:
 - easing outline-link clicks to the target section over 620 ms, while preserving instant jumps for readers who prefer reduced motion and canceling the animation when the reader manually wheels or touches the scroll root
 - initializing from the current URL hash
 - rebinding after RazorWire/Turbo frame navigation replaces `rw:island id="doc-content"`
+- containing scroll inside the expanded compact outline so touch or wheel input over `On this page` does not move the article behind it
 - collapsing the mobile outline after an outline link is chosen
 - skipping missing heading targets for active-state tracking while leaving their normal hash links intact instead of marking stale entries current or closing the drawer
 

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/css/app.css
@@ -609,10 +609,11 @@ body {
 @media (max-width: 79.999rem) {
     .docs-outline-shell[data-outline-enhanced="true"] {
         --docs-outline-compact-bleed: 1rem;
+        --docs-outline-compact-top: 0px;
 
         position: sticky;
         z-index: 20;
-        top: 0;
+        top: var(--docs-outline-compact-top);
         width: calc(100% + (var(--docs-outline-compact-bleed) * 2));
         margin-right: calc(var(--docs-outline-compact-bleed) * -1);
         margin-left: calc(var(--docs-outline-compact-bleed) * -1);
@@ -622,6 +623,13 @@ body {
         border-radius: 0;
         background: var(--docs-color-surface-overlay-strong);
         backdrop-filter: blur(10px);
+    }
+
+    .docs-outline-shell[data-outline-enhanced="true"][data-outline-expanded="true"] {
+        max-height: calc(100dvh - var(--docs-outline-compact-top));
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        -webkit-overflow-scrolling: touch;
     }
 }
 
@@ -633,7 +641,7 @@ body {
 
 @media (max-width: 47.999rem) {
     .docs-outline-shell[data-outline-enhanced="true"] {
-        top: 3.8125rem;
+        --docs-outline-compact-top: 3.8125rem;
     }
 }
 

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -684,6 +684,106 @@ public sealed class RazorDocsWayfindingPlaywrightTests
     }
 
     [Fact]
+    public async Task MobileOutline_ExpandedPanelContainsScroll()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 390,
+                Height = 844
+            }
+        });
+        var page = await context.NewPageAsync();
+
+        await RazorDocsRouteHelper.GotoFirstAvailableAsync(
+            page,
+            _fixture.DocsUrl,
+            "/web/forgetrust.appsurface.docs",
+            "/Web/ForgeTrust.AppSurface.Docs/README.md.html");
+        await page.WaitForSelectorAsync("#docs-page-outline", new PageWaitForSelectorOptions
+        {
+            Timeout = 30_000,
+            State = WaitForSelectorState.Visible
+        });
+        await page.WaitForFunctionAsync(
+            "() => document.getElementById('docs-page-outline')?.dataset.outlineEnhanced === 'true'",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        await page.ClickAsync("#docs-page-outline [data-doc-outline-toggle]");
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const shell = document.getElementById('docs-page-outline');
+              const toggle = shell?.querySelector('[data-doc-outline-toggle]');
+              return toggle?.getAttribute('aria-expanded') === 'true'
+                && shell.scrollHeight > shell.clientHeight;
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        var initialState = await page.EvaluateAsync<ExpandedOutlineScrollState>(
+            """
+            () => {
+              const main = document.getElementById('main-content');
+              const shell = document.getElementById('docs-page-outline');
+              if (main) {
+                main.scrollTop = 180;
+              }
+
+              return {
+                mainScrollTop: main?.scrollTop ?? 0,
+                shellScrollTop: shell?.scrollTop ?? 0,
+                shellScrollHeight: shell?.scrollHeight ?? 0,
+                shellClientHeight: shell?.clientHeight ?? 0,
+                shellOverflowY: shell ? getComputedStyle(shell).overflowY : '',
+                shellOverscrollBehaviorY: shell ? getComputedStyle(shell).overscrollBehaviorY : ''
+              };
+            }
+            """);
+
+        Assert.Equal("auto", initialState.ShellOverflowY);
+        Assert.Equal("contain", initialState.ShellOverscrollBehaviorY);
+        Assert.True(initialState.ShellScrollHeight > initialState.ShellClientHeight);
+
+        var panelBox = await page.Locator("#docs-page-outline-panel").BoundingBoxAsync();
+        Assert.NotNull(panelBox);
+
+        await page.Mouse.MoveAsync(panelBox.X + panelBox.Width / 2, panelBox.Y + Math.Min(160, panelBox.Height / 2));
+        await page.Mouse.WheelAsync(0, 360);
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+              const shell = document.getElementById('docs-page-outline');
+              return (shell?.scrollTop ?? 0) > 0;
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        var scrolledState = await page.EvaluateAsync<ExpandedOutlineScrollState>(
+            """
+            () => {
+              const main = document.getElementById('main-content');
+              const shell = document.getElementById('docs-page-outline');
+              return {
+                mainScrollTop: main?.scrollTop ?? 0,
+                shellScrollTop: shell?.scrollTop ?? 0,
+                shellScrollHeight: shell?.scrollHeight ?? 0,
+                shellClientHeight: shell?.clientHeight ?? 0,
+                shellOverflowY: shell ? getComputedStyle(shell).overflowY : '',
+                shellOverscrollBehaviorY: shell ? getComputedStyle(shell).overscrollBehaviorY : ''
+              };
+            }
+            """);
+
+        Assert.True(scrolledState.ShellScrollTop > initialState.ShellScrollTop);
+        Assert.Equal(initialState.MainScrollTop, scrolledState.MainScrollTop);
+    }
+
+    [Fact]
     public async Task MobileOutline_StickyContextTracksNeighborSections()
     {
         await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
@@ -1077,6 +1177,21 @@ public sealed class RazorDocsWayfindingPlaywrightTests
         public string RollDirection { get; init; } = string.Empty;
 
         public string Motion { get; init; } = string.Empty;
+    }
+
+    private sealed class ExpandedOutlineScrollState
+    {
+        public double MainScrollTop { get; init; }
+
+        public double ShellScrollTop { get; init; }
+
+        public double ShellScrollHeight { get; init; }
+
+        public double ShellClientHeight { get; init; }
+
+        public string ShellOverflowY { get; init; } = string.Empty;
+
+        public string ShellOverscrollBehaviorY { get; init; } = string.Empty;
     }
 
     private sealed class CompactOutlineBandState

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs
@@ -780,7 +780,10 @@ public sealed class RazorDocsWayfindingPlaywrightTests
             """);
 
         Assert.True(scrolledState.ShellScrollTop > initialState.ShellScrollTop);
-        Assert.Equal(initialState.MainScrollTop, scrolledState.MainScrollTop);
+        Assert.InRange(
+            scrolledState.MainScrollTop - initialState.MainScrollTop,
+            -1,
+            1);
     }
 
     [Fact]

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -96,6 +96,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs pages can now expose typed `On this page` outlines, explicit proof-path previous/next links, related-page cards, and sidebar anchor navigation from harvested metadata instead of scraping rendered HTML.
 - RazorDocs details pages now render those `On this page` outlines as a page-local navigation surface, using a sticky desktop rail, a compact narrow-viewport drawer, and active-section state that keeps the reader oriented without competing with the global sidebar.
 - RazorDocs compact `On this page` outlines now stay visible while reading on narrow viewports, showing smaller previous/next context around the current section with reduced-motion-safe rolling label updates.
+- RazorDocs compact `On this page` outlines now contain their own scrolling while expanded, preventing touch or wheel input over the outline from scrolling the article behind it.
 - RazorDocs details pages now emit the outline client as a normal deferred script asset, so static exports publish `/docs/outline-client.js` through the existing asset crawler instead of depending on an inline loader.
 - RazorDocs detail-page outlines now keep long-section active states and the desktop right rail aligned, including the full-height rail rule, active-item visibility on long pages, and animated section jumps.
 - Public docs navigation now groups pages by intent-first sections, preserves authored editorial breadcrumbs, and keeps Start Here recovery links hidden when that section is unavailable.


### PR DESCRIPTION
## Summary
- Contain the compact mobile RazorDocs On this page panel so its scroll does not chain into article content.
- Add a Playwright regression covering expanded panel scroll containment and article scroll stability.
- Update RazorDocs README, design notes, and unreleased release notes.

## Validation
- dotnet format ForgeTrust.AppSurface.slnx --include Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsWayfindingPlaywrightTests.cs --verify-no-changes
- dotnet test Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj --filter FullyQualifiedName~RazorDocsWayfindingPlaywrightTests (15/15 passed)
- /qa against http://localhost:6197/docs: health 100 -> 100, no findings
- /review: no issues found