### PR TITLE
feat(web): improve startup watchdog sandbox diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 
 - AppSurface now has a planned `appsurface` .NET tool surface. Its first verb is `appsurface docs`, which runs RazorDocs preview workflows through the existing standalone docs host instead of minting a separate `razordocs` CLI.
 - AppSurface Web now has a startup watchdog that fails fast when a web host stalls before Kestrel starts listening; `appsurface docs` exposes the same guard through `--startup-timeout-seconds`.
+- AppSurface Web startup watchdog failures now include sandbox markers and startup phase context so Codex-hosted local web runs point operators toward an unsandboxed retry first.
 - RazorDocs and RazorWire runtime assets are now embedded into their assemblies and served through endpoint fallbacks, so packaged CLI hosts can serve docs UI assets without relying on static web asset manifests.
 - AppSurface now has a repo-level release contract: a public release hub, an unreleased proof artifact, a pre-1.0 upgrade policy, and a tagged-release template for future versioned notes.
 - RazorWire now has a package-level generated UI design contract that defines ownership scope, data-attribute and CSS custom-property styling surfaces, accessibility expectations, override levels, and anti-patterns for package-owned UI.

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -69,7 +69,7 @@ public sealed class ProgramEntryPointTests
         Assert.Contains("/reference/next", runner.Args);
         Assert.Contains("--environment", runner.Args);
         Assert.Contains("Development", runner.Args);
-        Assert.Equal(TimeSpan.FromSeconds(30), runner.StartupTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(10), runner.StartupTimeout);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public sealed class ProgramEntryPointTests
         Assert.Contains(repository.Path, runner.Args);
         Assert.Contains("--port", runner.Args);
         Assert.Contains("5189", runner.Args);
-        Assert.Equal(TimeSpan.FromSeconds(30), runner.StartupTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(10), runner.StartupTimeout);
     }
 
     [Fact]

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -156,11 +156,11 @@ internal abstract class RazorDocsPreviewCommand : ICommand
     /// Gets the number of seconds to wait for the web host to start before failing fast.
     /// </summary>
     /// <remarks>
-    /// Defaults to 30 seconds. Set to <c>0</c> to disable the startup watchdog. Negative, infinite, and NaN values are
+    /// Defaults to 10 seconds. Set to <c>0</c> to disable the startup watchdog. Negative, infinite, and NaN values are
     /// rejected before the host starts.
     /// </remarks>
     [CommandOption("startup-timeout-seconds", Description = "Seconds to wait for the RazorDocs web host to start before failing fast. Use 0 to disable.")]
-    public double StartupTimeoutSeconds { get; init; } = 30;
+    public double StartupTimeoutSeconds { get; init; } = 10;
 
     /// <summary>
     /// Executes the command through the CliFx console integration.

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -29,7 +29,7 @@ Options:
 - `--route-root`: Route-family root for version and archive routes.
 - `--docs-root`: Live docs preview root.
 - `--environment`, `-e`: Host environment forwarded to the RazorDocs host.
-- `--startup-timeout-seconds`: Seconds to wait for the web host to start before failing fast. Defaults to `30`; use `0` to disable while investigating intentional pre-bind delays.
+- `--startup-timeout-seconds`: Seconds to wait for the web host to start before failing fast. Defaults to `10`; use `0` to disable while investigating intentional pre-bind delays.
 
 `appsurface docs preview` is an alias for the same behavior, kept so the old deferred shape maps cleanly to the new AppSurface command family.
 

--- a/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
@@ -33,7 +33,7 @@ Do not duplicate standalone setup in test fixtures. If a scenario needs differen
 `CreateBuilder` is lower level than `RunAsync`: callers that build and start the host themselves should pass `--urls`, `--port`, or configure the web host before `Build()` instead of relying on the executable startup path's development-port fallback.
 The builder pins this standalone assembly as the host entry point identity so in-process callers, including xUnit, resolve the same static web asset manifest as the executable.
 
-The optional `configureOptions` callback is for host-shape seams that must stay on the normal AppSurface Web path. `appsurface docs` uses it to disable static web asset manifest loading for packaged tool runs because RazorDocs and RazorWire runtime assets are embedded in their assemblies. The shared AppSurface Web startup watchdog still applies through `WebOptions.StartupTimeout`, which defaults to 30 seconds and fails fast when the process stalls before Kestrel starts listening.
+The optional `configureOptions` callback is for host-shape seams that must stay on the normal AppSurface Web path. `appsurface docs` uses it to disable static web asset manifest loading for packaged tool runs because RazorDocs and RazorWire runtime assets are embedded in their assemblies. The shared AppSurface Web startup watchdog still applies through `WebOptions.StartupTimeout`, which defaults to 10 seconds and fails fast when the process stalls before Kestrel starts listening.
 
 ## Strict Harvest Failure
 

--- a/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
@@ -173,6 +173,21 @@ public class WebStartupTests
     }
 
     [Fact]
+    public void StartupTimeoutDiagnostic_UsesNone_WhenNoEndpointArgumentsSurviveFiltering()
+    {
+        var diagnostic = AppSurfaceWebStartupTimeoutDiagnostic.Create(
+            TimeSpan.FromSeconds(10),
+            "StartHost",
+            "/workspace/app",
+            "/workspace/app/bin",
+            staticWebAssetsEnabled: true,
+            ["--name", "docs preview", "--ConnectionStrings:Default", "Server=secret"],
+            _ => null);
+
+        Assert.Equal("<none>", diagnostic.StartupArgsSummary);
+    }
+
+    [Fact]
     public void StartupTimeoutDiagnostic_Uses_GenericRecommendation_WhenSandboxMarkersAreAbsent()
     {
         var diagnostic = AppSurfaceWebStartupTimeoutDiagnostic.Create(

--- a/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
@@ -105,6 +105,93 @@ public class WebStartupTests
     }
 
     [Fact]
+    public void StartupTimeoutDiagnostic_Detects_CodexSandboxMarkers()
+    {
+        var diagnostic = AppSurfaceWebStartupTimeoutDiagnostic.Create(
+            TimeSpan.FromSeconds(10),
+            "StartHost",
+            "/workspace/app",
+            "/workspace/app/bin",
+            staticWebAssetsEnabled: false,
+            ["--urls", "http://127.0.0.1:5000", "--name", "docs preview", "--ConnectionStrings:Default", "Server=secret"],
+            key => key switch
+            {
+                "CODEX_SANDBOX" => "seatbelt",
+                "CODEX_SANDBOX_NETWORK_DISABLED" => "1",
+                _ => null
+            });
+
+        Assert.True(diagnostic.SandboxDetected);
+        Assert.Contains("CODEX_SANDBOX=seatbelt", diagnostic.SandboxSummary, StringComparison.Ordinal);
+        Assert.Contains("CODEX_SANDBOX_NETWORK_DISABLED=1", diagnostic.SandboxSummary, StringComparison.Ordinal);
+        Assert.Contains("Rerun the command outside the sandbox", diagnostic.RecommendedAction, StringComparison.Ordinal);
+        Assert.Contains("--urls http://127.0.0.1:5000", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.DoesNotContain("docs preview", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.DoesNotContain("ConnectionStrings", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StartupTimeoutDiagnostic_Renders_Only_EndpointArgumentForms()
+    {
+        var diagnostic = AppSurfaceWebStartupTimeoutDiagnostic.Create(
+            TimeSpan.FromSeconds(10),
+            "StartHost",
+            "/workspace/app",
+            "/workspace/app/bin",
+            staticWebAssetsEnabled: true,
+            [
+                "--urls=http://127.0.0.1:5000",
+                "--password=secret",
+                "--port",
+                "5189",
+                "--port",
+                "--ApiSecret=secret",
+                "--ApiKey",
+                "secret",
+                "--Kestrel:Endpoints:Http:Url",
+                "http://127.0.0.1:5190",
+                "--Kestrel:Endpoints:Admin:Url",
+                "--Password=secret",
+                "--Kestrel__Endpoints__Https__Url=https://127.0.0.1:5191",
+                "--Kestrel:Endpoints:Https:Certificate:Password",
+                "cert-secret",
+                "--Kestrel__Endpoints__Https__Certificate__Password=cert-secret"
+            ],
+            _ => null);
+
+        Assert.Contains("--urls=http://127.0.0.1:5000", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.Contains("--port 5189", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.Contains("--Kestrel:Endpoints:Http:Url http://127.0.0.1:5190", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.Contains("--Kestrel__Endpoints__Https__Url=https://127.0.0.1:5191", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.DoesNotContain("password", diagnostic.StartupArgsSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ApiKey", diagnostic.StartupArgsSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ApiSecret", diagnostic.StartupArgsSummary, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("secret", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.DoesNotContain("Certificate", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+        Assert.DoesNotContain("cert-secret", diagnostic.StartupArgsSummary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StartupTimeoutDiagnostic_Uses_GenericRecommendation_WhenSandboxMarkersAreAbsent()
+    {
+        var diagnostic = AppSurfaceWebStartupTimeoutDiagnostic.Create(
+            TimeSpan.FromSeconds(10),
+            "",
+            "/workspace/app",
+            "/workspace/app/bin",
+            staticWebAssetsEnabled: true,
+            [],
+            _ => null);
+
+        Assert.False(diagnostic.SandboxDetected);
+        Assert.Equal("none detected", diagnostic.SandboxSummary);
+        Assert.Equal("unknown", diagnostic.StartupPhase);
+        Assert.Equal("<none>", diagnostic.StartupArgsSummary);
+        Assert.Contains("Check static web asset discovery", diagnostic.RecommendedAction, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task RunResolvedAsync_FailsFast_WhenStartupCancellationCallbackDoesNotComplete()
     {
         var module = new HangingCancellationWebModule();
@@ -1231,11 +1318,11 @@ public class WebStartupTests
 public class WebOptionsTests
 {
     [Fact]
-    public void WebOptions_DefaultStartupTimeout_IsThirtySeconds()
+    public void WebOptions_DefaultStartupTimeout_IsTenSeconds()
     {
         var opts = new WebOptions();
 
-        Assert.Equal(TimeSpan.FromSeconds(30), opts.StartupTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(10), opts.StartupTimeout);
     }
 }
 

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebStartupTimeoutDiagnostic.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebStartupTimeoutDiagnostic.cs
@@ -45,9 +45,19 @@ internal sealed record AppSurfaceWebStartupTimeoutDiagnostic(
     /// <summary>
     /// Gets endpoint-related command-line arguments rendered for diagnostics.
     /// </summary>
-    internal string StartupArgsSummary => StartupArgs.Count == 0
-        ? "<none>"
-        : string.Join(" ", SelectEndpointArguments(StartupArgs).Select(QuoteArgument));
+    internal string StartupArgsSummary
+    {
+        get
+        {
+            var endpointArguments = SelectEndpointArguments(StartupArgs)
+                .Select(QuoteArgument)
+                .ToArray();
+
+            return endpointArguments.Length == 0
+                ? "<none>"
+                : string.Join(" ", endpointArguments);
+        }
+    }
 
     /// <summary>
     /// Creates a startup-timeout diagnostic from the current process environment.

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebStartupTimeoutDiagnostic.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebStartupTimeoutDiagnostic.cs
@@ -1,0 +1,175 @@
+namespace ForgeTrust.AppSurface.Web;
+
+/// <summary>
+/// Builds operator-facing details for AppSurface Web startup watchdog failures.
+/// </summary>
+/// <remarks>
+/// The diagnostic intentionally keeps to process and host-shape facts that are safe to log: sandbox markers, startup
+/// phase, directories, static-asset mode, and endpoint-shaped command-line arguments. It avoids inspecting arbitrary app
+/// configuration values, which may contain secrets.
+/// </remarks>
+internal sealed record AppSurfaceWebStartupTimeoutDiagnostic(
+    TimeSpan StartupTimeout,
+    string StartupPhase,
+    string CurrentDirectory,
+    string BaseDirectory,
+    bool StaticWebAssetsEnabled,
+    IReadOnlyList<string> StartupArgs,
+    IReadOnlyDictionary<string, string> SandboxEnvironment)
+{
+    private static readonly string[] SandboxEnvironmentVariables =
+    [
+        "CODEX_SANDBOX",
+        "CODEX_SANDBOX_NETWORK_DISABLED"
+    ];
+
+    /// <summary>
+    /// Gets a value indicating whether the process environment contains a known sandbox marker.
+    /// </summary>
+    internal bool SandboxDetected => SandboxEnvironment.Count > 0;
+
+    /// <summary>
+    /// Gets a display-safe summary of detected sandbox markers.
+    /// </summary>
+    internal string SandboxSummary => SandboxDetected
+        ? string.Join(", ", SandboxEnvironment.Select(pair => $"{pair.Key}={pair.Value}"))
+        : "none detected";
+
+    /// <summary>
+    /// Gets the concrete next step operators should try first.
+    /// </summary>
+    internal string RecommendedAction => SandboxDetected
+        ? "Detected a Codex sandbox. Rerun the command outside the sandbox, or with the runner's approved unsandboxed/escalated permission, before investigating package layout, static web assets, or hosted services."
+        : "No sandbox marker was detected. Check static web asset discovery, package layout, endpoint binding, and hosted services that block StartAsync before Kestrel binds.";
+
+    /// <summary>
+    /// Gets endpoint-related command-line arguments rendered for diagnostics.
+    /// </summary>
+    internal string StartupArgsSummary => StartupArgs.Count == 0
+        ? "<none>"
+        : string.Join(" ", SelectEndpointArguments(StartupArgs).Select(QuoteArgument));
+
+    /// <summary>
+    /// Creates a startup-timeout diagnostic from the current process environment.
+    /// </summary>
+    /// <param name="startupTimeout">Configured startup watchdog timeout.</param>
+    /// <param name="startupPhase">Startup phase observed when the watchdog fired.</param>
+    /// <param name="currentDirectory">Current working directory used by the host.</param>
+    /// <param name="baseDirectory">Application base directory used for dependency and asset resolution.</param>
+    /// <param name="staticWebAssetsEnabled">Whether AppSurface static web asset loading was enabled.</param>
+    /// <param name="startupArgs">Effective startup arguments after AppSurface development-port resolution.</param>
+    /// <param name="environmentReader">Environment reader used to detect sandbox markers.</param>
+    /// <returns>A diagnostic object suitable for structured logging and tests.</returns>
+    internal static AppSurfaceWebStartupTimeoutDiagnostic Create(
+        TimeSpan startupTimeout,
+        string startupPhase,
+        string currentDirectory,
+        string baseDirectory,
+        bool staticWebAssetsEnabled,
+        IReadOnlyList<string> startupArgs,
+        Func<string, string?> environmentReader)
+    {
+        ArgumentNullException.ThrowIfNull(environmentReader);
+
+        var sandboxEnvironment = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        foreach (var variable in SandboxEnvironmentVariables)
+        {
+            var value = environmentReader(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                sandboxEnvironment[variable] = value;
+            }
+        }
+
+        return new AppSurfaceWebStartupTimeoutDiagnostic(
+            startupTimeout,
+            string.IsNullOrWhiteSpace(startupPhase) ? "unknown" : startupPhase,
+            currentDirectory,
+            baseDirectory,
+            staticWebAssetsEnabled,
+            startupArgs,
+            sandboxEnvironment);
+    }
+
+    private static string QuoteArgument(string argument)
+    {
+        if (argument.Length == 0)
+        {
+            return "\"\"";
+        }
+
+        return argument.Any(char.IsWhiteSpace) || argument.Contains('"', StringComparison.Ordinal)
+            ? "\"" + argument.Replace("\"", "\\\"", StringComparison.Ordinal) + "\""
+            : argument;
+    }
+
+    private static IEnumerable<string> SelectEndpointArguments(IReadOnlyList<string> arguments)
+    {
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var argument = arguments[index];
+            if (IsEndpointArgumentAssignment(argument))
+            {
+                yield return argument;
+                continue;
+            }
+
+            if (!IsEndpointArgumentName(argument))
+            {
+                continue;
+            }
+
+            yield return argument;
+            if (index + 1 < arguments.Count && !LooksLikeOption(arguments[index + 1]))
+            {
+                yield return arguments[index + 1];
+                index++;
+            }
+        }
+    }
+
+    private static bool IsEndpointArgumentAssignment(string argument)
+    {
+        var equalsIndex = argument.IndexOf('=', StringComparison.Ordinal);
+        if (equalsIndex <= 0)
+        {
+            return false;
+        }
+
+        return IsEndpointArgumentName(argument[..equalsIndex]);
+    }
+
+    private static bool IsEndpointArgumentName(string argument)
+    {
+        var normalized = argument.TrimStart('-').Replace("__", ":", StringComparison.Ordinal);
+        return normalized.Equals("urls", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("port", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("http_ports", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("https_ports", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("ASPNETCORE_URLS", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("ASPNETCORE_HTTP_PORTS", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("ASPNETCORE_HTTPS_PORTS", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("DOTNET_URLS", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("DOTNET_HTTP_PORTS", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("DOTNET_HTTPS_PORTS", StringComparison.OrdinalIgnoreCase)
+            || IsKestrelEndpointUrlOrPortArgument(normalized);
+    }
+
+    private static bool LooksLikeOption(string argument)
+    {
+        return argument.StartsWith("-", StringComparison.Ordinal);
+    }
+
+    private static bool IsKestrelEndpointUrlOrPortArgument(string normalizedArgument)
+    {
+        const string prefix = "Kestrel:Endpoints:";
+        if (!normalizedArgument.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var suffix = normalizedArgument[prefix.Length..];
+        var parts = suffix.Split(':', StringSplitOptions.RemoveEmptyEntries);
+        return parts is [_, "Url"] or [_, "Port"];
+    }
+}

--- a/Web/ForgeTrust.AppSurface.Web/README.md
+++ b/Web/ForgeTrust.AppSurface.Web/README.md
@@ -191,7 +191,9 @@ You can override the application's listening port using several methods:
 
 ### Startup Watchdog
 
-AppSurface Web fails fast when a host does not complete startup within `WebOptions.StartupTimeout`. The default is 30 seconds. This catches pre-bind stalls where the process is alive but Kestrel has not started listening, including sandbox restrictions, package layout issues, static web asset discovery hangs, and hosted services that block startup.
+AppSurface Web fails fast when a host does not complete startup within `WebOptions.StartupTimeout`. The default is 10 seconds. This catches pre-bind stalls where the process is alive but Kestrel has not started listening, including sandbox restrictions, package layout issues, static web asset discovery hangs, and hosted services that block startup.
+
+When the watchdog fires, AppSurface logs the observed startup phase, current directory, application base directory, static web asset mode, endpoint-related startup arguments, and any known Codex sandbox markers such as `CODEX_SANDBOX`. If a Codex sandbox is detected, try the same command outside the sandbox or with the runner's approved unsandboxed/escalated permission before debugging package layout or hosted-service startup.
 
 Configure or disable the watchdog through `WebOptions`:
 

--- a/Web/ForgeTrust.AppSurface.Web/WebOptions.cs
+++ b/Web/ForgeTrust.AppSurface.Web/WebOptions.cs
@@ -46,14 +46,16 @@ public record WebOptions
     /// Gets or sets the amount of time AppSurface waits for the web host to complete startup before failing fast.
     /// </summary>
     /// <remarks>
-    /// The default is 30 seconds. Set this to <see langword="null"/> only for hosts that intentionally perform
+    /// The default is 10 seconds. Set this to <see langword="null"/> only for hosts that intentionally perform
     /// long-running startup work before Kestrel binds. The watchdog covers pre-bind stalls caused by package layout,
     /// sandboxing, static asset discovery, hosted-service startup, and similar issues; it does not limit normal request
-    /// processing after the host has started.
+    /// processing after the host has started. Timeout diagnostics include safe process context, the observed startup
+    /// phase, and known Codex sandbox markers when present so operators can rerun outside the sandbox before chasing
+    /// package or host-layout causes.
     /// <see cref="StartupTimeout"/> must be <see langword="null"/> or greater than <see cref="TimeSpan.Zero"/>.
     /// Use <see langword="null"/> to disable the watchdog instead of <see cref="TimeSpan.Zero"/>.
     /// </remarks>
-    public TimeSpan? StartupTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan? StartupTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Gets or sets an optional delegate to configure endpoint routing for the application.

--- a/Web/ForgeTrust.AppSurface.Web/WebStartup.cs
+++ b/Web/ForgeTrust.AppSurface.Web/WebStartup.cs
@@ -93,11 +93,15 @@ public abstract class WebStartup<TModule> : AppSurfaceStartup<TModule>
         IHost? host = null;
         CancellationTokenSource? startupCts = null;
         var timedOut = false;
+        var startupPhase = new StartupPhaseTracker();
 
         try
         {
+            startupPhase.Enter("RegisterDependencies");
             RegisterDependencies(context);
+            startupPhase.Enter("BuildModules");
             BuildModules(context);
+            startupPhase.Enter("BuildWebOptions");
             BuildWebOptions(context);
 
             var startupTimeout = _options.StartupTimeout;
@@ -112,10 +116,12 @@ public abstract class WebStartup<TModule> : AppSurfaceStartup<TModule>
 
             var logger = GetStartupLogger();
             startupCts = new CancellationTokenSource();
+            startupPhase.Enter("BuildAndStartHost");
             var startTask = Task.Run(
                 () => BuildAndStartHostAsync(
                     context,
                     startupCts.Token,
+                    startupPhase.Enter,
                     (startedHost, startupLogger) =>
                     {
                         host = startedHost;
@@ -129,9 +135,24 @@ public abstract class WebStartup<TModule> : AppSurfaceStartup<TModule>
                     timedOut = true;
                     var cancellationTask = startupCts.CancelAsync();
                     ObserveTimedOutStartupTask(startTask, startupCts, () => host?.Dispose(), cancellationTask);
+                    var diagnostic = AppSurfaceWebStartupTimeoutDiagnostic.Create(
+                        startupTimeout.Value,
+                        startupPhase.Current,
+                        Directory.GetCurrentDirectory(),
+                        AppContext.BaseDirectory,
+                        _options.StaticFiles.EnableStaticWebAssets,
+                        args,
+                        Environment.GetEnvironmentVariable);
                     logger.LogCritical(
-                        "AppSurface Web host startup did not complete within {StartupTimeoutSeconds} seconds. The host may be blocked before Kestrel has bound its URLs. Check sandbox restrictions, static web asset discovery, package layout, and hosted-service startup work. Set WebOptions.StartupTimeout to null only when this pre-bind delay is intentional.",
-                        startupTimeout.Value.TotalSeconds);
+                        "AppSurface Web host startup did not complete within {StartupTimeoutSeconds} seconds before Kestrel finished binding. Startup phase: {StartupPhase}. Sandbox markers: {SandboxSummary}. Recommendation: {RecommendedAction} Current directory: {CurrentDirectory}. App base directory: {BaseDirectory}. Static web assets enabled: {StaticWebAssetsEnabled}. Endpoint startup args: {StartupArgs}. Set WebOptions.StartupTimeout to null only when this pre-bind delay is intentional.",
+                        diagnostic.StartupTimeout.TotalSeconds,
+                        diagnostic.StartupPhase,
+                        diagnostic.SandboxSummary,
+                        diagnostic.RecommendedAction,
+                        diagnostic.CurrentDirectory,
+                        diagnostic.BaseDirectory,
+                        diagnostic.StaticWebAssetsEnabled,
+                        diagnostic.StartupArgsSummary);
                     Environment.ExitCode = -100;
                     return;
                 }
@@ -159,13 +180,27 @@ public abstract class WebStartup<TModule> : AppSurfaceStartup<TModule>
         }
     }
 
+    private sealed class StartupPhaseTracker
+    {
+        private string _current = "created";
+
+        internal string Current => Volatile.Read(ref _current);
+
+        internal void Enter(string phase)
+        {
+            Volatile.Write(ref _current, phase);
+        }
+    }
+
     [ExcludeFromCodeCoverage(
         Justification = "Private framework-host adapter; RunResolvedAsync tests verify success, fault, cancellation, and timeout outcomes through the public startup path.")]
     private async Task<IHost> BuildAndStartHostAsync(
         StartupContext context,
         CancellationToken startupCancellationToken,
+        Action<string> setStartupPhase,
         Action<IHost, ILogger> hostStarted)
     {
+        setStartupPhase("BuildHost");
         var host = ((IAppSurfaceStartup)this).CreateHostBuilder(context).Build();
         var loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
         var logger = loggerFactory.CreateLogger(GetType().Name);
@@ -173,7 +208,9 @@ public abstract class WebStartup<TModule> : AppSurfaceStartup<TModule>
 
         try
         {
+            setStartupPhase("StartHost");
             await host.StartAsync(startupCancellationToken);
+            setStartupPhase("HostStarted");
         }
         catch (OperationCanceledException) when (startupCancellationToken.IsCancellationRequested)
         {

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -73,7 +73,8 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 ### Web host development defaults
 
 - AppSurface web hosts now choose a deterministic localhost-only development URL when no endpoint is configured, while production, staging, container, and appsettings-based endpoint choices remain untouched.
-- AppSurface web hosts now fail fast when startup does not complete before `WebOptions.StartupTimeout`, which defaults to 30 seconds and catches pre-bind stalls from sandbox restrictions, package layout issues, static asset discovery, or hosted services that block startup.
+- AppSurface web hosts now fail fast when startup does not complete before `WebOptions.StartupTimeout`, which defaults to 10 seconds and catches pre-bind stalls from sandbox restrictions, package layout issues, static asset discovery, or hosted services that block startup.
+- Startup watchdog failures now surface Codex sandbox markers, the observed startup phase, safe path context, static web asset mode, endpoint startup arguments, and a sandbox-first rerun recommendation when applicable.
 - OpenAPI's optional web package now has dedicated test coverage for service registration, endpoint mapping, generated document titles, and transformer behavior that removes `ForgeTrust.AppSurface.Web` tags at the document and operation levels while preserving unrelated tags, so the public module contract is guarded independently of Scalar.
 - Scalar's optional web package now has dedicated test coverage for OpenAPI dependency wiring, Scalar endpoint mapping, no-op lifecycle hooks, and minimal AppSurface web host composition.
 - Tailwind development watch mode now treats a missing standalone CLI as a recoverable local-tooling gap: the app keeps serving existing CSS and logs a warning that points to the runtime package or `TailwindCliPath` override.


### PR DESCRIPTION
## What changed

- Add shared AppSurface Web startup-timeout diagnostics that surface Codex sandbox markers, startup phase, safe path context, static web asset mode, and endpoint-only startup args.
- Lower the shared web startup watchdog default, and the `appsurface docs` default, from 30 seconds to 10 seconds.
- Keep timeout command-line logging safe by allowlisting only endpoint URL/port arguments and excluding arbitrary app configuration, Kestrel certificate settings, and missing-value secret-shaped options.
- Update README, changelog, and unreleased release notes for the new watchdog behavior.

## Why

The startup watchdog was already catching pre-bind stalls, but its old failure message made sandboxing one possible cause among several. In Codex-hosted local web runs, that led to debugging package layout before trying the more useful unsandboxed rerun.

## Validation

- `dotnet test Web/ForgeTrust.AppSurface.Web.Tests/ForgeTrust.AppSurface.Web.Tests.csproj`
- `dotnet test Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj`
- `dotnet format Web/ForgeTrust.AppSurface.Web.Tests/ForgeTrust.AppSurface.Web.Tests.csproj --verify-no-changes`
- `dotnet format Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj --verify-no-changes`
