### PR TITLE
fix(cli): default docs preview to development

### DIFF
--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -92,6 +92,42 @@ public sealed class ProgramEntryPointTests
     }
 
     [Fact]
+    public async Task DocsCommand_Should_Default_ToDevelopmentEnvironment_ForLocalPreview()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", repository.Path],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        var environmentIndex = Array.IndexOf(runner.Args, "--environment");
+        Assert.InRange(environmentIndex, 0, runner.Args.Length - 2);
+        Assert.Equal("Development", runner.Args[environmentIndex + 1]);
+        Assert.DoesNotContain("--urls", runner.Args);
+        Assert.DoesNotContain("--port", runner.Args);
+    }
+
+    [Fact]
+    public async Task DocsCommand_Should_Preserve_Explicit_Environment()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var runner = new CapturingRazorDocsHostRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "--repo", repository.Path, "--environment", "Production"],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        var environmentIndex = Array.IndexOf(runner.Args, "--environment");
+        Assert.InRange(environmentIndex, 0, runner.Args.Length - 2);
+        Assert.Equal("Production", runner.Args[environmentIndex + 1]);
+    }
+
+    [Fact]
     public async Task DocsCommand_Should_Allow_Disabling_Startup_Timeout()
     {
         using var repository = TempDirectory.Create("appsurface-docs-repo-");

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -128,6 +128,36 @@ public sealed class ProgramEntryPointTests
     }
 
     [Fact]
+    public async Task DocsCommand_Should_RunHost_FromRepositoryRoot()
+    {
+        using var callerDirectory = TempDirectory.Create("appsurface-docs-caller-");
+        using var repository = TempDirectory.Create("appsurface-docs-repo-");
+        var previousDirectory = Directory.GetCurrentDirectory();
+        var runner = new CapturingRazorDocsHostRunner();
+
+        try
+        {
+            Directory.SetCurrentDirectory(callerDirectory.Path);
+
+            var result = await InvokeProgramEntryPointAsync(
+                ["docs", "--repo", repository.Path],
+                options => RegisterRunner(options, runner));
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(
+                NormalizeDirectoryForComparison(repository.Path),
+                NormalizeDirectoryForComparison(runner.WorkingDirectoryDuringRun));
+            Assert.Equal(
+                NormalizeDirectoryForComparison(callerDirectory.Path),
+                NormalizeDirectoryForComparison(Directory.GetCurrentDirectory()));
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(previousDirectory);
+        }
+    }
+
+    [Fact]
     public async Task DocsCommand_Should_Allow_Disabling_Startup_Timeout()
     {
         using var repository = TempDirectory.Create("appsurface-docs-repo-");
@@ -360,6 +390,18 @@ public sealed class ProgramEntryPointTests
         options.CustomRegistrations.Add(services => services.AddSingleton<IRazorDocsHostRunner>(runner));
     }
 
+    private static string NormalizeDirectoryForComparison(string? path)
+    {
+        Assert.NotNull(path);
+
+        var normalized = Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return OperatingSystem.IsMacOS() && normalized.StartsWith("/private/var/", StringComparison.Ordinal)
+            ? normalized["/private".Length..]
+            : normalized;
+    }
+
     private sealed record CapturedCliRun(
         string RawStdout,
         string RawStderr,
@@ -387,10 +429,13 @@ public sealed class ProgramEntryPointTests
 
         public TimeSpan? StartupTimeout { get; private set; }
 
+        public string? WorkingDirectoryDuringRun { get; private set; }
+
         public Task RunAsync(string[] args, TimeSpan? startupTimeout, CancellationToken cancellationToken)
         {
             Args = args;
             StartupTimeout = startupTimeout;
+            WorkingDirectoryDuringRun = Directory.GetCurrentDirectory();
             return Task.CompletedTask;
         }
     }

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -150,7 +150,7 @@ internal abstract class RazorDocsPreviewCommand : ICommand
     /// </summary>
     /// <remarks>
     /// Defaults to <c>Development</c> so local previews receive AppSurface Web's deterministic per-workspace endpoint
-    /// fallback when no URL or port is supplied. Set this explicitly when testing production or staging behavior.
+    /// fallback when no endpoint is configured. Set this explicitly when testing production or staging behavior.
     /// </remarks>
     [CommandOption("environment", 'e', Description = "Host environment forwarded to the RazorDocs host (default: Development).")]
     public string? EnvironmentName { get; init; }

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -6,6 +6,7 @@ using CliFx.Exceptions;
 using CliFx.Infrastructure;
 using ForgeTrust.AppSurface.Docs.Standalone;
 using ForgeTrust.AppSurface.Web;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.AppSurface.Cli;
@@ -61,6 +62,8 @@ internal sealed class DocsPreviewCommand : RazorDocsPreviewCommand
 /// </remarks>
 internal abstract class RazorDocsPreviewCommand : ICommand
 {
+    private static readonly string DefaultPreviewEnvironmentName = Environments.Development;
+
     private readonly ILogger _logger;
     private readonly IRazorDocsHostRunner _hostRunner;
 
@@ -146,10 +149,10 @@ internal abstract class RazorDocsPreviewCommand : ICommand
     /// Gets the host environment forwarded to the RazorDocs standalone host.
     /// </summary>
     /// <remarks>
-    /// Use <c>Development</c> for local preview diagnostics and development defaults. Leave unset to let the host choose
-    /// its normal environment from command-line and process configuration.
+    /// Defaults to <c>Development</c> so local previews receive AppSurface Web's deterministic per-workspace endpoint
+    /// fallback when no URL or port is supplied. Set this explicitly when testing production or staging behavior.
     /// </remarks>
-    [CommandOption("environment", 'e', Description = "Host environment forwarded to the RazorDocs host.")]
+    [CommandOption("environment", 'e', Description = "Host environment forwarded to the RazorDocs host (default: Development).")]
     public string? EnvironmentName { get; init; }
 
     /// <summary>
@@ -236,9 +239,16 @@ internal abstract class RazorDocsPreviewCommand : ICommand
 
         AddOptional(args, "--RazorDocs:Routing:RouteRootPath", RouteRootPath);
         AddOptional(args, "--RazorDocs:Routing:DocsRootPath", DocsRootPath);
-        AddOptional(args, "--environment", EnvironmentName);
+        AddOptional(args, "--environment", ResolveEnvironmentName());
 
         return new RazorDocsHostArgs(repositoryRoot, args.ToArray(), ResolveStartupTimeout());
+    }
+
+    private string ResolveEnvironmentName()
+    {
+        return string.IsNullOrWhiteSpace(EnvironmentName)
+            ? DefaultPreviewEnvironmentName
+            : EnvironmentName;
     }
 
     private static void AddOptional(List<string> args, string name, string? value)

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -189,6 +189,7 @@ internal abstract class RazorDocsPreviewCommand : ICommand
     {
         var hostArgs = BuildHostArgs();
         _logger.LogInformation("Starting RazorDocs preview for {RepositoryRoot}.", hostArgs.RepositoryRoot);
+        using var currentDirectory = CurrentDirectoryScope.ChangeTo(hostArgs.RepositoryRoot);
         await _hostRunner.RunAsync(hostArgs.Args, hostArgs.StartupTimeout, cancellationToken);
     }
 
@@ -278,6 +279,28 @@ internal abstract class RazorDocsPreviewCommand : ICommand
         return StartupTimeoutSeconds == 0
             ? null
             : TimeSpan.FromSeconds(StartupTimeoutSeconds);
+    }
+
+    private sealed class CurrentDirectoryScope : IDisposable
+    {
+        private readonly string _previousDirectory;
+
+        private CurrentDirectoryScope(string previousDirectory)
+        {
+            _previousDirectory = previousDirectory;
+        }
+
+        public static CurrentDirectoryScope ChangeTo(string directory)
+        {
+            var previousDirectory = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(directory);
+            return new CurrentDirectoryScope(previousDirectory);
+        }
+
+        public void Dispose()
+        {
+            Directory.SetCurrentDirectory(_previousDirectory);
+        }
     }
 }
 

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -28,12 +28,12 @@ Options:
 - `--strict`: Enables `RazorDocs:Harvest:FailOnFailure=true`, which fails startup when every configured harvester fails.
 - `--route-root`: Route-family root for version and archive routes.
 - `--docs-root`: Live docs preview root.
-- `--environment`, `-e`: Host environment forwarded to the RazorDocs host. Defaults to `Development` so the AppSurface Web deterministic per-workspace localhost URL is used when no endpoint is supplied.
+- `--environment`, `-e`: Host environment forwarded to the RazorDocs host. Defaults to `Development` so the AppSurface Web deterministic per-workspace localhost URL is used when no endpoint is configured.
 - `--startup-timeout-seconds`: Seconds to wait for the web host to start before failing fast. Defaults to `10`; use `0` to disable while investigating intentional pre-bind delays.
 
 `appsurface docs preview` is an alias for the same behavior, kept so the old deferred shape maps cleanly to the new AppSurface command family.
 
-When neither `--urls` nor `--port` is supplied, the command runs the host in `Development` and lets AppSurface Web choose the stable localhost port for the current repository or worktree. Use the startup log as the source of truth for the selected URL. Pass `--port`, `--urls`, or `--environment Production` when you intentionally want to bypass that local preview default.
+When no endpoint is configured, the command runs the host in `Development` from the selected repository root and lets AppSurface Web choose the stable localhost port for that repository or worktree. Use the startup log as the source of truth for the selected URL. Pass `--port`, `--urls`, `--environment Production`, or endpoint settings such as `ASPNETCORE_URLS`, HTTP/HTTPS ports, or Kestrel endpoints when you intentionally want to bypass that local preview default.
 
 ## Development
 

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -5,7 +5,7 @@ The **AppSurface CLI** is the command-line home for repository-level AppSurface 
 The first public verb is `docs`, which replaces the earlier standalone `razordocs preview --repo .` idea with an AppSurface-owned command:
 
 ```bash
-appsurface docs --repo . --urls http://127.0.0.1:5189
+appsurface docs --repo .
 ```
 
 `appsurface docs` runs the same RazorDocs standalone host used by CI and integration tests. It forwards RazorDocs configuration into that host instead of duplicating harvesting, routing, static web asset, or MVC setup in the CLI.
@@ -17,7 +17,7 @@ appsurface docs --repo . --urls http://127.0.0.1:5189
 Preview RazorDocs for a repository checkout.
 
 ```bash
-appsurface docs --repo . --port 5189
+appsurface docs --repo .
 ```
 
 Options:
@@ -28,17 +28,19 @@ Options:
 - `--strict`: Enables `RazorDocs:Harvest:FailOnFailure=true`, which fails startup when every configured harvester fails.
 - `--route-root`: Route-family root for version and archive routes.
 - `--docs-root`: Live docs preview root.
-- `--environment`, `-e`: Host environment forwarded to the RazorDocs host.
+- `--environment`, `-e`: Host environment forwarded to the RazorDocs host. Defaults to `Development` so the AppSurface Web deterministic per-workspace localhost URL is used when no endpoint is supplied.
 - `--startup-timeout-seconds`: Seconds to wait for the web host to start before failing fast. Defaults to `10`; use `0` to disable while investigating intentional pre-bind delays.
 
 `appsurface docs preview` is an alias for the same behavior, kept so the old deferred shape maps cleanly to the new AppSurface command family.
+
+When neither `--urls` nor `--port` is supplied, the command runs the host in `Development` and lets AppSurface Web choose the stable localhost port for the current repository or worktree. Use the startup log as the source of truth for the selected URL. Pass `--port`, `--urls`, or `--environment Production` when you intentionally want to bypass that local preview default.
 
 ## Development
 
 Run the tool from source while developing:
 
 ```bash
-dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http://127.0.0.1:5189
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo .
 ```
 
 Use `--strict` for CI-like validation when an all-failed harvest should stop the preview before the host begins serving.

--- a/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
@@ -134,6 +134,35 @@ public class DefaultEnvironmentProviderTests
     }
 
     [Fact]
+    public void DefaultEnvironmentProvider_IgnoresBlankSplitCommandLineEnvironment()
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Production");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+
+            var provider = new DefaultEnvironmentProvider(["--environment", " "]);
+
+            Assert.Equal("Development", provider.Environment);
+            Assert.True(provider.IsDevelopment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
+    [Fact]
+    public void DefaultEnvironmentProvider_Throws_WhenArgsIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DefaultEnvironmentProvider(null!));
+    }
+
+    [Fact]
     public void GetEnvironmentVariable_ReturnsEmptyString_WhenVariableIsExplicitlyEmpty()
     {
         var variableName = $"APPSURFACE_TEST_{Guid.NewGuid():N}";

--- a/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
@@ -185,6 +185,35 @@ public class DefaultEnvironmentProviderTests
     }
 
     [Fact]
+    public void DefaultEnvironmentProvider_IgnoresOptionLikeTokenAfterEnvironment()
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Production");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Staging");
+
+            var provider = new DefaultEnvironmentProvider([
+                "--environment",
+                "--urls",
+                "http://localhost:5001",
+                "--environment",
+                "Development"
+            ]);
+
+            Assert.Equal("Development", provider.Environment);
+            Assert.True(provider.IsDevelopment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
+    [Fact]
     public void DefaultEnvironmentProvider_Throws_WhenArgsIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => new DefaultEnvironmentProvider(null!));

--- a/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
@@ -241,6 +241,34 @@ public class DefaultEnvironmentProviderTests
     }
 
     [Fact]
+    public void DefaultEnvironmentProvider_IgnoresAssignmentShapedSplitEnvironmentValue()
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Production");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Staging");
+
+            var provider = new DefaultEnvironmentProvider([
+                "--environment",
+                "Dev=1",
+                "--environment",
+                "Development"
+            ]);
+
+            Assert.Equal("Development", provider.Environment);
+            Assert.True(provider.IsDevelopment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
+    [Fact]
     public void DefaultEnvironmentProvider_Throws_WhenArgsIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => new DefaultEnvironmentProvider(null!));

--- a/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
@@ -73,6 +73,66 @@ public class DefaultEnvironmentProviderTests
         Assert.False(provider.IsDevelopment);
     }
 
+    [Theory]
+    [InlineData("--environment", "Development", "Development", true)]
+    [InlineData("--environment", "Production", "Production", false)]
+    [InlineData("--environment=Development", null, "Development", true)]
+    [InlineData("--environment=Production", null, "Production", false)]
+    public void DefaultEnvironmentProvider_PrefersCommandLineEnvironmentOverEnvironmentVariables(
+        string environmentOption,
+        string? environmentValue,
+        string expectedEnvironment,
+        bool expectedIsDevelopment)
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Development");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+
+            string[] args = environmentValue is null
+                ? [environmentOption]
+                : [environmentOption, environmentValue];
+
+            var provider = new DefaultEnvironmentProvider(args);
+
+            Assert.Equal(expectedEnvironment, provider.Environment);
+            Assert.Equal(expectedIsDevelopment, provider.IsDevelopment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
+    [Theory]
+    [InlineData("--environment")]
+    [InlineData("--environment=")]
+    public void DefaultEnvironmentProvider_IgnoresBlankCommandLineEnvironment(string environmentOption)
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Staging");
+
+            var provider = new DefaultEnvironmentProvider([environmentOption]);
+
+            Assert.Equal("Staging", provider.Environment);
+            Assert.False(provider.IsDevelopment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
     [Fact]
     public void GetEnvironmentVariable_ReturnsEmptyString_WhenVariableIsExplicitlyEmpty()
     {

--- a/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
@@ -214,6 +214,33 @@ public class DefaultEnvironmentProviderTests
     }
 
     [Fact]
+    public void DefaultEnvironmentProvider_UsesLastValidCommandLineEnvironment()
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Staging");
+
+            var provider = new DefaultEnvironmentProvider([
+                "--environment",
+                "Production",
+                "--environment=Development"
+            ]);
+
+            Assert.Equal("Development", provider.Environment);
+            Assert.True(provider.IsDevelopment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
+    [Fact]
     public void DefaultEnvironmentProvider_Throws_WhenArgsIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => new DefaultEnvironmentProvider(null!));

--- a/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/DefaultEnvironmentProviderTests.cs
@@ -157,6 +157,34 @@ public class DefaultEnvironmentProviderTests
     }
 
     [Fact]
+    public void DefaultEnvironmentProvider_HandlesBlankThenValidCommandLineEnvironment()
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Production");
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Staging");
+
+            var provider = new DefaultEnvironmentProvider([
+                "--environment",
+                " ",
+                "--environment",
+                "Development"
+            ]);
+
+            Assert.Equal("Development", provider.Environment);
+            Assert.True(provider.IsDevelopment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
+    [Fact]
     public void DefaultEnvironmentProvider_Throws_WhenArgsIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => new DefaultEnvironmentProvider(null!));

--- a/ForgeTrust.AppSurface.Core.Tests/StartupContextTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/StartupContextTests.cs
@@ -36,6 +36,15 @@ public class StartupContextTests
         Assert.Equal(ConsoleOutputMode.CommandFirst, context.ConsoleOutputMode);
     }
 
+    [Fact]
+    public void EnvironmentProvider_DefaultsToCommandLineAwareProvider()
+    {
+        var context = new StartupContext(["--environment", Environments.Development], new DummyModule());
+
+        Assert.True(context.IsDevelopment);
+        Assert.Equal(Environments.Development, context.EnvironmentProvider.Environment);
+    }
+
     [Theory]
     [InlineData(ConsoleOutputMode.Default, 0)]
     [InlineData(ConsoleOutputMode.CommandFirst, 1)]

--- a/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
+++ b/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
@@ -100,12 +100,20 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
                 continue;
             }
 
-            if (index + 1 >= args.Count || string.IsNullOrWhiteSpace(args[index + 1]))
+            if (index + 1 >= args.Count)
             {
                 continue;
             }
 
-            return args[index + 1];
+            var environmentValue = args[index + 1];
+            if (string.IsNullOrWhiteSpace(environmentValue)
+                || environmentValue.StartsWith("-", StringComparison.Ordinal)
+                || environmentValue.Contains('='))
+            {
+                continue;
+            }
+
+            return environmentValue;
         }
 
         return null;

--- a/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
+++ b/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
@@ -87,7 +87,12 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
             if (arg.StartsWith(environmentPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 var inlineValue = arg[environmentPrefix.Length..];
-                return string.IsNullOrWhiteSpace(inlineValue) ? null : inlineValue;
+                if (string.IsNullOrWhiteSpace(inlineValue))
+                {
+                    continue;
+                }
+
+                return inlineValue;
             }
 
             if (!string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
@@ -97,7 +102,7 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
 
             if (index + 1 >= args.Count || string.IsNullOrWhiteSpace(args[index + 1]))
             {
-                return null;
+                continue;
             }
 
             return args[index + 1];

--- a/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
+++ b/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
@@ -4,8 +4,9 @@ using Microsoft.Extensions.Hosting;
 
 /// <summary>
 ///    Default implementation of <see cref="IEnvironmentProvider"/> that retrieves the environment from
-/// system environment variables. It checks for "ASPNETCORE_ENVIRONMENT" first, then "DOTNET_ENVIRONMENT",
-/// and defaults to "Production" if neither is set.
+/// command-line host arguments or system environment variables. Command-line <c>--environment</c> wins when supplied,
+/// otherwise it checks for "ASPNETCORE_ENVIRONMENT" first, then "DOTNET_ENVIRONMENT", and defaults to "Production" if
+/// neither is set.
 ///
 /// Can be overridden by passing a custom implementation to the <see cref="StartupContext"/>,
 /// when building the host.
@@ -16,9 +17,26 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
     /// Initializes a new instance of the <see cref="DefaultEnvironmentProvider"/> class.
     /// </summary>
     public DefaultEnvironmentProvider()
+        : this([])
     {
-        // Prefer ASPNETCORE_ENVIRONMENT for Generic Host, fallback to DOTNET_ENVIRONMENT, default to Production
-        var env = System.Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultEnvironmentProvider"/> class using startup arguments.
+    /// </summary>
+    /// <param name="args">Command-line arguments supplied to the host startup pipeline.</param>
+    /// <remarks>
+    /// Pass the same arguments supplied to the Generic Host so AppSurface module configuration sees the same
+    /// environment as host configuration. The provider recognizes <c>--environment Development</c> and
+    /// <c>--environment=Development</c>. Blank command-line values are ignored and fall back to environment variables.
+    /// </remarks>
+    public DefaultEnvironmentProvider(IReadOnlyList<string> args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        // Prefer explicit host command-line configuration, then ASPNETCORE_ENVIRONMENT, then DOTNET_ENVIRONMENT.
+        var env = ResolveEnvironmentArgument(args)
+                  ?? System.Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
                   ?? System.Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
                   ?? Environments.Production;
 
@@ -29,8 +47,8 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
     /// <summary>
     /// The current environment name.
     ///
-    /// Read from "ASPNETCORE_ENVIRONMENT" or "DOTNET_ENVIRONMENT" environment variables,
-    /// defaults to "Production" if neither is set.
+    /// Read from command-line <c>--environment</c>, "ASPNETCORE_ENVIRONMENT", or "DOTNET_ENVIRONMENT"; defaults to
+    /// "Production" if none is set.
     /// </summary>
     public string Environment { get; }
 
@@ -58,5 +76,33 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
         var value = System.Environment.GetEnvironmentVariable(name);
 
         return value ?? defaultValue;
+    }
+
+    private static string? ResolveEnvironmentArgument(IReadOnlyList<string> args)
+    {
+        for (var index = 0; index < args.Count; index++)
+        {
+            var arg = args[index];
+            const string environmentPrefix = "--environment=";
+            if (arg.StartsWith(environmentPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                var inlineValue = arg[environmentPrefix.Length..];
+                return string.IsNullOrWhiteSpace(inlineValue) ? null : inlineValue;
+            }
+
+            if (!string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (index + 1 >= args.Count || string.IsNullOrWhiteSpace(args[index + 1]))
+            {
+                return null;
+            }
+
+            return args[index + 1];
+        }
+
+        return null;
     }
 }

--- a/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
+++ b/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
@@ -78,8 +78,21 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
         return value ?? defaultValue;
     }
 
-    private static string? ResolveEnvironmentArgument(IReadOnlyList<string> args)
+    /// <summary>
+    /// Resolves the effective command-line environment value from host arguments.
+    /// </summary>
+    /// <remarks>
+    /// Recognizes split and inline forms such as <c>--environment Development</c> and
+    /// <c>--environment=Development</c>. Blank, switch-like, or assignment-shaped split values are ignored, and the
+    /// last valid command-line value wins to match Microsoft configuration duplicate-key behavior. Returns
+    /// <see langword="null"/> when the arguments do not contain a valid command-line environment value.
+    /// </remarks>
+    /// <param name="args">Command-line arguments supplied to the host startup pipeline.</param>
+    /// <returns>The last valid command-line environment value, or <see langword="null"/> when none is supplied.</returns>
+    public static string? ResolveEnvironmentArgument(IReadOnlyList<string> args)
     {
+        ArgumentNullException.ThrowIfNull(args);
+
         string? environmentName = null;
 
         for (var index = 0; index < args.Count; index++)

--- a/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
+++ b/ForgeTrust.AppSurface.Core/Defaults/DefaultEnvironmentProvider.cs
@@ -80,6 +80,8 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
 
     private static string? ResolveEnvironmentArgument(IReadOnlyList<string> args)
     {
+        string? environmentName = null;
+
         for (var index = 0; index < args.Count; index++)
         {
             var arg = args[index];
@@ -87,12 +89,12 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
             if (arg.StartsWith(environmentPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 var inlineValue = arg[environmentPrefix.Length..];
-                if (string.IsNullOrWhiteSpace(inlineValue))
+                if (!string.IsNullOrWhiteSpace(inlineValue))
                 {
-                    continue;
+                    environmentName = inlineValue;
                 }
 
-                return inlineValue;
+                continue;
             }
 
             if (!string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
@@ -113,9 +115,10 @@ public class DefaultEnvironmentProvider : IEnvironmentProvider
                 continue;
             }
 
-            return environmentValue;
+            environmentName = environmentValue;
+            index++;
         }
 
-        return null;
+        return environmentName;
     }
 }

--- a/ForgeTrust.AppSurface.Core/README.md
+++ b/ForgeTrust.AppSurface.Core/README.md
@@ -27,6 +27,17 @@ The Core library is designed to be lightweight and implementation-agnostic. It p
 
 Keep these values separate. ASP.NET static web assets use the host application name to find runtime manifests. Passing a custom display label such as `CustomDocsHost` into the host environment can make static asset requests resolve against a manifest that does not exist. When a test or custom host needs a different manifest identity, set `StartupContext.OverrideEntryPointAssembly` instead of overloading `ApplicationName`.
 
+## Environment resolution
+
+`StartupContext.EnvironmentProvider` defaults to `DefaultEnvironmentProvider`, which keeps AppSurface module decisions aligned with the Generic Host arguments. When startup receives `--environment Development` or `--environment=Development`, `StartupContext.IsDevelopment` reports `true` before module hooks run.
+
+If no command-line environment is supplied, AppSurface falls back to `ASPNETCORE_ENVIRONMENT`, then `DOTNET_ENVIRONMENT`, then `Production`. Pass a custom `IEnvironmentProvider` to `StartupContext` when a test, embedded host, or specialized runner needs a different source of truth. Blank `--environment` values are ignored so normal process environment fallback still works.
+
+Pitfalls:
+
+- Do not read only `IHostEnvironment` when writing module startup decisions. Module hooks receive `StartupContext` before the built host exists.
+- Do not pass `--environment` only to the Generic Host if an AppSurface module also needs the same value. Put it in `StartupContext.Args`, or pass a matching custom `IEnvironmentProvider`.
+
 ## Startup dependency graph
 
 `AppSurfaceStartup` registers framework dependencies and root-module dependencies exactly once per `StartupContext`. Standard hosts do not need to call anything directly: the registration happens during host-builder creation before module hooks and service registration run.

--- a/ForgeTrust.AppSurface.Core/README.md
+++ b/ForgeTrust.AppSurface.Core/README.md
@@ -31,7 +31,7 @@ Keep these values separate. ASP.NET static web assets use the host application n
 
 `StartupContext.EnvironmentProvider` defaults to `DefaultEnvironmentProvider`, which keeps AppSurface module decisions aligned with the Generic Host arguments. When startup receives `--environment Development` or `--environment=Development`, `StartupContext.IsDevelopment` reports `true` before module hooks run.
 
-If no command-line environment is supplied, AppSurface falls back to `ASPNETCORE_ENVIRONMENT`, then `DOTNET_ENVIRONMENT`, then `Production`. Pass a custom `IEnvironmentProvider` to `StartupContext` when a test, embedded host, or specialized runner needs a different source of truth. Blank `--environment` values are ignored so normal process environment fallback still works.
+If no command-line environment is supplied, AppSurface falls back to `ASPNETCORE_ENVIRONMENT`, then `DOTNET_ENVIRONMENT`, then `Production`. Pass a custom `IEnvironmentProvider` to `StartupContext` when a test, embedded host, or specialized runner needs a different source of truth. `DefaultEnvironmentProvider.ResolveEnvironmentArgument` is the shared parser for AppSurface hosts: blank, switch-like, and assignment-shaped split values are ignored, while duplicate `--environment` keys use the last valid value to match Microsoft configuration behavior.
 
 Pitfalls:
 

--- a/ForgeTrust.AppSurface.Core/StartupContext.cs
+++ b/ForgeTrust.AppSurface.Core/StartupContext.cs
@@ -90,7 +90,7 @@ public record StartupContext(
     /// <summary>
     /// Gets the environment provider for the application.
     /// </summary>
-    public IEnvironmentProvider EnvironmentProvider { get; } = EnvironmentProvider ?? new DefaultEnvironmentProvider();
+    public IEnvironmentProvider EnvironmentProvider { get; } = EnvironmentProvider ?? new DefaultEnvironmentProvider(Args);
 
     /// <summary>
     /// Gets a value indicating whether the current environment is development.

--- a/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
@@ -13,7 +13,7 @@ This project is the thin executable wrapper around the reusable [ForgeTrust.AppS
 For public command-line workflows, use the AppSurface CLI as the public command surface:
 
 ```bash
-dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http://127.0.0.1:5189
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo .
 ```
 
 The CLI delegates to this standalone host, so the host remains the source of truth for RazorDocs startup, static web assets, routes, and configuration binding.
@@ -51,6 +51,7 @@ Strict mode fails only when every configured harvester fails, times out, or canc
 When you run this host in `Development` without explicit endpoint configuration, AppSurface Web assigns a deterministic localhost-only development URL from the current workspace path. That keeps sibling worktrees from colliding on the same default localhost URL.
 
 - The standalone host redirects `/` to the configured RazorDocs home, `/docs` by default. The reusable RazorDocs package keeps embedded apps isolated to their configured docs routes; this root redirect exists only because this executable is a docs-only host and CI export target.
+- The public `appsurface docs` and `appsurface docs preview` commands default the forwarded host environment to `Development`, so omitting `--urls` and `--port` uses this deterministic local URL behavior.
 - Use the startup log as the source of truth for the selected local URL.
 - Pass `--port 5189`, `--urls http://127.0.0.1:5189`, `ASPNETCORE_HTTP_PORTS=5189`, or a `Kestrel:Endpoints` appsettings/environment entry when you intentionally want a fixed address.
 - The checked-in launch profile no longer pins a single shared localhost port, because that was the source of cross-worktree QA confusion.

--- a/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
@@ -51,7 +51,7 @@ Strict mode fails only when every configured harvester fails, times out, or canc
 When you run this host in `Development` without explicit endpoint configuration, AppSurface Web assigns a deterministic localhost-only development URL from the current workspace path. That keeps sibling worktrees from colliding on the same default localhost URL.
 
 - The standalone host redirects `/` to the configured RazorDocs home, `/docs` by default. The reusable RazorDocs package keeps embedded apps isolated to their configured docs routes; this root redirect exists only because this executable is a docs-only host and CI export target.
-- The public `appsurface docs` and `appsurface docs preview` commands default the forwarded host environment to `Development`, so omitting `--urls` and `--port` uses this deterministic local URL behavior.
+- The public `appsurface docs` and `appsurface docs preview` commands default the forwarded host environment to `Development`, so when no endpoint is configured they use this deterministic local URL behavior.
 - Use the startup log as the source of truth for the selected local URL.
 - Pass `--port 5189`, `--urls http://127.0.0.1:5189`, `ASPNETCORE_HTTP_PORTS=5189`, or a `Kestrel:Endpoints` appsettings/environment entry when you intentionally want a fixed address.
 - The checked-in launch profile no longer pins a single shared localhost port, because that was the source of cross-worktree QA confusion.

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -916,10 +916,10 @@ dotnet run --project Web/ForgeTrust.AppSurface.Docs.Standalone -- --urls http://
 Or use the AppSurface CLI shape, which keeps RazorDocs workflows under the `appsurface` command family:
 
 ```bash
-dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http://localhost:5189
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo .
 ```
 
-Then open the configured docs home, `http://localhost:5189/docs` by default. The standalone host remains the reusable runtime seam; `appsurface docs` is the public CLI entry point for the same preview workflow rather than a separate `razordocs` tool.
+Then open the docs home printed in the startup log. The AppSurface CLI defaults the host environment to `Development`, so omitting `--urls` and `--port` uses AppSurface Web's deterministic per-workspace localhost URL. The standalone host remains the reusable runtime seam; `appsurface docs` is the public CLI entry point for the same preview workflow rather than a separate `razordocs` tool.
 
 ### Fallback and visibility rules
 

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -919,7 +919,7 @@ Or use the AppSurface CLI shape, which keeps RazorDocs workflows under the `apps
 dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo .
 ```
 
-Then open the docs home printed in the startup log. The AppSurface CLI defaults the host environment to `Development`, so omitting `--urls` and `--port` uses AppSurface Web's deterministic per-workspace localhost URL. The standalone host remains the reusable runtime seam; `appsurface docs` is the public CLI entry point for the same preview workflow rather than a separate `razordocs` tool.
+Then open the docs home printed in the startup log. The AppSurface CLI defaults the host environment to `Development`, so when no endpoint is configured it uses AppSurface Web's deterministic per-workspace localhost URL. The standalone host remains the reusable runtime seam; `appsurface docs` is the public CLI entry point for the same preview workflow rather than a separate `razordocs` tool.
 
 ### Fallback and visibility rules
 

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -61,6 +61,65 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
     }
 
     [Fact]
+    public void Resolve_AppendsDeterministicPort_WhenCommandLineEnvironmentIsDevelopment()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { "--environment", Environments.Development };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            _ => null);
+
+        Assert.NotNull(resolution.AppliedPort);
+        Assert.Equal(
+            ["--environment", Environments.Development, "--urls", $"http://localhost:{resolution.AppliedPort.Value}"],
+            resolution.Args);
+    }
+
+    [Fact]
+    public void Resolve_AppendsDeterministicPort_WhenCommandLineEnvironmentIsDevelopmentInline()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { $"--environment={Environments.Development}" };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            _ => null);
+
+        Assert.NotNull(resolution.AppliedPort);
+        Assert.Equal(
+            [$"--environment={Environments.Development}", "--urls", $"http://localhost:{resolution.AppliedPort.Value}"],
+            resolution.Args);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotAppendDeterministicPort_WhenCommandLineEnvironmentIsProduction()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { "--environment", Environments.Production };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            ReadDevelopmentEnvironment);
+
+        Assert.Null(resolution.AppliedPort);
+        Assert.Same(args, resolution.Args);
+        Assert.Null(resolution.SeedPath);
+    }
+
+    [Fact]
     public void Resolve_AppendsDeterministicPort_WhenDotnetEnvironmentIsDevelopment()
     {
         using var environment = new TemporaryEnvironment();

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -197,6 +197,26 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
     }
 
     [Fact]
+    public void Resolve_UsesLastValidCommandLineEnvironment()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { "--environment", Environments.Production, $"--environment={Environments.Development}" };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            ReadDevelopmentEnvironment);
+
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
+        Assert.Equal(
+            ["--environment", Environments.Production, $"--environment={Environments.Development}", "--urls", $"http://localhost:{appliedPort}"],
+            resolution.Args);
+    }
+
+    [Fact]
     public void Resolve_AppendsDeterministicPort_WhenDotnetEnvironmentIsDevelopment()
     {
         using var environment = new TemporaryEnvironment();

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -119,6 +119,43 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
         Assert.Null(resolution.SeedPath);
     }
 
+    [Theory]
+    [InlineData("--environment")]
+    [InlineData("--environment=")]
+    public void Resolve_FallsBackToEnvironmentVariables_WhenCommandLineEnvironmentIsBlank(string environmentOption)
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            [environmentOption],
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            ReadDevelopmentEnvironment);
+
+        Assert.NotNull(resolution.AppliedPort);
+        Assert.Equal([environmentOption, "--urls", $"http://localhost:{resolution.AppliedPort.Value}"], resolution.Args);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToEnvironmentVariables_WhenSplitCommandLineEnvironmentIsBlank()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { "--environment", " " };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            ReadDevelopmentEnvironment);
+
+        Assert.NotNull(resolution.AppliedPort);
+        Assert.Equal(["--environment", " ", "--urls", $"http://localhost:{resolution.AppliedPort.Value}"], resolution.Args);
+    }
+
     [Fact]
     public void Resolve_AppendsDeterministicPort_WhenDotnetEnvironmentIsDevelopment()
     {

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -177,6 +177,26 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
     }
 
     [Fact]
+    public void Resolve_AppendsDeterministicPort_WhenEnvironmentValueIsAnotherOption()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { "--environment", "--docs-root", "/docs", "--environment", Environments.Development };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            ReadDevelopmentEnvironment);
+
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
+        Assert.Equal(
+            ["--environment", "--docs-root", "/docs", "--environment", Environments.Development, "--urls", $"http://localhost:{appliedPort}"],
+            resolution.Args);
+    }
+
+    [Fact]
     public void Resolve_AppendsDeterministicPort_WhenDotnetEnvironmentIsDevelopment()
     {
         using var environment = new TemporaryEnvironment();

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -217,6 +217,26 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
     }
 
     [Fact]
+    public void Resolve_IgnoresSplitEnvWithEquals_UsesLaterValidEnvironment()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { "--environment", "Dev=1", "--environment", Environments.Development };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            ReadDevelopmentEnvironment);
+
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
+        Assert.Equal(
+            ["--environment", "Dev=1", "--environment", Environments.Development, "--urls", $"http://localhost:{appliedPort}"],
+            resolution.Args);
+    }
+
+    [Fact]
     public void Resolve_AppendsDeterministicPort_WhenDotnetEnvironmentIsDevelopment()
     {
         using var environment = new TemporaryEnvironment();

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -157,6 +157,26 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
     }
 
     [Fact]
+    public void Resolve_AppendsDeterministicPort_WhenBlankThenValidCommandLineEnvironmentIsDevelopment()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var appBaseDirectory = environment.CreateApplicationBaseDirectory("workspace");
+        var args = new[] { "--environment", " ", "--environment", Environments.Development };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            appBaseDirectory,
+            ReadDevelopmentEnvironment);
+
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
+        Assert.Equal(
+            ["--environment", " ", "--environment", Environments.Development, "--urls", $"http://localhost:{appliedPort}"],
+            resolution.Args);
+    }
+
+    [Fact]
     public void Resolve_AppendsDeterministicPort_WhenDotnetEnvironmentIsDevelopment()
     {
         using var environment = new TemporaryEnvironment();

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -74,9 +74,9 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
             appBaseDirectory,
             _ => null);
 
-        Assert.NotNull(resolution.AppliedPort);
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
         Assert.Equal(
-            ["--environment", Environments.Development, "--urls", $"http://localhost:{resolution.AppliedPort.Value}"],
+            ["--environment", Environments.Development, "--urls", $"http://localhost:{appliedPort}"],
             resolution.Args);
     }
 
@@ -94,9 +94,9 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
             appBaseDirectory,
             _ => null);
 
-        Assert.NotNull(resolution.AppliedPort);
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
         Assert.Equal(
-            [$"--environment={Environments.Development}", "--urls", $"http://localhost:{resolution.AppliedPort.Value}"],
+            [$"--environment={Environments.Development}", "--urls", $"http://localhost:{appliedPort}"],
             resolution.Args);
     }
 
@@ -134,8 +134,8 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
             appBaseDirectory,
             ReadDevelopmentEnvironment);
 
-        Assert.NotNull(resolution.AppliedPort);
-        Assert.Equal([environmentOption, "--urls", $"http://localhost:{resolution.AppliedPort.Value}"], resolution.Args);
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
+        Assert.Equal([environmentOption, "--urls", $"http://localhost:{appliedPort}"], resolution.Args);
     }
 
     [Fact]
@@ -152,8 +152,8 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
             appBaseDirectory,
             ReadDevelopmentEnvironment);
 
-        Assert.NotNull(resolution.AppliedPort);
-        Assert.Equal(["--environment", " ", "--urls", $"http://localhost:{resolution.AppliedPort.Value}"], resolution.Args);
+        var appliedPort = Assert.IsType<int>(resolution.AppliedPort);
+        Assert.Equal(["--environment", " ", "--urls", $"http://localhost:{appliedPort}"], resolution.Args);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/AppSurfaceWebDevelopmentPortDefaultsTests.cs
@@ -462,6 +462,23 @@ public sealed class AppSurfaceWebDevelopmentPortDefaultsTests
         Assert.Same(args, resolution.Args);
     }
 
+    [Fact]
+    public void Resolve_DoesNotOverrideEndpointCommandLineConfiguration_WhenEnvironmentOptionIsDangling()
+    {
+        using var environment = new TemporaryEnvironment();
+        environment.CreateGitRepo("workspace");
+        var args = new[] { "--environment", "--http_ports", "5005" };
+
+        var resolution = AppSurfaceWebDevelopmentPortDefaults.Resolve(
+            args,
+            environment.WorkspaceRoot,
+            environment.CreateApplicationBaseDirectory("workspace"),
+            ReadDevelopmentEnvironment);
+
+        Assert.Null(resolution.AppliedPort);
+        Assert.Same(args, resolution.Args);
+    }
+
     [Theory]
     [InlineData("ASPNETCORE_URLS")]
     [InlineData("URLS")]

--- a/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/WebStartupTests.cs
@@ -398,6 +398,35 @@ public class WebStartupTests
     }
 
     [Fact]
+    public void ConfigureServices_Cors_EnableAllOriginsInDevelopment_WorksWithCommandLineEnvironment()
+    {
+        var previousDotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+
+            var root = new TestWebModule();
+            var startup = new TestWebStartup(root);
+            startup.WithOptions(o => o.Cors.EnableAllOriginsInDevelopment = true);
+
+            var context = new StartupContext(["--environment", Environments.Development], root);
+            var builder = ((IAppSurfaceStartup)startup).CreateHostBuilder(context);
+            using var host = builder.Build();
+
+            Assert.True(context.IsDevelopment);
+            Assert.NotNull(host.Services.GetService<ICorsService>());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", previousDotnetEnvironment);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetCoreEnvironment);
+        }
+    }
+
+    [Fact]
     public async Task ConfigureServices_Cors_SpecificOrigins_Works()
     {
         var previous = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
@@ -85,12 +85,20 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
                 continue;
             }
 
-            if (index + 1 >= args.Count || string.IsNullOrWhiteSpace(args[index + 1]))
+            if (index + 1 >= args.Count)
             {
                 continue;
             }
 
-            return args[index + 1];
+            var environmentValue = args[index + 1];
+            if (string.IsNullOrWhiteSpace(environmentValue)
+                || environmentValue.StartsWith("-", StringComparison.Ordinal)
+                || environmentValue.Contains('='))
+            {
+                continue;
+            }
+
+            return environmentValue;
         }
 
         return null;

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
@@ -65,6 +65,8 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
 
     private static string? ResolveEnvironmentArgument(IReadOnlyList<string> args)
     {
+        string? environmentName = null;
+
         for (var index = 0; index < args.Count; index++)
         {
             var arg = args[index];
@@ -72,12 +74,12 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
             if (arg.StartsWith(environmentPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 var inlineValue = arg[environmentPrefix.Length..];
-                if (string.IsNullOrWhiteSpace(inlineValue))
+                if (!string.IsNullOrWhiteSpace(inlineValue))
                 {
-                    continue;
+                    environmentName = inlineValue;
                 }
 
-                return inlineValue;
+                continue;
             }
 
             if (!string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
@@ -98,10 +100,11 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
                 continue;
             }
 
-            return environmentValue;
+            environmentName = environmentValue;
+            index++;
         }
 
-        return null;
+        return environmentName;
     }
 
     private static bool HasExplicitEndpointConfiguration(

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using ForgeTrust.AppSurface.Core.Defaults;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -57,54 +58,10 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
         IReadOnlyList<string> args,
         Func<string, string?> environmentReader)
     {
-        return ResolveEnvironmentArgument(args)
+        return DefaultEnvironmentProvider.ResolveEnvironmentArgument(args)
                ?? environmentReader("ASPNETCORE_ENVIRONMENT")
                ?? environmentReader("DOTNET_ENVIRONMENT")
                ?? Environments.Production;
-    }
-
-    private static string? ResolveEnvironmentArgument(IReadOnlyList<string> args)
-    {
-        string? environmentName = null;
-
-        for (var index = 0; index < args.Count; index++)
-        {
-            var arg = args[index];
-            const string environmentPrefix = "--environment=";
-            if (arg.StartsWith(environmentPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                var inlineValue = arg[environmentPrefix.Length..];
-                if (!string.IsNullOrWhiteSpace(inlineValue))
-                {
-                    environmentName = inlineValue;
-                }
-
-                continue;
-            }
-
-            if (!string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            if (index + 1 >= args.Count)
-            {
-                continue;
-            }
-
-            var environmentValue = args[index + 1];
-            if (string.IsNullOrWhiteSpace(environmentValue)
-                || environmentValue.StartsWith("-", StringComparison.Ordinal)
-                || environmentValue.Contains('='))
-            {
-                continue;
-            }
-
-            environmentName = environmentValue;
-            index++;
-        }
-
-        return environmentName;
     }
 
     private static bool HasExplicitEndpointConfiguration(

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
@@ -126,7 +126,7 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
             .SetBasePath(currentDirectory)
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
             .AddJsonFile($"appsettings.{environmentName}.json", optional: true, reloadOnChange: false)
-            .AddCommandLine(args.ToArray())
+            .AddCommandLine(BuildEndpointProbeArguments(args))
             .Build();
 
         return HasConfigurationValue(configuration, "urls")
@@ -136,6 +136,39 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
                    .GetSection("Kestrel:Endpoints")
                    .GetChildren()
                    .Any(endpoint => HasConfigurationValue(endpoint, "Url"));
+    }
+
+    private static string[] BuildEndpointProbeArguments(IReadOnlyList<string> args)
+    {
+        var probeArgs = new List<string>(args.Count);
+        for (var index = 0; index < args.Count; index++)
+        {
+            var arg = args[index];
+            if (arg.StartsWith("--environment=", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
+            {
+                if (index + 1 >= args.Count)
+                {
+                    continue;
+                }
+
+                var candidate = args[index + 1];
+                if (!candidate.StartsWith("-", StringComparison.Ordinal))
+                {
+                    index++;
+                }
+
+                continue;
+            }
+
+            probeArgs.Add(arg);
+        }
+
+        return [.. probeArgs];
     }
 
     private static bool HasConfigurationValue(

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
@@ -39,7 +39,7 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
         ArgumentNullException.ThrowIfNull(applicationBaseDirectory);
         ArgumentNullException.ThrowIfNull(environmentReader);
 
-        var environmentName = ResolveEnvironmentName(environmentReader);
+        var environmentName = ResolveEnvironmentName(args, environmentReader);
         if (!string.Equals(environmentName, Environments.Development, StringComparison.OrdinalIgnoreCase)
             || HasExplicitEndpointConfiguration(args, currentDirectory, environmentName, environmentReader, environmentVariableNames))
         {
@@ -53,11 +53,42 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
         return new([.. args, "--urls", url], port, seedPath);
     }
 
-    private static string ResolveEnvironmentName(Func<string, string?> environmentReader)
+    private static string ResolveEnvironmentName(
+        IReadOnlyList<string> args,
+        Func<string, string?> environmentReader)
     {
-        return environmentReader("ASPNETCORE_ENVIRONMENT")
+        return ResolveEnvironmentArgument(args)
+               ?? environmentReader("ASPNETCORE_ENVIRONMENT")
                ?? environmentReader("DOTNET_ENVIRONMENT")
                ?? Environments.Production;
+    }
+
+    private static string? ResolveEnvironmentArgument(IReadOnlyList<string> args)
+    {
+        for (var index = 0; index < args.Count; index++)
+        {
+            var arg = args[index];
+            const string environmentPrefix = "--environment=";
+            if (arg.StartsWith(environmentPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                var inlineValue = arg[environmentPrefix.Length..];
+                return string.IsNullOrWhiteSpace(inlineValue) ? null : inlineValue;
+            }
+
+            if (!string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (index + 1 >= args.Count || string.IsNullOrWhiteSpace(args[index + 1]))
+            {
+                return null;
+            }
+
+            return args[index + 1];
+        }
+
+        return null;
     }
 
     private static bool HasExplicitEndpointConfiguration(

--- a/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
+++ b/Web/ForgeTrust.AppSurface.Web/AppSurfaceWebDevelopmentPortDefaults.cs
@@ -72,7 +72,12 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
             if (arg.StartsWith(environmentPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 var inlineValue = arg[environmentPrefix.Length..];
-                return string.IsNullOrWhiteSpace(inlineValue) ? null : inlineValue;
+                if (string.IsNullOrWhiteSpace(inlineValue))
+                {
+                    continue;
+                }
+
+                return inlineValue;
             }
 
             if (!string.Equals(arg, "--environment", StringComparison.OrdinalIgnoreCase))
@@ -82,7 +87,7 @@ internal static class AppSurfaceWebDevelopmentPortDefaults
 
             if (index + 1 >= args.Count || string.IsNullOrWhiteSpace(args[index + 1]))
             {
-                return null;
+                continue;
             }
 
             return args[index + 1];

--- a/Web/ForgeTrust.AppSurface.Web/README.md
+++ b/Web/ForgeTrust.AppSurface.Web/README.md
@@ -145,6 +145,7 @@ The web application supports standard ASP.NET Core configuration sources (comman
 When an AppSurface web application starts in `Development` without explicit endpoint configuration, AppSurface Web chooses a deterministic localhost-only fallback URL based on the current workspace path. That gives each local worktree a stable URL instead of every development environment fighting for the same hard-coded dev port.
 
 - Use this default for local `dotnet run` convenience when you do not care about a specific port ahead of time.
+- AppSurface treats `--environment Development`, `ASPNETCORE_ENVIRONMENT=Development`, and `DOTNET_ENVIRONMENT=Development` as development for both the deterministic port resolver and module-level `StartupContext.IsDevelopment` decisions.
 - Override it any time with `--port`, `--urls`, `ASPNETCORE_URLS`/`URLS`, `ASPNETCORE_HTTP_PORTS`/`DOTNET_HTTP_PORTS`/`HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`/`DOTNET_HTTPS_PORTS`/`HTTPS_PORTS`, `urls`/`http_ports`/`https_ports` in appsettings, or `Kestrel:Endpoints` in appsettings/environment variables.
 - Treat the startup log as the source of truth for the selected local URL.
 - The automatic fallback binds only `http://localhost:{port}`. Use `--port` or an explicit wildcard URL when you intentionally need LAN/container access.

--- a/Web/ForgeTrust.AppSurface.Web/README.md
+++ b/Web/ForgeTrust.AppSurface.Web/README.md
@@ -145,7 +145,7 @@ The web application supports standard ASP.NET Core configuration sources (comman
 When an AppSurface web application starts in `Development` without explicit endpoint configuration, AppSurface Web chooses a deterministic localhost-only fallback URL based on the current workspace path. That gives each local worktree a stable URL instead of every development environment fighting for the same hard-coded dev port.
 
 - Use this default for local `dotnet run` convenience when you do not care about a specific port ahead of time.
-- AppSurface treats `--environment Development`, `ASPNETCORE_ENVIRONMENT=Development`, and `DOTNET_ENVIRONMENT=Development` as development for both the deterministic port resolver and module-level `StartupContext.IsDevelopment` decisions.
+- AppSurface treats `--environment Development`, `ASPNETCORE_ENVIRONMENT=Development`, and `DOTNET_ENVIRONMENT=Development` as development for both the deterministic port resolver and module-level `StartupContext.IsDevelopment` decisions. Command-line environment parsing is shared with `DefaultEnvironmentProvider`, so duplicate `--environment` keys use the last valid value.
 - Override it any time with `--port`, `--urls`, `ASPNETCORE_URLS`/`URLS`, `ASPNETCORE_HTTP_PORTS`/`DOTNET_HTTP_PORTS`/`HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`/`DOTNET_HTTPS_PORTS`/`HTTPS_PORTS`, `urls`/`http_ports`/`https_ports` in appsettings, or `Kestrel:Endpoints` in appsettings/environment variables.
 - Treat the startup log as the source of truth for the selected local URL.
 - The automatic fallback binds only `http://localhost:{port}`. Use `--port` or an explicit wildcard URL when you intentionally need LAN/container access.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -49,7 +49,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorWire CLI validation errors now include a concrete source-selection example and `razorwire export --help` hint, so a failed export tells developers the next useful command instead of only naming the bad input.
 - RazorWire CLI users who still want extensionless, server-routed export output should pass `--mode hybrid`. The default `cdn` mode is for plain static hosts and CDNs, not S3-specific infrastructure.
 - PackageIndex now has a real `--help`/`-h` surface that exits successfully, describes its commands and options, and reports unknown commands before printing usage.
-- AppSurface docs preview now defaults to the Development host environment when no `--environment` is supplied, so local `appsurface docs` runs use the deterministic per-workspace localhost port instead of falling through to Kestrel's port `5000` default.
+- AppSurface docs preview now defaults to the Development host environment when no `--environment` is supplied, so local `appsurface docs` runs with no configured endpoint use the deterministic per-workspace localhost port instead of falling through to Kestrel's port `5000` default.
 
 ### Core diagnostics
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -49,6 +49,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorWire CLI validation errors now include a concrete source-selection example and `razorwire export --help` hint, so a failed export tells developers the next useful command instead of only naming the bad input.
 - RazorWire CLI users who still want extensionless, server-routed export output should pass `--mode hybrid`. The default `cdn` mode is for plain static hosts and CDNs, not S3-specific infrastructure.
 - PackageIndex now has a real `--help`/`-h` surface that exits successfully, describes its commands and options, and reports unknown commands before printing usage.
+- AppSurface docs preview now defaults to the Development host environment when no `--environment` is supplied, so local `appsurface docs` runs use the deterministic per-workspace localhost port instead of falling through to Kestrel's port `5000` default.
 
 ### Core diagnostics
 
@@ -73,6 +74,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 ### Web host development defaults
 
 - AppSurface web hosts now choose a deterministic localhost-only development URL when no endpoint is configured, while production, staging, container, and appsettings-based endpoint choices remain untouched.
+- AppSurface startup environment resolution now treats command-line `--environment` as the highest-priority source before `ASPNETCORE_ENVIRONMENT` and `DOTNET_ENVIRONMENT`, keeping module startup context aligned with Generic Host configuration.
 - AppSurface web hosts now fail fast when startup does not complete before `WebOptions.StartupTimeout`, which defaults to 10 seconds and catches pre-bind stalls from sandbox restrictions, package layout issues, static asset discovery, or hosted services that block startup.
 - Startup watchdog failures now surface Codex sandbox markers, the observed startup phase, safe path context, static web asset mode, endpoint startup arguments, and a sandbox-first rerun recommendation when applicable.
 - OpenAPI's optional web package now has dedicated test coverage for service registration, endpoint mapping, generated document titles, and transformer behavior that removes `ForgeTrust.AppSurface.Web` tags at the document and operation levels while preserving unrelated tags, so the public module contract is guarded independently of Scalar.


### PR DESCRIPTION
## Summary

- Default `appsurface docs` preview runs to `Development` when no environment is provided.
- Teach AppSurface environment resolution to honor `--environment` before process environment variables.
- Keep deterministic per-workspace development port selection aligned between CLI, web host defaults, and module startup context.

## Why

The docs preview command could fall through to Kestrel's default `5000` binding instead of the repo's deterministic per-workspace development port. On this machine, `5000` is already owned by a local system service, so the preview host should avoid that path by default.

## Validation

- `dotnet test ForgeTrust.AppSurface.Core.Tests/ForgeTrust.AppSurface.Core.Tests.csproj --no-restore`
- `dotnet test Web/ForgeTrust.AppSurface.Web.Tests/ForgeTrust.AppSurface.Web.Tests.csproj --no-restore`
- `dotnet test Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj --no-restore`
- `dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes`
- `git diff --check`
- `/qa` browser pass: preview listened on `http://localhost:6477`, `Hosting environment: Development`, `/docs`, `/docs/search`, `/docs/packages`, `/docs/_health.json`, sidebar search, full search, and mobile nav all passed with no console errors.

QA report: `.gstack/qa-reports/qa-report-localhost-6477-2026-05-16-rerun.md`