### PR TITLE
test(docs): add RazorDocs JavaScript parser decision spike

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting" Version="9.4.2" />
+    <PackageVersion Include="Acornima" Version="1.6.1" />
     <PackageVersion Include="Autofac" Version="8.0.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageVersion Include="CliFx" Version="2.3.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting" Version="9.4.2" />
+    <!-- Acornima 1.6.1 is an intentional SemVer-stable NuGet pin for this test-only parser spike. -->
     <PackageVersion Include="Acornima" Version="1.6.1" />
     <PackageVersion Include="Autofac" Version="8.0.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Acornima" />
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="GitHubActionsTestLogger">

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/JavaScriptParserDecisionTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/JavaScriptParserDecisionTests.cs
@@ -1,0 +1,633 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using Acornima;
+using Acornima.Ast;
+using Xunit.Abstractions;
+using JsRange = Acornima.Range;
+
+namespace ForgeTrust.AppSurface.Docs.Tests;
+
+public sealed class JavaScriptParserDecisionTests
+{
+    private static readonly string FixtureDirectory = Path.Combine(
+        TestPathUtils.FindRepoRoot(AppContext.BaseDirectory),
+        "Web",
+        "ForgeTrust.AppSurface.Docs.Tests",
+        "TestData",
+        "JavaScriptParserDecision");
+
+    private readonly ITestOutputHelper _output;
+
+    public JavaScriptParserDecisionTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public static TheoryData<string, string, JavaScriptProbeKind, int, int> SupportedDeclarationFixtures()
+    {
+        return new TheoryData<string, string, JavaScriptProbeKind, int, int>
+        {
+            { "public-function.js", "wireForm", JavaScriptProbeKind.Function, 7, 0 },
+            { "public-arrow-function.js", "createFailureListener", JavaScriptProbeKind.Function, 5, 0 },
+            { "public-const-value.js", "streamTimeoutMs", JavaScriptProbeKind.Constant, 5, 0 },
+            { "window-razorwire-global.js", "window.RazorWire", JavaScriptProbeKind.Global, 6, 0 },
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedDeclarationFixtures))]
+    public void Acornima_Should_Attach_Leading_Public_Block_Comments_To_Supported_Declarations(
+        string fixtureName,
+        string expectedName,
+        JavaScriptProbeKind expectedKind,
+        int expectedLine,
+        int expectedColumn)
+    {
+        var source = ReadFixture(fixtureName);
+        var result = ProbeSource(source);
+
+        var item = Assert.Single(result.AttachedDoclets);
+        Assert.Equal(expectedName, item.Name);
+        Assert.Equal(expectedKind, item.Kind);
+        Assert.Equal(1, item.CommentLocation.Start.Line);
+        Assert.Equal(0, item.CommentLocation.Start.Column);
+        Assert.Equal(expectedLine, item.NodeLocation.Start.Line);
+        Assert.Equal(expectedColumn, item.NodeLocation.Start.Column);
+        Assert.True(item.CommentRange.Start >= 0);
+        Assert.True(item.CommentRange.End > item.CommentRange.Start);
+        Assert.True(item.NodeRange.End > item.NodeRange.Start);
+        Assert.Contains("@public", item.CommentText, StringComparison.Ordinal);
+        Assert.True(IsOnlyWhitespace(source, item.CommentRange.End, item.NodeRange.Start));
+    }
+
+    [Theory]
+    [InlineData("public-event-doclet.js", JavaScriptProbeKind.Event, "razorwire:form:failure")]
+    [InlineData("public-typedef-doclet.js", JavaScriptProbeKind.Typedef, "FormFailureDetail")]
+    public void Acornima_Should_Collect_Standalone_Public_Doclets(
+        string fixtureName,
+        JavaScriptProbeKind expectedKind,
+        string expectedName)
+    {
+        var source = ReadFixture(fixtureName);
+        var result = ProbeSource(source);
+
+        Assert.Empty(result.AttachedDoclets);
+        var item = Assert.Single(result.StandaloneDoclets);
+        Assert.Equal(expectedName, item.Name);
+        Assert.Equal(expectedKind, item.Kind);
+        Assert.Equal(1, item.CommentLocation.Start.Line);
+        Assert.Equal(0, item.CommentLocation.Start.Column);
+        Assert.Contains("@public", item.CommentText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Acornima_Should_Report_Catchable_Parse_Failure()
+    {
+        var source = ReadFixture("malformed.js");
+
+        var exception = Assert.ThrowsAny<ParseErrorException>(() => ProbeSource(source));
+
+        Assert.True(exception.LineNumber > 0);
+        Assert.True(exception.Column >= 0);
+        Assert.Contains("Unexpected", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Acornima_Should_Parse_Real_Assets_And_Record_Lightweight_Costs()
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var cases = new[]
+        {
+            ParseCostCase.RealFile(
+                "razorwire.js",
+                Path.Combine(repoRoot, "Web", "ForgeTrust.RazorWire", "wwwroot", "razorwire", "razorwire.js"),
+                expectedSuccess: true),
+            ParseCostCase.RealFile(
+                "search-client.js",
+                Path.Combine(repoRoot, "Web", "ForgeTrust.AppSurface.Docs", "wwwroot", "docs", "search-client.js"),
+                expectedSuccess: true),
+            ParseCostCase.SkippedFile(
+                "minisearch.min.js",
+                Path.Combine(repoRoot, "Web", "ForgeTrust.AppSurface.Docs", "wwwroot", "docs", "minisearch.min.js"),
+                "*.min.js remains excluded by default"),
+            ParseCostCase.Fixture("malformed.js", ReadFixture("malformed.js"), expectedSuccess: false),
+            ParseCostCase.Fixture("synthetic-large-public-doclet.js", CreateSyntheticPublicDocletFixture(750), expectedSuccess: true),
+        };
+
+        WarmParser();
+
+        foreach (var testCase in cases)
+        {
+            if (testCase.Skipped)
+            {
+                _output.WriteLine(
+                    FormattableString.Invariant(
+                        $"{testCase.Name}: {testCase.SizeBytes} bytes, skipped, {testCase.SkipReason}"));
+                continue;
+            }
+
+            var measurement = MeasureParseCost(testCase.Source);
+
+            Assert.Equal(testCase.ExpectedSuccess, measurement.Success);
+            Assert.True(measurement.Elapsed < TimeSpan.FromSeconds(5));
+            _output.WriteLine(
+                FormattableString.Invariant(
+                    $"{testCase.Name}: {testCase.SizeBytes} bytes, {measurement.Elapsed.TotalMilliseconds:F3} ms, success={measurement.Success}, nodes={measurement.NodeCount}, blockComments={measurement.BlockCommentCount}"));
+        }
+    }
+
+    [Fact]
+    public void Acornima_Bsd3Clause_Compliance_Case_Should_Be_Documented()
+    {
+        var repoRoot = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
+        var packageVersion = ReadCentralPackageVersion(repoRoot, "Acornima");
+        var nuspec = XDocument.Load(FindNuGetPackageFile(repoRoot, "acornima", packageVersion, "acornima.nuspec"));
+        var metadata = nuspec.Root?.Element(NuGetNuspecNamespace + "metadata")
+            ?? throw new InvalidOperationException("Acornima nuspec metadata was not found.");
+        var license = metadata.Element(NuGetNuspecNamespace + "license");
+
+        Assert.Equal("1.6.1", packageVersion);
+        Assert.Equal("expression", license?.Attribute("type")?.Value);
+        Assert.Equal("BSD-3-Clause", license?.Value);
+
+        var testProject = XDocument.Load(
+            Path.Combine(repoRoot, "Web", "ForgeTrust.AppSurface.Docs.Tests", "ForgeTrust.AppSurface.Docs.Tests.csproj"));
+        Assert.Equal("false", testProject.Descendants("IsPackable").Single().Value);
+        Assert.Contains(
+            testProject.Descendants("PackageReference"),
+            reference => string.Equals(reference.Attribute("Include")?.Value, "Acornima", StringComparison.Ordinal));
+        Assert.Equal(
+            ["Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj"],
+            FindProjectsReferencingPackage(repoRoot, "Acornima"));
+
+        var decision = File.ReadAllText(Path.Combine(FixtureDirectory, "README.md"));
+        Assert.Contains("## License Compliance Case", decision, StringComparison.Ordinal);
+        Assert.Contains("Current spike use", decision, StringComparison.Ordinal);
+        Assert.Contains("not redistributed", decision, StringComparison.Ordinal);
+        Assert.Contains("Future product use", decision, StringComparison.Ordinal);
+        Assert.Contains("third-party notice", decision, StringComparison.Ordinal);
+        Assert.Contains("No endorsement", decision, StringComparison.Ordinal);
+    }
+
+    private static string ReadFixture(string name)
+    {
+        return File.ReadAllText(Path.Combine(FixtureDirectory, name));
+    }
+
+    private static XNamespace NuGetNuspecNamespace { get; } =
+        XNamespace.Get("http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd");
+
+    private static string ReadCentralPackageVersion(string repoRoot, string packageId)
+    {
+        var packages = XDocument.Load(Path.Combine(repoRoot, "Directory.Packages.props"));
+        var version = packages
+            .Descendants("PackageVersion")
+            .Single(package => string.Equals(package.Attribute("Include")?.Value, packageId, StringComparison.Ordinal))
+            .Attribute("Version")
+            ?.Value;
+
+        return version ?? throw new InvalidOperationException($"No central package version was found for {packageId}.");
+    }
+
+    private static string FindNuGetPackageFile(string repoRoot, string packageId, string packageVersion, string fileName)
+    {
+        var assetsPath = Path.Combine(
+            repoRoot,
+            "Web",
+            "ForgeTrust.AppSurface.Docs.Tests",
+            "obj",
+            "project.assets.json");
+        using var assets = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        var packagesPath = assets.RootElement
+            .GetProperty("project")
+            .GetProperty("restore")
+            .GetProperty("packagesPath")
+            .GetString();
+
+        if (string.IsNullOrWhiteSpace(packagesPath))
+        {
+            throw new InvalidOperationException("NuGet packages path was not found in project.assets.json.");
+        }
+
+        return Path.Combine(packagesPath, packageId, packageVersion, fileName);
+    }
+
+    private static IReadOnlyList<string> FindProjectsReferencingPackage(string repoRoot, string packageId)
+    {
+        return Directory
+            .EnumerateFiles(repoRoot, "*.csproj", SearchOption.AllDirectories)
+            .Where(static path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => ProjectReferencesPackage(path, packageId))
+            .Select(path => Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool ProjectReferencesPackage(string projectPath, string packageId)
+    {
+        var project = XDocument.Load(projectPath);
+        return project
+            .Descendants("PackageReference")
+            .Any(reference => string.Equals(reference.Attribute("Include")?.Value, packageId, StringComparison.Ordinal));
+    }
+
+    private static JavaScriptProbeResult ProbeSource(string source)
+    {
+        var comments = new List<Comment>();
+        var parser = new Parser(new ParserOptions
+        {
+            EcmaVersion = EcmaVersion.Latest,
+            OnComment = (in Comment comment) => comments.Add(comment),
+        });
+
+        var script = parser.ParseScript(source);
+        var attachedCommentStarts = new HashSet<int>();
+        var attachedDoclets = new List<ObservedJavaScriptDoclet>();
+
+        foreach (var statement in script.Body)
+        {
+            switch (statement)
+            {
+                case FunctionDeclaration function:
+                    if (function.Id?.Name is not { } functionName)
+                    {
+                        break;
+                    }
+
+                    AddAttachedDoclet(
+                        comments,
+                        attachedCommentStarts,
+                        attachedDoclets,
+                        source,
+                        function,
+                        function,
+                        functionName,
+                        JavaScriptProbeKind.Function);
+                    break;
+
+                case VariableDeclaration declaration:
+                    foreach (var declarator in declaration.Declarations)
+                    {
+                        var name = declarator.Id is Identifier identifier ? identifier.Name : null;
+                        if (name is null)
+                        {
+                            continue;
+                        }
+
+                        var kind = declarator.Init is ArrowFunctionExpression or FunctionExpression
+                            ? JavaScriptProbeKind.Function
+                            : JavaScriptProbeKind.Constant;
+                        AddAttachedDoclet(
+                            comments,
+                            attachedCommentStarts,
+                            attachedDoclets,
+                            source,
+                            declaration,
+                            declaration,
+                            name,
+                            kind);
+                    }
+
+                    break;
+
+                case ExpressionStatement expressionStatement
+                    when expressionStatement.Expression is AssignmentExpression assignment
+                         && TryGetMemberPath(assignment.Left) is { } memberPath
+                         && memberPath.StartsWith("window.", StringComparison.Ordinal):
+                    AddAttachedDoclet(
+                        comments,
+                        attachedCommentStarts,
+                        attachedDoclets,
+                        source,
+                        expressionStatement,
+                        expressionStatement,
+                        memberPath,
+                        JavaScriptProbeKind.Global);
+                    break;
+            }
+        }
+
+        var standaloneDoclets = comments
+            .Where(comment => !attachedCommentStarts.Contains(comment.Start))
+            .Select(comment => TryCreateStandaloneDoclet(source, comment))
+            .Where(static doclet => doclet is not null)
+            .Select(static doclet => doclet!)
+            .ToArray();
+
+        return new JavaScriptProbeResult(attachedDoclets.ToArray(), standaloneDoclets);
+    }
+
+    private static void AddAttachedDoclet(
+        IReadOnlyList<Comment> comments,
+        ISet<int> attachedCommentStarts,
+        ICollection<ObservedJavaScriptDoclet> attachedDoclets,
+        string source,
+        Node attachmentNode,
+        Node provenanceNode,
+        string name,
+        JavaScriptProbeKind kind)
+    {
+        var comment = FindLeadingBlockComment(comments, attachmentNode, source);
+        if (comment is null)
+        {
+            return;
+        }
+
+        var commentText = GetCommentText(source, comment.Value);
+        if (!HasTag(commentText, "public"))
+        {
+            return;
+        }
+
+        attachedCommentStarts.Add(comment.Value.Start);
+        attachedDoclets.Add(new ObservedJavaScriptDoclet(
+            name,
+            kind,
+            commentText,
+            comment.Value.Range,
+            comment.Value.Location,
+            provenanceNode.Range,
+            provenanceNode.Location));
+    }
+
+    private static Comment? FindLeadingBlockComment(IReadOnlyList<Comment> comments, Node node, string source)
+    {
+        for (var index = comments.Count - 1; index >= 0; index--)
+        {
+            var comment = comments[index];
+            if (comment.Kind != CommentKind.Block || comment.End > node.Start)
+            {
+                continue;
+            }
+
+            return IsOnlyWhitespace(source, comment.End, node.Start) ? comment : null;
+        }
+
+        return null;
+    }
+
+    private static ObservedJavaScriptDoclet? TryCreateStandaloneDoclet(string source, Comment comment)
+    {
+        if (comment.Kind != CommentKind.Block)
+        {
+            return null;
+        }
+
+        var commentText = GetCommentText(source, comment);
+        if (!HasTag(commentText, "public"))
+        {
+            return null;
+        }
+
+        if (TryReadTagValue(commentText, "event") is { } eventName)
+        {
+            return new ObservedJavaScriptDoclet(
+                eventName,
+                JavaScriptProbeKind.Event,
+                commentText,
+                comment.Range,
+                comment.Location,
+                comment.Range,
+                comment.Location);
+        }
+
+        if (TryReadTagValue(commentText, "typedef") is { } typedefName)
+        {
+            return new ObservedJavaScriptDoclet(
+                typedefName,
+                JavaScriptProbeKind.Typedef,
+                commentText,
+                comment.Range,
+                comment.Location,
+                comment.Range,
+                comment.Location);
+        }
+
+        return null;
+    }
+
+    private static string? TryReadTagValue(string commentText, string tag)
+    {
+        foreach (var rawLine in commentText.Split('\n'))
+        {
+            var line = rawLine.Trim().TrimStart('*').Trim();
+            var prefix = "@" + tag;
+            if (!line.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var value = line[prefix.Length..].Trim();
+            if (value.Length == 0)
+            {
+                return null;
+            }
+
+            var spaceIndex = value.IndexOf(' ', StringComparison.Ordinal);
+            return spaceIndex < 0 ? value : value[..spaceIndex];
+        }
+
+        return null;
+    }
+
+    private static bool HasTag(string commentText, string tag)
+    {
+        return commentText.Contains("@" + tag, StringComparison.Ordinal);
+    }
+
+    private static string? TryGetMemberPath(Node node)
+    {
+        return node switch
+        {
+            Identifier identifier => identifier.Name,
+            MemberExpression memberExpression => TryGetMemberPath(memberExpression),
+            _ => null,
+        };
+    }
+
+    private static string? TryGetMemberPath(MemberExpression memberExpression)
+    {
+        var objectPath = TryGetMemberPath(memberExpression.Object);
+        if (objectPath is null)
+        {
+            return null;
+        }
+
+        var propertyName = memberExpression.Property switch
+        {
+            Identifier identifier => identifier.Name,
+            StringLiteral stringLiteral when memberExpression.Computed => stringLiteral.Value,
+            _ => null,
+        };
+
+        return propertyName is null
+            ? null
+            : objectPath + "." + propertyName;
+    }
+
+    private static string GetCommentText(string source, Comment comment)
+    {
+        return source[comment.ContentRange.Start..comment.ContentRange.End].Trim();
+    }
+
+    private static bool IsOnlyWhitespace(string source, int start, int end)
+    {
+        if (start > end)
+        {
+            return false;
+        }
+
+        for (var index = start; index < end; index++)
+        {
+            if (!char.IsWhiteSpace(source[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string CreateSyntheticPublicDocletFixture(int itemCount)
+    {
+        var builder = new StringBuilder(capacity: itemCount * 160);
+        builder.AppendLine("\"use strict\";");
+        builder.AppendLine();
+        for (var index = 0; index < itemCount; index++)
+        {
+            builder.AppendLine("/**");
+            builder.AppendLine(CultureInfo.InvariantCulture, $" * Synthetic public function {index}.");
+            builder.AppendLine(" * @public");
+            builder.AppendLine(CultureInfo.InvariantCulture, $" * @param {{string}} value{index} - Input value.");
+            builder.AppendLine(" */");
+            builder.AppendLine(CultureInfo.InvariantCulture, $"function syntheticPublic{index}(value{index}) {{");
+            builder.AppendLine(CultureInfo.InvariantCulture, $"  return value{index};");
+            builder.AppendLine("}");
+            builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    private static void WarmParser()
+    {
+        _ = MeasureParseCost("const warmup = 1;");
+    }
+
+    private static ParseMeasurement MeasureParseCost(string source)
+    {
+        var comments = new List<Comment>();
+        var parser = new Parser(new ParserOptions
+        {
+            EcmaVersion = EcmaVersion.Latest,
+            OnComment = (in Comment comment) => comments.Add(comment),
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var script = parser.ParseScript(source);
+            stopwatch.Stop();
+            return new ParseMeasurement(
+                Success: true,
+                Elapsed: stopwatch.Elapsed,
+                NodeCount: CountNodes(script),
+                BlockCommentCount: comments.Count(static comment => comment.Kind == CommentKind.Block));
+        }
+        catch (ParseErrorException)
+        {
+            stopwatch.Stop();
+            return new ParseMeasurement(
+                Success: false,
+                Elapsed: stopwatch.Elapsed,
+                NodeCount: 0,
+                BlockCommentCount: comments.Count(static comment => comment.Kind == CommentKind.Block));
+        }
+    }
+
+    private static int CountNodes(Node node)
+    {
+        var count = 1;
+        foreach (var child in node.ChildNodes)
+        {
+            count += CountNodes(child);
+        }
+
+        return count;
+    }
+
+    private sealed record ParseCostCase(
+        string Name,
+        string Source,
+        long SizeBytes,
+        bool ExpectedSuccess,
+        bool Skipped,
+        string? SkipReason)
+    {
+        public static ParseCostCase RealFile(string name, string path, bool expectedSuccess)
+        {
+            return new ParseCostCase(
+                name,
+                File.ReadAllText(path),
+                new FileInfo(path).Length,
+                expectedSuccess,
+                Skipped: false,
+                SkipReason: null);
+        }
+
+        public static ParseCostCase Fixture(string name, string source, bool expectedSuccess)
+        {
+            return new ParseCostCase(
+                name,
+                source,
+                Encoding.UTF8.GetByteCount(source),
+                expectedSuccess,
+                Skipped: false,
+                SkipReason: null);
+        }
+
+        public static ParseCostCase SkippedFile(string name, string path, string skipReason)
+        {
+            return new ParseCostCase(
+                name,
+                File.ReadAllText(path),
+                new FileInfo(path).Length,
+                ExpectedSuccess: false,
+                Skipped: true,
+                skipReason);
+        }
+    }
+
+    private sealed record JavaScriptProbeResult(
+        IReadOnlyList<ObservedJavaScriptDoclet> AttachedDoclets,
+        IReadOnlyList<ObservedJavaScriptDoclet> StandaloneDoclets);
+
+    private sealed record ObservedJavaScriptDoclet(
+        string Name,
+        JavaScriptProbeKind Kind,
+        string CommentText,
+        JsRange CommentRange,
+        SourceLocation CommentLocation,
+        JsRange NodeRange,
+        SourceLocation NodeLocation);
+
+    private sealed record ParseMeasurement(
+        bool Success,
+        TimeSpan Elapsed,
+        int NodeCount,
+        int BlockCommentCount);
+}
+
+public enum JavaScriptProbeKind
+{
+    Function,
+    Constant,
+    Global,
+    Event,
+    Typedef,
+}

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/JavaScriptParserDecisionTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/JavaScriptParserDecisionTests.cs
@@ -12,7 +12,7 @@ namespace ForgeTrust.AppSurface.Docs.Tests;
 
 public sealed class JavaScriptParserDecisionTests
 {
-    private static readonly string FixtureDirectory = Path.Combine(
+    private static readonly string FixtureDirectory = PathUnder(
         TestPathUtils.FindRepoRoot(AppContext.BaseDirectory),
         "Web",
         "ForgeTrust.AppSurface.Docs.Tests",
@@ -26,14 +26,14 @@ public sealed class JavaScriptParserDecisionTests
         _output = output;
     }
 
-    public static TheoryData<string, string, JavaScriptProbeKind, int, int> SupportedDeclarationFixtures()
+    public static TheoryData<string, string, string, int, int> SupportedDeclarationFixtures()
     {
-        return new TheoryData<string, string, JavaScriptProbeKind, int, int>
+        return new TheoryData<string, string, string, int, int>
         {
-            { "public-function.js", "wireForm", JavaScriptProbeKind.Function, 7, 0 },
-            { "public-arrow-function.js", "createFailureListener", JavaScriptProbeKind.Function, 5, 0 },
-            { "public-const-value.js", "streamTimeoutMs", JavaScriptProbeKind.Constant, 5, 0 },
-            { "window-razorwire-global.js", "window.RazorWire", JavaScriptProbeKind.Global, 6, 0 },
+            { "public-function.js", "wireForm", nameof(JavaScriptProbeKind.Function), 7, 0 },
+            { "public-arrow-function.js", "createFailureListener", nameof(JavaScriptProbeKind.Function), 5, 0 },
+            { "public-const-value.js", "streamTimeoutMs", nameof(JavaScriptProbeKind.Constant), 5, 0 },
+            { "window-razorwire-global.js", "window.RazorWire", nameof(JavaScriptProbeKind.Global), 6, 0 },
         };
     }
 
@@ -42,7 +42,7 @@ public sealed class JavaScriptParserDecisionTests
     public void Acornima_Should_Attach_Leading_Public_Block_Comments_To_Supported_Declarations(
         string fixtureName,
         string expectedName,
-        JavaScriptProbeKind expectedKind,
+        string expectedKind,
         int expectedLine,
         int expectedColumn)
     {
@@ -51,7 +51,7 @@ public sealed class JavaScriptParserDecisionTests
 
         var item = Assert.Single(result.AttachedDoclets);
         Assert.Equal(expectedName, item.Name);
-        Assert.Equal(expectedKind, item.Kind);
+        Assert.Equal(expectedKind, item.Kind.ToString());
         Assert.Equal(1, item.CommentLocation.Start.Line);
         Assert.Equal(0, item.CommentLocation.Start.Column);
         Assert.Equal(expectedLine, item.NodeLocation.Start.Line);
@@ -64,11 +64,11 @@ public sealed class JavaScriptParserDecisionTests
     }
 
     [Theory]
-    [InlineData("public-event-doclet.js", JavaScriptProbeKind.Event, "razorwire:form:failure")]
-    [InlineData("public-typedef-doclet.js", JavaScriptProbeKind.Typedef, "FormFailureDetail")]
+    [InlineData("public-event-doclet.js", nameof(JavaScriptProbeKind.Event), "razorwire:form:failure")]
+    [InlineData("public-typedef-doclet.js", nameof(JavaScriptProbeKind.Typedef), "FormFailureDetail")]
     public void Acornima_Should_Collect_Standalone_Public_Doclets(
         string fixtureName,
-        JavaScriptProbeKind expectedKind,
+        string expectedKind,
         string expectedName)
     {
         var source = ReadFixture(fixtureName);
@@ -77,10 +77,27 @@ public sealed class JavaScriptParserDecisionTests
         Assert.Empty(result.AttachedDoclets);
         var item = Assert.Single(result.StandaloneDoclets);
         Assert.Equal(expectedName, item.Name);
-        Assert.Equal(expectedKind, item.Kind);
+        Assert.Equal(expectedKind, item.Kind.ToString());
         Assert.Equal(1, item.CommentLocation.Start.Line);
         Assert.Equal(0, item.CommentLocation.Start.Column);
         Assert.Contains("@public", item.CommentText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Acornima_Should_Not_Treat_Dynamic_Window_Members_As_Concrete_Globals()
+    {
+        const string source = """
+            /**
+             * Dynamic global assignment should not become a concrete API name.
+             * @public
+             */
+            window[someDynamicName] = {};
+            """;
+
+        var result = ProbeSource(source);
+
+        Assert.Empty(result.AttachedDoclets);
+        Assert.Empty(result.StandaloneDoclets);
     }
 
     [Fact]
@@ -103,15 +120,15 @@ public sealed class JavaScriptParserDecisionTests
         {
             ParseCostCase.RealFile(
                 "razorwire.js",
-                Path.Combine(repoRoot, "Web", "ForgeTrust.RazorWire", "wwwroot", "razorwire", "razorwire.js"),
+                PathUnder(repoRoot, "Web", "ForgeTrust.RazorWire", "wwwroot", "razorwire", "razorwire.js"),
                 expectedSuccess: true),
             ParseCostCase.RealFile(
                 "search-client.js",
-                Path.Combine(repoRoot, "Web", "ForgeTrust.AppSurface.Docs", "wwwroot", "docs", "search-client.js"),
+                PathUnder(repoRoot, "Web", "ForgeTrust.AppSurface.Docs", "wwwroot", "docs", "search-client.js"),
                 expectedSuccess: true),
             ParseCostCase.SkippedFile(
                 "minisearch.min.js",
-                Path.Combine(repoRoot, "Web", "ForgeTrust.AppSurface.Docs", "wwwroot", "docs", "minisearch.min.js"),
+                PathUnder(repoRoot, "Web", "ForgeTrust.AppSurface.Docs", "wwwroot", "docs", "minisearch.min.js"),
                 "*.min.js remains excluded by default"),
             ParseCostCase.Fixture("malformed.js", ReadFixture("malformed.js"), expectedSuccess: false),
             ParseCostCase.Fixture("synthetic-large-public-doclet.js", CreateSyntheticPublicDocletFixture(750), expectedSuccess: true),
@@ -132,7 +149,6 @@ public sealed class JavaScriptParserDecisionTests
             var measurement = MeasureParseCost(testCase.Source);
 
             Assert.Equal(testCase.ExpectedSuccess, measurement.Success);
-            Assert.True(measurement.Elapsed < TimeSpan.FromSeconds(5));
             _output.WriteLine(
                 FormattableString.Invariant(
                     $"{testCase.Name}: {testCase.SizeBytes} bytes, {measurement.Elapsed.TotalMilliseconds:F3} ms, success={measurement.Success}, nodes={measurement.NodeCount}, blockComments={measurement.BlockCommentCount}"));
@@ -154,7 +170,7 @@ public sealed class JavaScriptParserDecisionTests
         Assert.Equal("BSD-3-Clause", license?.Value);
 
         var testProject = XDocument.Load(
-            Path.Combine(repoRoot, "Web", "ForgeTrust.AppSurface.Docs.Tests", "ForgeTrust.AppSurface.Docs.Tests.csproj"));
+            PathUnder(repoRoot, "Web", "ForgeTrust.AppSurface.Docs.Tests", "ForgeTrust.AppSurface.Docs.Tests.csproj"));
         Assert.Equal("false", testProject.Descendants("IsPackable").Single().Value);
         Assert.Contains(
             testProject.Descendants("PackageReference"),
@@ -163,7 +179,7 @@ public sealed class JavaScriptParserDecisionTests
             ["Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj"],
             FindProjectsReferencingPackage(repoRoot, "Acornima"));
 
-        var decision = File.ReadAllText(Path.Combine(FixtureDirectory, "README.md"));
+        var decision = File.ReadAllText(PathUnder(FixtureDirectory, "README.md"));
         Assert.Contains("## License Compliance Case", decision, StringComparison.Ordinal);
         Assert.Contains("Current spike use", decision, StringComparison.Ordinal);
         Assert.Contains("not redistributed", decision, StringComparison.Ordinal);
@@ -174,7 +190,7 @@ public sealed class JavaScriptParserDecisionTests
 
     private static string ReadFixture(string name)
     {
-        return File.ReadAllText(Path.Combine(FixtureDirectory, name));
+        return File.ReadAllText(PathUnder(FixtureDirectory, name));
     }
 
     private static XNamespace NuGetNuspecNamespace { get; } =
@@ -182,7 +198,7 @@ public sealed class JavaScriptParserDecisionTests
 
     private static string ReadCentralPackageVersion(string repoRoot, string packageId)
     {
-        var packages = XDocument.Load(Path.Combine(repoRoot, "Directory.Packages.props"));
+        var packages = XDocument.Load(PathUnder(repoRoot, "Directory.Packages.props"));
         var version = packages
             .Descendants("PackageVersion")
             .Single(package => string.Equals(package.Attribute("Include")?.Value, packageId, StringComparison.Ordinal))
@@ -194,7 +210,7 @@ public sealed class JavaScriptParserDecisionTests
 
     private static string FindNuGetPackageFile(string repoRoot, string packageId, string packageVersion, string fileName)
     {
-        var assetsPath = Path.Combine(
+        var assetsPath = PathUnder(
             repoRoot,
             "Web",
             "ForgeTrust.AppSurface.Docs.Tests",
@@ -212,7 +228,7 @@ public sealed class JavaScriptParserDecisionTests
             throw new InvalidOperationException("NuGet packages path was not found in project.assets.json.");
         }
 
-        return Path.Combine(packagesPath, packageId, packageVersion, fileName);
+        return PathUnder(packagesPath, packageId, packageVersion, fileName);
     }
 
     private static IReadOnlyList<string> FindProjectsReferencingPackage(string repoRoot, string packageId)
@@ -413,9 +429,8 @@ public sealed class JavaScriptParserDecisionTests
 
     private static string? TryReadTagValue(string commentText, string tag)
     {
-        foreach (var rawLine in commentText.Split('\n'))
+        foreach (var line in commentText.Split('\n').Select(static rawLine => rawLine.Trim().TrimStart('*').Trim()))
         {
-            var line = rawLine.Trim().TrimStart('*').Trim();
             var prefix = "@" + tag;
             if (!line.StartsWith(prefix, StringComparison.Ordinal))
             {
@@ -460,7 +475,7 @@ public sealed class JavaScriptParserDecisionTests
 
         var propertyName = memberExpression.Property switch
         {
-            Identifier identifier => identifier.Name,
+            Identifier identifier when !memberExpression.Computed => identifier.Name,
             StringLiteral stringLiteral when memberExpression.Computed => stringLiteral.Value,
             _ => null,
         };
@@ -473,6 +488,23 @@ public sealed class JavaScriptParserDecisionTests
     private static string GetCommentText(string source, Comment comment)
     {
         return source[comment.ContentRange.Start..comment.ContentRange.End].Trim();
+    }
+
+    private static string PathUnder(string basePath, params string[] segments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
+        ArgumentNullException.ThrowIfNull(segments);
+
+        foreach (var segment in segments)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(segment);
+            if (Path.IsPathRooted(segment))
+            {
+                throw new ArgumentException($"Path segment must be relative: {segment}", nameof(segments));
+            }
+        }
+
+        return Path.Join([basePath, .. segments]);
     }
 
     private static bool IsOnlyWhitespace(string source, int start, int end)
@@ -595,7 +627,7 @@ public sealed class JavaScriptParserDecisionTests
         {
             return new ParseCostCase(
                 name,
-                File.ReadAllText(path),
+                Source: string.Empty,
                 new FileInfo(path).Length,
                 ExpectedSuccess: false,
                 Skipped: true,
@@ -621,13 +653,13 @@ public sealed class JavaScriptParserDecisionTests
         TimeSpan Elapsed,
         int NodeCount,
         int BlockCommentCount);
-}
 
-public enum JavaScriptProbeKind
-{
-    Function,
-    Constant,
-    Global,
-    Event,
-    Typedef,
+    private enum JavaScriptProbeKind
+    {
+        Function,
+        Constant,
+        Global,
+        Event,
+        Typedef,
+    }
 }

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/README.md
@@ -1,0 +1,117 @@
+# RazorDocs JavaScript Parser Decision
+
+Issue: https://github.com/forge-trust/AppSurface/issues/299
+
+## Decision
+
+Use `Acornima` as the first parser dependency for the future RazorDocs JavaScript public API harvester.
+
+The spike keeps the dependency in `ForgeTrust.AppSurface.Docs.Tests` only. The product harvester should add the package to `ForgeTrust.AppSurface.Docs` in the later implementation PR after the public JavaScript harvest options and diagnostics are built.
+
+## Why Acornima
+
+- NuGet-contained parser. It does not require Node, npm, or a runtime package manager.
+- `ParserOptions.OnComment` exposes skipped comments, including block comment ranges.
+- AST nodes expose zero-based `Start`, `End`, `Range`, and line/column `Location`.
+- Parser errors are catchable through `ParseErrorException` with line and zero-based column data.
+- The package targets `net8.0`, `netstandard2.0`, `netstandard2.1`, and `net462`, so it fits the package and CLI distribution story.
+- The package is BSD-3-Clause licensed, which is acceptable for AppSurface package and CLI distribution with normal third-party notice handling.
+- The installed `1.6.1` package is 632,439 bytes as a `.nupkg`, and the `net8.0` assembly is 363,520 bytes.
+
+## Candidate Result
+
+| Question | Result |
+| --- | --- |
+| Parser package | `Acornima` `1.6.1` |
+| Supported ECMAScript version | `ParserOptions.EcmaVersion` supports through `ES17` / `ES2026`, with `Latest` as the default. |
+| Block comment spans | Available through `ParserOptions.OnComment`; `Comment.Range` gives zero-based start/end and `Comment.ContentRange` gives the comment body. |
+| AST node spans | Available on every `Node` through `Start`, `End`, `Range`, and `Location`. |
+| Source line/column behavior | Lines are one-based. Columns are zero-based. This matches parser error columns and node/comment locations. |
+| Parser failure behavior | Malformed JavaScript throws a catchable `ParseErrorException` subclass. The probe catches `SyntaxErrorException` for `malformed.js`, with line and column populated. |
+| Package size | `.nupkg`: 632,439 bytes. `lib/net8.0/Acornima.dll`: 363,520 bytes. |
+| License compatibility | BSD-3-Clause. Acceptable for AppSurface package and CLI distribution. |
+| Maintenance status | Current NuGet package, current README, and current ECMAScript coverage claim. This is healthier than depending on an abandoned grammar fork. |
+| Comment attachment algorithm | Attach a block comment only when it immediately precedes a supported declaration with whitespace only between `comment.End` and `node.Start`. Standalone `@event` and `@typedef` doclets are collected from unattached block comments. |
+
+## Rejected Alternatives
+
+- `Esprima` remains viable but supports ECMAScript 2022 on the current NuGet line, while Acornima reports current ECMAScript 2026 Test262 coverage and the same .NET-contained parser model.
+- `Jint` is an execution engine, not a parser-only dependency. It is too much runtime surface for a docs harvester that only needs syntax and comments.
+- `NUglify` is optimized for minification scenarios, not source-provenance-heavy public API documentation.
+- `ANTLR` is a parser-generator strategy, not a ready JavaScript parser decision. It would make RazorDocs own generated parser code, grammar updates, hidden-channel comment handling, and AST shaping before the first JavaScript harvester proves user value.
+- `Tree-sitter` is the more interesting future multi-language parser substrate because it is built around source-spanned concrete syntax trees and broad grammar coverage. It should be evaluated when RazorDocs starts a second or third code-language harvester, but the native/runtime packaging story needs a separate AppSurface CLI distribution review.
+- A regex-only harvester is rejected. It would fail the source-span and failure-isolation requirements and would make public API docs depend on source formatting luck.
+
+## Multi-Language Parser Strategy
+
+Do not make the JavaScript v1 harvester pay for a cross-language parser abstraction yet. The right near-term boundary is a small internal RazorDocs parser result model that can be backed by Acornima for JavaScript now and by another parser later.
+
+Revisit ANTLR, Tree-sitter, and language-specific parsers after RazorDocs has at least two code-language harvesters with concrete needs. Otherwise the abstraction is theory, and theory has a way of becoming a 400-line options object.
+
+## License Compliance Case
+
+Current spike use:
+
+- Acornima is referenced only by `ForgeTrust.AppSurface.Docs.Tests`, and that project has `IsPackable=false`.
+- The spike does not add Acornima to `ForgeTrust.AppSurface.Docs`, `ForgeTrust.AppSurface.Cli`, or any other shipped package.
+- Because the current use is test-only, Acornima is not redistributed in an AppSurface package or CLI artifact by this spike.
+
+Future product use:
+
+- If the JavaScript harvester adds Acornima to a shipped package, package, tool, or self-contained CLI artifact, that artifact must carry Acornima's BSD-3-Clause copyright notice, license conditions, and disclaimer in third-party notice materials.
+- No endorsement: release and marketing copy must not imply Acornima, Adam Simon, or Acornima contributors endorse AppSurface or RazorDocs without specific written permission.
+- The product implementation PR should add or update the repository's third-party notice flow before moving Acornima from the test project into product code.
+
+## Parser Probe
+
+Runnable command:
+
+```bash
+dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --filter JavaScriptParserDecisionTests
+```
+
+The probe verifies:
+
+- block comment spans
+- AST node spans
+- stable one-based line and zero-based column data
+- deterministic leading block comment attachment
+- standalone public `@event` doclets
+- standalone public `@typedef` doclets
+- `window.RazorWire = { ... }` assignment detection
+- catchable malformed-file parse failures
+- lightweight parse-cost measurements for real and synthetic JavaScript inputs
+
+## Parse-Cost Snapshot
+
+Captured locally with:
+
+```bash
+dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --filter JavaScriptParserDecisionTests --logger "console;verbosity=detailed"
+```
+
+| Fixture/file | Size | Parse time | Notes |
+| --- | ---: | ---: | --- |
+| `Web/ForgeTrust.RazorWire/wwwroot/razorwire/razorwire.js` | 41,380 bytes | 13.434 ms | real RazorWire dogfood file; parsed successfully with 4,380 AST nodes and 2 block comments |
+| `Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/search-client.js` | 68,314 bytes | 4.560 ms | larger RazorDocs browser asset; parsed successfully with 9,460 AST nodes |
+| `Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/minisearch.min.js` | 944 bytes | skipped | should stay excluded by `*.min.js` by default |
+| `malformed.js` | 107 bytes | 0.450 ms | failure path; catchable parse exception |
+| synthetic large public-doclet fixture | 117,965 bytes | 5.563 ms | 750 public function doclets; parsed successfully with 4,503 AST nodes and 750 block comments |
+
+## Known Unsupported Syntax For V1 Harvesting
+
+The parser can accept more JavaScript than RazorDocs v1 should harvest. The first harvester should still treat these as unsupported public shapes until later issues add explicit product behavior:
+
+- TypeScript syntax
+- JSX unless `Acornima.Extras` is deliberately added
+- JavaScript classes and class members
+- default export inference
+- CommonJS `module.exports` inference
+- automatic event inference from `dispatchEvent(new CustomEvent(...))`
+- cross-doclet typedef enrichment
+
+## First Max-File-Size Recommendation
+
+The first default should skip files larger than 256 KiB and continue excluding `*.min.js` by default.
+
+That threshold covers the current real dogfood files measured by this spike, leaves headroom above `search-client.js`, and avoids accidentally parsing large bundles before the harvester has production diagnostics and configuration.

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/README.md
@@ -27,7 +27,7 @@ The spike keeps the dependency in `ForgeTrust.AppSurface.Docs.Tests` only. The p
 | Block comment spans | Available through `ParserOptions.OnComment`; `Comment.Range` gives zero-based start/end and `Comment.ContentRange` gives the comment body. |
 | AST node spans | Available on every `Node` through `Start`, `End`, `Range`, and `Location`. |
 | Source line/column behavior | Lines are one-based. Columns are zero-based. This matches parser error columns and node/comment locations. |
-| Parser failure behavior | Malformed JavaScript throws a catchable `ParseErrorException` subclass. The probe catches `SyntaxErrorException` for `malformed.js`, with line and column populated. |
+| Parser failure behavior | Malformed JavaScript throws a catchable `ParseErrorException` subclass. The probe catches `ParseErrorException` for `malformed.js`, with line and column populated. |
 | Package size | `.nupkg`: 632,439 bytes. `lib/net8.0/Acornima.dll`: 363,520 bytes. |
 | License compatibility | BSD-3-Clause. Acceptable for AppSurface package and CLI distribution. |
 | Maintenance status | Current NuGet package, current README, and current ECMAScript coverage claim. This is healthier than depending on an abandoned grammar fork. |

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/README.md
@@ -64,7 +64,7 @@ Future product use:
 
 ## Parser Probe
 
-Runnable command:
+Probe command:
 
 ```bash
 dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --filter JavaScriptParserDecisionTests

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/malformed.js
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/malformed.js
@@ -1,0 +1,5 @@
+/**
+ * This doclet proves parser failure stays isolated to one file.
+ * @public
+ */
+function brokenSyntax(

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-arrow-function.js
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-arrow-function.js
@@ -1,0 +1,7 @@
+/**
+ * Creates a listener that can observe RazorWire form failures.
+ * @public
+ */
+const createFailureListener = (callback) => {
+  return (event) => callback(event.detail);
+};

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-const-value.js
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-const-value.js
@@ -1,0 +1,5 @@
+/**
+ * Default timeout before a RazorWire stream is considered stale.
+ * @public
+ */
+const streamTimeoutMs = 30000;

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-event-doclet.js
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-event-doclet.js
@@ -1,0 +1,12 @@
+/**
+ * Raised when a RazorWire form response returns validation diagnostics.
+ * @public
+ * @event razorwire:form:failure
+ * @target form
+ * @firesWhen the server returns validation errors for a submitted form
+ * @property {string} detail.message - Human-readable summary for custom UI.
+ * @example
+ * form.addEventListener("razorwire:form:failure", (event) => {
+ *   showError(event.detail.message);
+ * });
+ */

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-function.js
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-function.js
@@ -1,0 +1,9 @@
+/**
+ * Starts the RazorWire form enhancement.
+ * @public
+ * @param {HTMLFormElement} form - Form that should receive RazorWire behavior.
+ * @returns {void}
+ */
+function wireForm(form) {
+  form.dataset.razorWire = "ready";
+}

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-typedef-doclet.js
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/public-typedef-doclet.js
@@ -1,0 +1,7 @@
+/**
+ * Payload delivered by RazorWire form failure events.
+ * @public
+ * @typedef FormFailureDetail
+ * @property {string} message - Human-readable failure summary.
+ * @property {Record<string,string[]>} fields - Field diagnostics keyed by field name.
+ */

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/window-razorwire-global.js
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/window-razorwire-global.js
@@ -1,0 +1,11 @@
+/**
+ * Public browser global used by advanced RazorWire consumers.
+ * @public
+ * @global
+ */
+window.RazorWire = {
+  version: "0.1.0",
+  refresh(target) {
+    target.dispatchEvent(new CustomEvent("razorwire:refresh"));
+  }
+};

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Acornima": {
+        "type": "Direct",
+        "requested": "[1.6.1, )",
+        "resolved": "1.6.1",
+        "contentHash": "EB2vFgpNar8DrC+KLJv8MG6YIU2xqNyrq8GpL69vectPCXoaq6XyZGb/VHbfPVYul7dscO1Mw30eblrxs05RHg=="
+      },
       "coverlet.msbuild": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -416,7 +422,7 @@
       "forgetrust.appsurface.caching": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Caching.Memory": "[9.0.6, )"
         }
       },
@@ -427,18 +433,12 @@
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
       },
-      "forgetrust.appsurface.web": {
-        "type": "Project",
-        "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
-        }
-      },
       "forgetrust.appsurface.docs": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Caching": "[1.0.0, )",
-          "ForgeTrust.RazorWire": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Caching": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )",
           "HtmlSanitizer": "[9.0.892, )",
           "Markdig": "[0.44.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
@@ -447,22 +447,21 @@
           "YamlDotNet": "[17.0.1, )"
         }
       },
-      "forgetrust.razorwire": {
+      "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
@@ -479,6 +478,13 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
       },
       "Markdig": {
         "type": "CentralTransitive",

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -142,6 +142,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs now treats `Releases` as a first-class public section and suppresses breadcrumb links to generated parent routes that do not correspond to published docs pages, keeping static export warnings focused on actionable broken links.
 - RazorDocs wayfinding coverage now waits for docs content replacement before asserting sequence-link destinations, keeping the details-page proof path deterministic in CI.
 - RazorDocs Playwright integration coverage now hosts the standalone docs app in-process through the standalone host builder, avoiding fixture-time `dotnet run` rebuilds and stale standalone `bin` output during focused test runs.
+- RazorDocs now has a test-backed JavaScript parser decision probe for future public API harvesting, covering Acornima span behavior, malformed syntax handling, BSD-3-Clause compliance expectations, and the first max-file-size recommendation before that parser moves into product code.
 
 ### RazorWire form UX
 


### PR DESCRIPTION
Fixes #299

Latest head commit: 2a83ee6

## Summary
- Adds Acornima 1.6.1 as a test-only parser candidate for the RazorDocs JavaScript harvester spike.
- Adds a runnable parser probe in Web/ForgeTrust.AppSurface.Docs.Tests with fixtures for public function, const arrow, const value, standalone event, standalone typedef, global assignment, dynamic window-member rejection, and malformed JavaScript.
- Documents the parser decision artifact with rejected alternatives, license handling, parse-cost snapshot, and the first max-file-size recommendation.

## Test Coverage
- Parser decision tests cover representative public JavaScript API shapes, catchable malformed syntax failures, real and synthetic parse-cost probing, dynamic member non-matches, and the BSD-3-Clause compliance case.
- The compliance case asserts Acornima stays test-only, docs tests remain non-packable, the package license is BSD-3-Clause, and future redistribution obligations are documented.

## Documentation
- Web/ForgeTrust.AppSurface.Docs.Tests/TestData/JavaScriptParserDecision/README.md records the parser decision, rejected alternatives, license compliance case, parse-cost snapshot, unsupported v1 shapes, and max-file-size recommendation.
- releases/unreleased.md records the RazorDocs JavaScript parser decision probe for the release contract gate.
- Directory.Packages.props now clarifies that Acornima 1.6.1 is an intentional SemVer-stable NuGet pin for this test-only spike.

## Review Feedback Addressed
- Removed hard wall-clock parse timing assertion; parse cost remains logged as test output.
- Tightened computed member handling so dynamic `window[someName]` does not become a concrete public global.
- Avoided loading skipped/minified files while still reporting file size.
- Made the probe enum private to the test class.
- Added safe path construction for repo-root and fixture paths.
- Verified the markdown tables use single leading pipes.

## CI Gate Fixes
- Fixed Release Contract / enforce by adding the required unreleased release note.
- Fixed package-gate by removing the stale brand string from the new parser decision README.

## Verification Results
- [x] dotnet restore Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj
- [x] dotnet format Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --no-restore
- [x] dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --filter JavaScriptParserDecisionTests (10 passed)
- [x] dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj (1114 passed)
- [x] dotnet build tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj --configuration Release
- [x] dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj --configuration Release --no-build -- gate
- [x] git diff --check

## Plan Completion
- Checkpoint requirements for the RazorDocs JavaScript parser spike are satisfied.
- No product API surface changed.