### PR TITLE
feat(docs): add RazorDocs localization foundation

### DIFF
--- a/Web/ForgeTrust.AppSurface.Docs.Tests/DocAggregatorTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/DocAggregatorTests.cs
@@ -2554,6 +2554,25 @@ public class DocAggregatorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSearchIndexPayloadAsync_ShouldReturnProjectionPayload_ForLocaleProjectionInPhaseOne()
+    {
+        var harvestedDocs = new List<DocNode>
+        {
+            new(
+                "Guide",
+                "guides/guide.md",
+                "<p>Guide body</p>")
+        };
+        A.CallTo(() => _harvesterFake.HarvestAsync(A<string>._, A<CancellationToken>._)).Returns(harvestedDocs);
+
+        var payload = await _aggregator.GetSearchIndexPayloadAsync(new DocsSearchIndexProjection(Locale: "fr"));
+
+        var indexedDocument = Assert.Single(payload.Documents);
+        Assert.Equal("/docs/guides/guide", indexedDocument.Path);
+        Assert.Equal("guides/guide.md", indexedDocument.SourcePath);
+    }
+
+    [Fact]
     public async Task GetSearchIndexPayloadAsync_ShouldSkipReservedRouteCollisions()
     {
         var harvestedDocs = new List<DocNode>

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/DocModelsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/DocModelsTests.cs
@@ -1,3 +1,4 @@
+using ForgeTrust.AppSurface.Docs;
 using ForgeTrust.AppSurface.Docs.Models;
 
 namespace ForgeTrust.AppSurface.Docs.Tests;
@@ -27,6 +28,11 @@ public class DocModelsTests
             {
                 SourcePathOverride = "docs/guide.md",
                 LastUpdatedOverride = new DateTimeOffset(2026, 4, 22, 23, 19, 0, TimeSpan.Zero)
+            },
+            Localization = new DocLocalizationMetadata
+            {
+                Locale = "fr",
+                TranslationKey = "guides/quickstart"
             },
             FeaturedPageGroups =
             [
@@ -79,6 +85,8 @@ public class DocModelsTests
         Assert.Equal("/docs/releases/upgrade-policy.md.html", node.Metadata?.Trust?.Migration?.Href);
         Assert.Equal("docs/guide.md", node.Metadata?.Contributor?.SourcePathOverride);
         Assert.Equal(new DateTimeOffset(2026, 4, 22, 23, 19, 0, TimeSpan.Zero), node.Metadata?.Contributor?.LastUpdatedOverride);
+        Assert.Equal("fr", node.Metadata?.Localization?.Locale);
+        Assert.Equal("guides/quickstart", node.Metadata?.Localization?.TranslationKey);
         Assert.Single(node.Metadata?.FeaturedPageGroups!);
         Assert.Equal(["alias-one"], node.Metadata?.Aliases);
         Assert.Equal(["legacy/alias"], node.Metadata?.RedirectAliases);
@@ -233,6 +241,35 @@ public class DocModelsTests
         Assert.Equal(
             new DateTimeOffset(2026, 4, 22, 23, 19, 0, TimeSpan.Zero),
             merged.Contributor.LastUpdatedOverride);
+    }
+
+    [Fact]
+    public void Merge_ShouldMergeLocalizationMetadata_FieldByField()
+    {
+        var merged = DocMetadata.Merge(
+            new DocMetadata
+            {
+                Localization = new DocLocalizationMetadata
+                {
+                    Locale = "fr",
+                    LocaleFallback = RazorDocsLocaleFallbackMode.Disabled
+                }
+            },
+            new DocMetadata
+            {
+                Localization = new DocLocalizationMetadata
+                {
+                    TranslationKey = "guides/getting-started",
+                    LocalizedTitle = "Getting started",
+                    LocaleFallback = RazorDocsLocaleFallbackMode.DefaultLocaleWithNotice
+                }
+            });
+
+        Assert.NotNull(merged?.Localization);
+        Assert.Equal("fr", merged!.Localization!.Locale);
+        Assert.Equal("guides/getting-started", merged.Localization.TranslationKey);
+        Assert.Equal("Getting started", merged.Localization.LocalizedTitle);
+        Assert.Equal(RazorDocsLocaleFallbackMode.Disabled, merged.Localization.LocaleFallback);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/DocModelsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/DocModelsTests.cs
@@ -266,10 +266,11 @@ public class DocModelsTests
             });
 
         Assert.NotNull(merged?.Localization);
-        Assert.Equal("fr", merged!.Localization!.Locale);
-        Assert.Equal("guides/getting-started", merged.Localization.TranslationKey);
-        Assert.Equal("Getting started", merged.Localization.LocalizedTitle);
-        Assert.Equal(RazorDocsLocaleFallbackMode.Disabled, merged.Localization.LocaleFallback);
+        var localization = merged!.Localization!;
+        Assert.Equal("fr", localization.Locale);
+        Assert.Equal("guides/getting-started", localization.TranslationKey);
+        Assert.Equal("Getting started", localization.LocalizedTitle);
+        Assert.Equal(RazorDocsLocaleFallbackMode.Disabled, localization.LocaleFallback);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
@@ -1,0 +1,24 @@
+using ForgeTrust.AppSurface.Docs.Services;
+
+namespace ForgeTrust.AppSurface.Docs.Tests;
+
+public sealed class DocsSearchIndexProjectionCacheTests
+{
+    [Fact]
+    public void GetPayload_ShouldPreserveDefaultPayload_ForLocaleProjectionInPhaseOne()
+    {
+        var payload = new DocsSearchIndexPayload(
+            new DocsSearchIndexMetadata("2026-05-16T00:00:00.0000000Z", "1", "minisearch"),
+            []);
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            options,
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home"));
+        var cache = new DocsSearchIndexProjectionCache(payload, graph);
+
+        var projected = cache.GetPayload(new DocsSearchIndexProjection(Locale: "fr"));
+
+        Assert.Same(payload, projected);
+        Assert.Equal("1", projected.Metadata.Version);
+    }
+}

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
@@ -62,6 +62,26 @@ public sealed class DocsSearchIndexProjectionCacheTests
     }
 
     [Fact]
+    public void GetPayload_ShouldBoundCachedLocaleProjections()
+    {
+        var payload = new DocsSearchIndexPayload(
+            new DocsSearchIndexMetadata("2026-05-16T00:00:00.0000000Z", "1", "minisearch"),
+            []);
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            options,
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home"));
+        var cache = new DocsSearchIndexProjectionCache(payload, graph);
+
+        for (var i = 0; i < 100; i++)
+        {
+            _ = cache.GetPayload(new DocsSearchIndexProjection(Locale: $"locale-{i}"));
+        }
+
+        Assert.Equal(64, cache.CachedProjectionCount);
+    }
+
+    [Fact]
     public void GetPayload_ShouldPreserveDefaultPayload_WhenLocalizationIsDisabled()
     {
         var payload = new DocsSearchIndexPayload(

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
@@ -21,4 +21,38 @@ public sealed class DocsSearchIndexProjectionCacheTests
         Assert.Same(payload, projected);
         Assert.Equal("1", projected.Metadata.Version);
     }
+
+    [Fact]
+    public void GetPayload_ShouldReturnCachedProjection_ForRepeatedLocaleProjection()
+    {
+        var payload = new DocsSearchIndexPayload(
+            new DocsSearchIndexMetadata("2026-05-16T00:00:00.0000000Z", "1", "minisearch"),
+            []);
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            options,
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home"));
+        var cache = new DocsSearchIndexProjectionCache(payload, graph);
+        var projection = new DocsSearchIndexProjection(Locale: "fr");
+
+        _ = cache.GetPayload(projection);
+        var projected = cache.GetPayload(projection);
+
+        Assert.Same(payload, projected);
+    }
+
+    [Fact]
+    public void GetPayload_ShouldPreserveDefaultPayload_WhenLocalizationIsDisabled()
+    {
+        var payload = new DocsSearchIndexPayload(
+            new DocsSearchIndexMetadata("2026-05-16T00:00:00.0000000Z", "1", "minisearch"),
+            []);
+        var cache = new DocsSearchIndexProjectionCache(
+            payload,
+            new LocalizedDocsGraph(false, null, [], new Dictionary<string, LocalizedDocVariant>(), []));
+
+        var projected = cache.GetPayload(new DocsSearchIndexProjection(Locale: "fr"));
+
+        Assert.Same(payload, projected);
+    }
 }

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/DocsSearchIndexProjectionCacheTests.cs
@@ -35,10 +35,30 @@ public sealed class DocsSearchIndexProjectionCacheTests
         var cache = new DocsSearchIndexProjectionCache(payload, graph);
         var projection = new DocsSearchIndexProjection(Locale: "fr");
 
-        _ = cache.GetPayload(projection);
-        var projected = cache.GetPayload(projection);
+        var firstPayload = cache.GetPayload(projection);
+        var secondPayload = cache.GetPayload(projection);
 
-        Assert.Same(payload, projected);
+        Assert.Same(payload, firstPayload);
+        Assert.Same(firstPayload, secondPayload);
+    }
+
+    [Fact]
+    public void GetPayload_ShouldNormalizeLocaleProjectionKeys()
+    {
+        var payload = new DocsSearchIndexPayload(
+            new DocsSearchIndexMetadata("2026-05-16T00:00:00.0000000Z", "1", "minisearch"),
+            []);
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            options,
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home"));
+        var cache = new DocsSearchIndexProjectionCache(payload, graph);
+
+        var firstPayload = cache.GetPayload(new DocsSearchIndexProjection(Locale: " FR "));
+        var secondPayload = cache.GetPayload(new DocsSearchIndexProjection(Locale: "fr"));
+
+        Assert.Same(payload, firstPayload);
+        Assert.Same(firstPayload, secondPayload);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
@@ -106,6 +106,20 @@ public sealed class LocalizedDocsGraphBuilderTests
     }
 
     [Fact]
+    public void Build_ShouldTreatUnknownCultureLikeSuffixAsOrdinaryDefaultLocaleDoc()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.not_a_culture.md", "Configuration"));
+
+        var variant = Assert.Single(graph.VariantsBySourcePath.Values);
+
+        Assert.Equal("en", variant.Locale);
+        Assert.Equal("guides/configuration.not_a_culture", variant.TranslationKey);
+        Assert.Empty(graph.Diagnostics);
+    }
+
+    [Fact]
     public void Build_ShouldInferMarkdownExtensionLocaleSuffixes()
     {
         var graph = RazorDocsLocalizationFixture.BuildGraph(
@@ -237,6 +251,7 @@ public sealed class LocalizedDocsGraphBuilderTests
         Assert.Contains(
             candidates,
             candidate => candidate.Locale == "en"
+                         && candidate.TranslationKey == "guides/getting-started"
                          && candidate.PublicRoutePath == "en/guides/getting-started");
         Assert.Contains(
             candidates,

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
@@ -1,0 +1,193 @@
+using ForgeTrust.AppSurface.Docs.Models;
+using ForgeTrust.AppSurface.Docs.Services;
+
+namespace ForgeTrust.AppSurface.Docs.Tests;
+
+public sealed class LocalizedDocsGraphBuilderTests
+{
+    [Fact]
+    public void Build_ShouldReturnDisabledGraph_WhenLocalizationIsDisabled()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            new RazorDocsLocalizationOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home"));
+
+        Assert.False(graph.Enabled);
+        Assert.Empty(graph.DocSets);
+        Assert.Empty(graph.Diagnostics);
+    }
+
+    [Fact]
+    public void Build_ShouldInferColocatedLocaleSuffixAndTranslationKeyFromBaseDocument()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            options,
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home"),
+            RazorDocsLocalizationFixture.MarkdownDoc("README.fr.md", "Accueil"));
+
+        var docSet = Assert.Single(graph.DocSets);
+        Assert.Equal("README", docSet.TranslationKey);
+        Assert.Equal("README.md", docSet.DefaultLocaleSourcePath);
+        Assert.Collection(
+            docSet.Variants.OrderBy(variant => variant.Locale, StringComparer.OrdinalIgnoreCase),
+            en =>
+            {
+                Assert.Equal("en", en.Locale);
+                Assert.Equal("README.md", en.SourcePath);
+                Assert.True(en.LocaleWasInferred);
+                Assert.True(en.TranslationKeyWasInferred);
+            },
+            fr =>
+            {
+                Assert.Equal("fr", fr.Locale);
+                Assert.Equal("README.fr.md", fr.SourcePath);
+                Assert.Equal(string.Empty, fr.PublicRoutePath);
+                Assert.True(fr.LocaleWasInferred);
+                Assert.True(fr.TranslationKeyWasInferred);
+            });
+        Assert.Empty(graph.Diagnostics);
+    }
+
+    [Fact]
+    public void Build_ShouldEmitMissingBaseDiagnostic_ForColocatedLocaleSuffixWithoutBase()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.fr.md", "Configuration"));
+
+        Assert.Contains(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationMissingBase);
+        var docSet = Assert.Single(graph.DocSets);
+        Assert.Equal("guides/configuration", docSet.TranslationKey);
+    }
+
+    [Fact]
+    public void Build_ShouldEmitUnsupportedLocaleDiagnostic_ForConfiguredMismatch()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.es.md", "Configuration"));
+
+        Assert.Contains(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationUnsupportedLocale);
+        Assert.Empty(graph.DocSets);
+        Assert.False(graph.VariantsBySourcePath.ContainsKey("guides/configuration.es.md"));
+    }
+
+    [Fact]
+    public void Build_ShouldInferFolderLocaleOnlyWhenTranslationKeyIsAuthored()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("fr/guides/demarrer.md", "Démarrer"),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "fr/guides/configuration.md",
+                "Configuration",
+                translationKey: "guides/configuration"));
+
+        var ordinaryFolderDoc = graph.VariantsBySourcePath["fr/guides/demarrer.md"];
+        var localizedFolderDoc = graph.VariantsBySourcePath["fr/guides/configuration.md"];
+
+        Assert.Equal("en", ordinaryFolderDoc.Locale);
+        Assert.Equal("fr/guides/demarrer", ordinaryFolderDoc.TranslationKey);
+        Assert.Equal("fr", localizedFolderDoc.Locale);
+        Assert.Equal("guides/configuration", localizedFolderDoc.TranslationKey);
+    }
+
+    [Fact]
+    public void Build_ShouldEmitFolderConflictDiagnostic_WhenAuthoredLocaleDisagreesWithFolderLocale()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "fr/guides/configuration.md",
+                "Configuration",
+                locale: "en",
+                translationKey: "guides/configuration"));
+
+        Assert.Contains(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationLocaleFolderConflict);
+    }
+
+    [Fact]
+    public void Build_ShouldEmitDuplicateVariantDiagnostic_ForSameTranslationKeyAndLocale()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/one.md", "One", locale: "fr", translationKey: "guides/shared"),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/two.md", "Two", locale: "fr", translationKey: "guides/shared"));
+
+        Assert.Contains(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationDuplicateVariant);
+    }
+
+    [Fact]
+    public void Build_ShouldEmitFallbackDisabledMissingVariantDiagnostic()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "guides/configuration.md",
+                "Configuration",
+                fallback: RazorDocsLocaleFallbackMode.Disabled));
+
+        Assert.Contains(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationFallbackDisabledMissingVariant);
+    }
+
+    [Fact]
+    public void RouteCatalog_ShouldBuildLocalePrefixedRouteCandidatesFromGraph()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var docs = new[]
+        {
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/getting-started.md", "Getting started"),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/getting-started.fr.md", "Démarrer")
+        };
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        var graph = new LocalizedDocsGraphBuilder(options).Build(docs, catalog);
+
+        var candidates = catalog.BuildLocalizedRouteCandidates(graph, options);
+
+        Assert.Contains(
+            candidates,
+            candidate => candidate.Locale == "en"
+                         && candidate.PublicRoutePath == "en/guides/getting-started");
+        Assert.Contains(
+            candidates,
+            candidate => candidate.Locale == "fr"
+                         && candidate.SourcePath == "guides/getting-started.fr.md"
+                         && candidate.PublicRoutePath == "fr/guides/getting-started");
+    }
+
+    [Fact]
+    public void RouteCatalog_ShouldSkipLocalizedRouteCandidatesWithoutPublicRoute()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var docs = new[]
+        {
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "guides/broken.md",
+                "Broken",
+                locale: "fr",
+                translationKey: "guides/broken",
+                canonicalSlug: "../broken")
+        };
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        var graph = new LocalizedDocsGraphBuilder(options).Build(docs, catalog);
+
+        var candidates = catalog.BuildLocalizedRouteCandidates(graph, options);
+
+        Assert.Empty(candidates);
+        var docSet = Assert.Single(graph.DocSets);
+        var variant = Assert.Single(docSet.Variants);
+        Assert.Null(variant.PublicRoutePath);
+    }
+}

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
@@ -79,6 +79,84 @@ public sealed class LocalizedDocsGraphBuilderTests
     }
 
     [Fact]
+    public void Build_ShouldEmitUnsupportedLocaleDiagnostic_ForExplicitUnsupportedLocale()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.md", "Configuration", locale: "es"));
+
+        Assert.Contains(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationUnsupportedLocale);
+        Assert.Empty(graph.DocSets);
+    }
+
+    [Fact]
+    public void Build_ShouldIgnoreNonMarkdownLocaleSuffixInference()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("api/configuration.fr", "Configuration"));
+
+        var variant = Assert.Single(graph.VariantsBySourcePath.Values);
+
+        Assert.Equal("en", variant.Locale);
+        Assert.Equal("api/configuration", variant.TranslationKey);
+        Assert.Empty(graph.Diagnostics);
+    }
+
+    [Fact]
+    public void Build_ShouldInferMarkdownExtensionLocaleSuffixes()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.markdown", "Configuration"),
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.fr.markdown", "Configuration"));
+
+        var docSet = Assert.Single(graph.DocSets);
+
+        Assert.Equal("guides/configuration", docSet.TranslationKey);
+        Assert.Contains(docSet.Variants, variant => variant.Locale == "fr" && variant.SourcePath == "guides/configuration.fr.markdown");
+    }
+
+    [Fact]
+    public void Build_ShouldKeepGraphEmpty_WhenDefaultLocaleCannotBeResolved()
+    {
+        var options = new RazorDocsLocalizationOptions
+        {
+            Enabled = true,
+            DefaultLocale = null!,
+            Locales =
+            [
+                new RazorDocsLocaleOptions { Code = "en" }
+            ]
+        };
+
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            options,
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home"));
+
+        Assert.Empty(graph.DocSets);
+        Assert.Empty(graph.VariantsBySourcePath);
+        Assert.Empty(graph.Diagnostics);
+    }
+
+    [Fact]
+    public void Build_ShouldResolveLocalizedTitleBeforeMetadataTitle()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "guides/configuration.md",
+                "Configuration",
+                localizedTitle: "Localized configuration"));
+
+        var variant = Assert.Single(graph.VariantsBySourcePath.Values);
+
+        Assert.Equal("Localized configuration", variant.Title);
+    }
+
+    [Fact]
     public void Build_ShouldInferFolderLocaleOnlyWhenTranslationKeyIsAuthored()
     {
         var graph = RazorDocsLocalizationFixture.BuildGraph(
@@ -165,6 +243,77 @@ public sealed class LocalizedDocsGraphBuilderTests
             candidate => candidate.Locale == "fr"
                          && candidate.SourcePath == "guides/getting-started.fr.md"
                          && candidate.PublicRoutePath == "fr/guides/getting-started");
+    }
+
+    [Fact]
+    public void RouteCatalog_ShouldBuildHomeLocaleRouteCandidateWithoutTrailingSlash()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var docs = new[]
+        {
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home")
+        };
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        var graph = new LocalizedDocsGraphBuilder(options).Build(docs, catalog);
+
+        var candidate = Assert.Single(catalog.BuildLocalizedRouteCandidates(graph, options));
+
+        Assert.Equal("en", candidate.Locale);
+        Assert.Equal("en", candidate.PublicRoutePath);
+    }
+
+    [Fact]
+    public void RouteCatalog_ShouldReturnNoLocalizedRouteCandidates_WhenGraphIsDisabled()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var docs = new[]
+        {
+            RazorDocsLocalizationFixture.MarkdownDoc("README.md", "Home")
+        };
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        var graph = RazorDocsLocalizationFixture.BuildGraph(new RazorDocsLocalizationOptions(), docs);
+
+        var candidates = catalog.BuildLocalizedRouteCandidates(graph, options);
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void RouteCatalog_ShouldSkipLocalizedRouteCandidatesForUnconfiguredLocale()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var docs = new[]
+        {
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.md", "Configuration")
+        };
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        var graph = new LocalizedDocsGraph(
+            Enabled: true,
+            DefaultLocale: "en",
+            DocSets:
+            [
+                new LocalizedDocSet(
+                    "guides/configuration",
+                    "guides/configuration.md",
+                    [
+                        new LocalizedDocVariant(
+                            "guides/configuration.md",
+                            "de",
+                            "guides/configuration",
+                            "Configuration",
+                            "guides/configuration",
+                            LocaleFallback: null,
+                            LocaleWasInferred: false,
+                            TranslationKeyWasInferred: false)
+                    ],
+                    RazorDocsLocaleFallbackMode.DefaultLocaleWithNotice)
+            ],
+            VariantsBySourcePath: new Dictionary<string, LocalizedDocVariant>(),
+            Diagnostics: []);
+
+        var candidates = catalog.BuildLocalizedRouteCandidates(graph, options);
+
+        Assert.Empty(candidates);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
@@ -15,6 +15,7 @@ public sealed class LocalizedDocsGraphBuilderTests
         Assert.False(graph.Enabled);
         Assert.Empty(graph.DocSets);
         Assert.Empty(graph.Diagnostics);
+        Assert.False(graph.VariantsBySourcePath.ContainsKey("readme.md"));
     }
 
     [Fact]
@@ -235,6 +236,44 @@ public sealed class LocalizedDocsGraphBuilderTests
     }
 
     [Fact]
+    public void Build_ShouldEmitFallbackConflictDiagnostic_ForConflictingVariantFallbackModes()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "guides/configuration.md",
+                "Configuration",
+                fallback: RazorDocsLocaleFallbackMode.Disabled),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "guides/configuration.fr.md",
+                "Configuration",
+                fallback: RazorDocsLocaleFallbackMode.DefaultLocaleWithNotice));
+
+        var docSet = Assert.Single(graph.DocSets);
+
+        Assert.Equal(RazorDocsLocaleFallbackMode.Disabled, docSet.FallbackMode);
+        Assert.Contains(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationFallbackConflict);
+    }
+
+    [Fact]
+    public void Build_ShouldSkipFragmentStubSourcePaths()
+    {
+        var graph = RazorDocsLocalizationFixture.BuildGraph(
+            RazorDocsLocalizationFixture.CreateOptions(),
+            RazorDocsLocalizationFixture.MarkdownDoc("api/Foo.md", "Foo"),
+            RazorDocsLocalizationFixture.MarkdownDoc("api/Foo.md#TypeId", "Foo type"));
+
+        var variant = Assert.Single(graph.VariantsBySourcePath.Values);
+
+        Assert.Equal("api/Foo.md", variant.SourcePath);
+        Assert.DoesNotContain(
+            graph.Diagnostics,
+            diagnostic => diagnostic.Code == DocHarvestDiagnosticCodes.LocalizationDuplicateVariant);
+    }
+
+    [Fact]
     public void RouteCatalog_ShouldBuildLocalePrefixedRouteCandidatesFromGraph()
     {
         var options = RazorDocsLocalizationFixture.CreateOptions();
@@ -323,7 +362,7 @@ public sealed class LocalizedDocsGraphBuilderTests
                     ],
                     RazorDocsLocaleFallbackMode.DefaultLocaleWithNotice)
             ],
-            VariantsBySourcePath: new Dictionary<string, LocalizedDocVariant>(),
+            VariantsBySourcePath: new Dictionary<string, LocalizedDocVariant>(StringComparer.OrdinalIgnoreCase),
             Diagnostics: []);
 
         var candidates = catalog.BuildLocalizedRouteCandidates(graph, options);

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
@@ -327,6 +327,34 @@ public sealed class LocalizedDocsGraphBuilderTests
     }
 
     [Fact]
+    public void RouteCatalog_ShouldAvoidDoublePrefixForExplicitLocaleInLocaleFolder()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var docs = new[]
+        {
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/configuration.md", "Configuration"),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "fr/guides/configuration.md",
+                "Configuration",
+                locale: "fr",
+                translationKey: "guides/configuration")
+        };
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        var graph = new LocalizedDocsGraphBuilder(options).Build(docs, catalog);
+
+        var candidates = catalog.BuildLocalizedRouteCandidates(graph, options);
+
+        Assert.Contains(
+            candidates,
+            candidate => candidate.Locale == "fr"
+                         && candidate.SourcePath == "fr/guides/configuration.md"
+                         && candidate.PublicRoutePath == "fr/guides/configuration");
+        Assert.DoesNotContain(
+            candidates,
+            candidate => candidate.PublicRoutePath == "fr/fr/guides/configuration");
+    }
+
+    [Fact]
     public void RouteCatalog_ShouldBuildHomeLocaleRouteCandidateWithoutTrailingSlash()
     {
         var options = RazorDocsLocalizationFixture.CreateOptions();

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/LocalizedDocsGraphBuilderTests.cs
@@ -300,6 +300,33 @@ public sealed class LocalizedDocsGraphBuilderTests
     }
 
     [Fact]
+    public void RouteCatalog_ShouldAvoidDoublePrefixForFolderInferredLocaleCandidates()
+    {
+        var options = RazorDocsLocalizationFixture.CreateOptions();
+        var docs = new[]
+        {
+            RazorDocsLocalizationFixture.MarkdownDoc("guides/getting-started.md", "Getting started"),
+            RazorDocsLocalizationFixture.MarkdownDoc(
+                "fr/guides/getting-started.md",
+                "Démarrer",
+                translationKey: "guides/getting-started")
+        };
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        var graph = new LocalizedDocsGraphBuilder(options).Build(docs, catalog);
+
+        var candidates = catalog.BuildLocalizedRouteCandidates(graph, options);
+
+        Assert.Contains(
+            candidates,
+            candidate => candidate.Locale == "fr"
+                         && candidate.SourcePath == "fr/guides/getting-started.md"
+                         && candidate.PublicRoutePath == "fr/guides/getting-started");
+        Assert.DoesNotContain(
+            candidates,
+            candidate => candidate.PublicRoutePath == "fr/fr/guides/getting-started");
+    }
+
+    [Fact]
     public void RouteCatalog_ShouldBuildHomeLocaleRouteCandidateWithoutTrailingSlash()
     {
         var options = RazorDocsLocalizationFixture.CreateOptions();

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
@@ -1,3 +1,4 @@
+using ForgeTrust.AppSurface.Docs;
 using ForgeTrust.AppSurface.Docs.Services;
 using YamlDotNet.Core;
 
@@ -38,6 +39,67 @@ public sealed class MarkdownFrontMatterParserTests
         Assert.Equal("Build forms, streams, and handlers together.", metadata?.Summary);
         Assert.Equal(["forms, anti-forgery", "quickstart"], metadata?.Aliases);
         Assert.Equal(["forms", "agent docs"], metadata?.Keywords);
+    }
+
+    [Fact]
+    public void Extract_ShouldParseFriendlyLocalizationMetadata()
+    {
+        var markdown = """
+            ---
+            locale: fr
+            translation_key: guides/getting-started
+            localized_title: Démarrer
+            locale_fallback: Disabled
+            ---
+            # Démarrer
+            """;
+
+        var (_, metadata) = MarkdownFrontMatterParser.Extract(markdown);
+
+        Assert.Equal("fr", metadata?.Localization?.Locale);
+        Assert.Equal("guides/getting-started", metadata?.Localization?.TranslationKey);
+        Assert.Equal("Démarrer", metadata?.Localization?.LocalizedTitle);
+        Assert.Equal(RazorDocsLocaleFallbackMode.Disabled, metadata?.Localization?.LocaleFallback);
+    }
+
+    [Fact]
+    public void Extract_ShouldParseNestedLocalizationMetadata()
+    {
+        var markdown = """
+            ---
+            localization:
+              locale: fr
+              translation_key: guides/getting-started
+              localized_title: Démarrer
+            ---
+            # Démarrer
+            """;
+
+        var (_, metadata) = MarkdownFrontMatterParser.Extract(markdown);
+
+        Assert.Equal("fr", metadata?.Localization?.Locale);
+        Assert.Equal("guides/getting-started", metadata?.Localization?.TranslationKey);
+        Assert.Equal("Démarrer", metadata?.Localization?.LocalizedTitle);
+    }
+
+    [Fact]
+    public void ExtractWithDiagnostics_ShouldReportInvalidLocaleFallback()
+    {
+        var markdown = """
+            ---
+            locale: fr
+            locale_fallback: Sometimes
+            ---
+            # Démarrer
+            """;
+
+        var (_, result) = MarkdownFrontMatterParser.ExtractWithDiagnostics(markdown);
+
+        Assert.Equal("fr", result.Metadata?.Localization?.Locale);
+        Assert.Null(result.Metadata?.Localization?.LocaleFallback);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("invalid-locale-fallback", diagnostic.Code);
+        Assert.Equal("locale_fallback", diagnostic.FieldPath);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
@@ -103,6 +103,26 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void ExtractWithDiagnostics_ShouldReportConflictingFlatAndNestedLocalizationFields()
+    {
+        var markdown = """
+            ---
+            locale: fr
+            localization:
+              locale: en
+            ---
+            # Démarrer
+            """;
+
+        var (_, result) = MarkdownFrontMatterParser.ExtractWithDiagnostics(markdown);
+
+        Assert.Equal("fr", result.Metadata?.Localization?.Locale);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("localization-field-conflict", diagnostic.Code);
+        Assert.Equal("locale", diagnostic.FieldPath);
+    }
+
+    [Fact]
     public void Extract_ShouldParseFeaturedPageGroups()
     {
         var markdown = """

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
@@ -103,6 +103,25 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void ExtractWithDiagnostics_ShouldReportNestedInvalidLocaleFallbackPath()
+    {
+        var markdown = """
+            ---
+            locale: fr
+            localization:
+              locale_fallback: Sometimes
+            ---
+            # Démarrer
+            """;
+
+        var (_, result) = MarkdownFrontMatterParser.ExtractWithDiagnostics(markdown);
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("invalid-locale-fallback", diagnostic.Code);
+        Assert.Equal("localization.locale_fallback", diagnostic.FieldPath);
+    }
+
+    [Fact]
     public void ExtractWithDiagnostics_ShouldReportConflictingFlatAndNestedLocalizationFields()
     {
         var markdown = """

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/MarkdownFrontMatterParserTests.cs
@@ -142,6 +142,30 @@ public sealed class MarkdownFrontMatterParserTests
     }
 
     [Fact]
+    public void ExtractWithDiagnostics_ShouldTreatCaseOnlyLocalizationValuesAsEquivalent()
+    {
+        var markdown = """
+            ---
+            locale: FR
+            translation_key: Guides/Getting-Started
+            locale_fallback: disabled
+            localization:
+              locale: fr
+              translation_key: guides/getting-started
+              locale_fallback: Disabled
+            ---
+            # Démarrer
+            """;
+
+        var (_, result) = MarkdownFrontMatterParser.ExtractWithDiagnostics(markdown);
+
+        Assert.Equal("FR", result.Metadata?.Localization?.Locale);
+        Assert.Equal("Guides/Getting-Started", result.Metadata?.Localization?.TranslationKey);
+        Assert.Equal(RazorDocsLocaleFallbackMode.Disabled, result.Metadata?.Localization?.LocaleFallback);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void Extract_ShouldParseFeaturedPageGroups()
     {
         var markdown = """

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsLocalizationFixture.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsLocalizationFixture.cs
@@ -1,0 +1,64 @@
+using ForgeTrust.AppSurface.Docs.Models;
+using ForgeTrust.AppSurface.Docs.Services;
+
+namespace ForgeTrust.AppSurface.Docs.Tests;
+
+internal static class RazorDocsLocalizationFixture
+{
+    internal static RazorDocsLocalizationOptions CreateOptions()
+    {
+        return new RazorDocsLocalizationOptions
+        {
+            Enabled = true,
+            DefaultLocale = "en",
+            Locales =
+            [
+                new RazorDocsLocaleOptions
+                {
+                    Code = "en",
+                    Label = "English"
+                },
+                new RazorDocsLocaleOptions
+                {
+                    Code = "fr",
+                    Label = "Français"
+                }
+            ]
+        };
+    }
+
+    internal static DocNode MarkdownDoc(
+        string path,
+        string title,
+        string? locale = null,
+        string? translationKey = null,
+        RazorDocsLocaleFallbackMode? fallback = null,
+        string? canonicalSlug = null)
+    {
+        return new DocNode(
+            title,
+            path,
+            $"<h1>{title}</h1><p>Body</p>",
+            Metadata: new DocMetadata
+            {
+                Title = title,
+                CanonicalSlug = canonicalSlug,
+                Localization = locale is null && translationKey is null && fallback is null
+                    ? null
+                    : new DocLocalizationMetadata
+                    {
+                        Locale = locale,
+                        TranslationKey = translationKey,
+                        LocaleFallback = fallback
+                    }
+            });
+    }
+
+    internal static LocalizedDocsGraph BuildGraph(
+        RazorDocsLocalizationOptions options,
+        params DocNode[] docs)
+    {
+        var catalog = DocRouteIdentityCatalog.Create(docs, new DocsUrlBuilder(new RazorDocsOptions()));
+        return new LocalizedDocsGraphBuilder(options).Build(docs, catalog);
+    }
+}

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsLocalizationFixture.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsLocalizationFixture.cs
@@ -32,6 +32,7 @@ internal static class RazorDocsLocalizationFixture
         string title,
         string? locale = null,
         string? translationKey = null,
+        string? localizedTitle = null,
         RazorDocsLocaleFallbackMode? fallback = null,
         string? canonicalSlug = null)
     {
@@ -43,12 +44,13 @@ internal static class RazorDocsLocalizationFixture
             {
                 Title = title,
                 CanonicalSlug = canonicalSlug,
-                Localization = locale is null && translationKey is null && fallback is null
+                Localization = locale is null && translationKey is null && localizedTitle is null && fallback is null
                     ? null
                     : new DocLocalizationMetadata
                     {
                         Locale = locale,
                         TranslationKey = translationKey,
+                        LocalizedTitle = localizedTitle,
                         LocaleFallback = fallback
                     }
             });

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
@@ -31,6 +31,12 @@ public sealed class RazorDocsOptionsTests
         Assert.Equal(1, (int)DocHarvestHealthStatus.Empty);
         Assert.Equal(2, (int)DocHarvestHealthStatus.Degraded);
         Assert.Equal(3, (int)DocHarvestHealthStatus.Failed);
+        Assert.Equal(0, (int)RazorDocsLocaleRouteMode.LocalePrefix);
+        Assert.Equal(0, (int)RazorDocsLocaleFallbackMode.DefaultLocaleWithNotice);
+        Assert.Equal(1, (int)RazorDocsLocaleFallbackMode.Disabled);
+        Assert.Equal(0, (int)RazorDocsLocaleSearchMode.ActiveLocale);
+        Assert.Equal(0, (int)RazorDocsTextDirection.Ltr);
+        Assert.Equal(1, (int)RazorDocsTextDirection.Rtl);
         Assert.Equal(0, (int)DocHarvesterHealthStatus.Succeeded);
         Assert.Equal(1, (int)DocHarvesterHealthStatus.ReturnedEmpty);
         Assert.Equal(2, (int)DocHarvesterHealthStatus.Failed);
@@ -56,6 +62,11 @@ public sealed class RazorDocsOptionsTests
         Assert.Equal("razordocs.routes.invalid_canonical_slug", DocHarvestDiagnosticCodes.DocInvalidCanonicalSlug);
         Assert.Equal("razordocs.routes.invalid_redirect_alias", DocHarvestDiagnosticCodes.DocInvalidRedirectAlias);
         Assert.Equal("razordocs.routes.lossy_slug_normalization", DocHarvestDiagnosticCodes.DocLossySlugNormalization);
+        Assert.Equal("razordocs.localization.unsupported_locale", DocHarvestDiagnosticCodes.LocalizationUnsupportedLocale);
+        Assert.Equal("razordocs.localization.missing_base", DocHarvestDiagnosticCodes.LocalizationMissingBase);
+        Assert.Equal("razordocs.localization.duplicate_variant", DocHarvestDiagnosticCodes.LocalizationDuplicateVariant);
+        Assert.Equal("razordocs.localization.locale_folder_conflict", DocHarvestDiagnosticCodes.LocalizationLocaleFolderConflict);
+        Assert.Equal("razordocs.localization.fallback_disabled_missing_variant", DocHarvestDiagnosticCodes.LocalizationFallbackDisabledMissingVariant);
     }
 
     [Fact]
@@ -106,6 +117,123 @@ public sealed class RazorDocsOptionsTests
         Assert.NotNull(options.Harvest.Health);
         Assert.Equal(RazorDocsHarvestHealthExposure.DevelopmentOnly, options.Harvest.Health.ExposeRoutes);
         Assert.Equal(RazorDocsHarvestHealthExposure.DevelopmentOnly, options.Harvest.Health.ShowChrome);
+    }
+
+    [Fact]
+    public void RazorDocsOptions_ShouldDefaultLocalizationToDisabledEnglish()
+    {
+        var options = new RazorDocsOptions();
+
+        Assert.NotNull(options.Localization);
+        Assert.False(options.Localization.Enabled);
+        Assert.Equal("en", options.Localization.DefaultLocale);
+        Assert.Empty(options.Localization.Locales);
+        Assert.Equal(RazorDocsLocaleRouteMode.LocalePrefix, options.Localization.RouteMode);
+        Assert.Equal(RazorDocsLocaleFallbackMode.DefaultLocaleWithNotice, options.Localization.FallbackMode);
+        Assert.Equal(RazorDocsLocaleSearchMode.ActiveLocale, options.Localization.SearchMode);
+    }
+
+    [Fact]
+    public void AddRazorDocs_ShouldBindAndNormalizeConfiguredLocalizationOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["RazorDocs:Localization:Enabled"] = "true",
+                        ["RazorDocs:Localization:DefaultLocale"] = " en ",
+                        ["RazorDocs:Localization:Locales:0:Code"] = " en ",
+                        ["RazorDocs:Localization:Locales:0:Label"] = " English ",
+                        ["RazorDocs:Localization:Locales:0:Lang"] = " en-US ",
+                        ["RazorDocs:Localization:Locales:0:Direction"] = "Ltr",
+                        ["RazorDocs:Localization:Locales:0:RoutePrefix"] = " en ",
+                        ["RazorDocs:Localization:Locales:1:Code"] = " fr ",
+                        ["RazorDocs:Localization:Locales:1:Label"] = " Français ",
+                        ["RazorDocs:Localization:Locales:1:Direction"] = "Rtl"
+                    })
+                .Build());
+
+        services.AddRazorDocs();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<RazorDocsOptions>>().Value;
+
+        Assert.True(options.Localization.Enabled);
+        Assert.Equal("en", options.Localization.DefaultLocale);
+        Assert.Collection(
+            options.Localization.Locales,
+            en =>
+            {
+                Assert.Equal("en", en.Code);
+                Assert.Equal("English", en.Label);
+                Assert.Equal("en-US", en.Lang);
+                Assert.Equal(RazorDocsTextDirection.Ltr, en.Direction);
+                Assert.Equal("en", en.RoutePrefix);
+            },
+            fr =>
+            {
+                Assert.Equal("fr", fr.Code);
+                Assert.Equal("Français", fr.Label);
+                Assert.Equal(RazorDocsTextDirection.Rtl, fr.Direction);
+            });
+    }
+
+    [Fact]
+    public void AddRazorDocs_ShouldRejectEnabledLocalizationWithoutLocales()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["RazorDocs:Localization:Enabled"] = "true"
+                    })
+                .Build());
+
+        services.AddRazorDocs();
+
+        using var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => _ = provider.GetRequiredService<IOptions<RazorDocsOptions>>().Value);
+
+        Assert.Contains(
+            ex.Failures,
+            failure => failure.Contains("at least one configured locale", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("search")]
+    [InlineData("versions")]
+    [InlineData("v")]
+    [InlineData("fr/docs")]
+    [InlineData("..")]
+    public void AddRazorDocs_ShouldRejectInvalidLocalizationRoutePrefixes(string routePrefix)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["RazorDocs:Localization:Enabled"] = "true",
+                        ["RazorDocs:Localization:DefaultLocale"] = "en",
+                        ["RazorDocs:Localization:Locales:0:Code"] = "en",
+                        ["RazorDocs:Localization:Locales:0:RoutePrefix"] = routePrefix
+                    })
+                .Build());
+
+        services.AddRazorDocs();
+
+        using var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => _ = provider.GetRequiredService<IOptions<RazorDocsOptions>>().Value);
+
+        Assert.NotEmpty(ex.Failures);
     }
 
     [Fact]
@@ -470,7 +598,8 @@ public sealed class RazorDocsOptionsTests
                     "Harvest": null,
                     "Bundle": null,
                     "Sidebar": null,
-                    "Contributor": null
+                    "Contributor": null,
+                    "Localization": null
                   }
                 }
                 """));
@@ -490,11 +619,16 @@ public sealed class RazorDocsOptionsTests
         Assert.NotNull(options.Bundle);
         Assert.NotNull(options.Sidebar);
         Assert.NotNull(options.Contributor);
+        Assert.NotNull(options.Localization);
         Assert.False(options.Harvest.FailOnFailure);
         Assert.Equal(RazorDocsHarvestHealthExposure.DevelopmentOnly, options.Harvest.Health.ExposeRoutes);
         Assert.Equal(RazorDocsHarvestHealthExposure.DevelopmentOnly, options.Harvest.Health.ShowChrome);
         Assert.NotNull(options.Sidebar.NamespacePrefixes);
         Assert.Empty(options.Sidebar.NamespacePrefixes);
+        Assert.False(options.Localization.Enabled);
+        Assert.Equal("en", options.Localization.DefaultLocale);
+        Assert.NotNull(options.Localization.Locales);
+        Assert.Empty(options.Localization.Locales);
     }
 
     [Fact]
@@ -526,6 +660,20 @@ public sealed class RazorDocsOptionsTests
             SymbolSourceUrlTemplate = " https://example.com/blob/{ref}/{path}#L{line} ",
             SourceRef = " abc123 "
         };
+        var localization = new RazorDocsLocalizationOptions
+        {
+            DefaultLocale = " en ",
+            Locales =
+            [
+                new RazorDocsLocaleOptions
+                {
+                    Code = " en ",
+                    Label = " English ",
+                    Lang = " en-US ",
+                    RoutePrefix = " en "
+                }
+            ]
+        };
 
         services.Configure<RazorDocsOptions>(
             options =>
@@ -535,6 +683,7 @@ public sealed class RazorDocsOptionsTests
                 options.Bundle = bundle;
                 options.Sidebar = sidebar;
                 options.Contributor = contributor;
+                options.Localization = localization;
             });
 
         services.AddRazorDocs();
@@ -547,6 +696,7 @@ public sealed class RazorDocsOptionsTests
         Assert.Same(bundle, options.Bundle);
         Assert.Same(sidebar, options.Sidebar);
         Assert.Same(contributor, options.Contributor);
+        Assert.Same(localization, options.Localization);
         Assert.Equal("/tmp/configured-root", options.Source.RepositoryRoot);
         Assert.True(options.Harvest.FailOnFailure);
         Assert.Equal(RazorDocsHarvestHealthExposure.Never, options.Harvest.Health.ShowChrome);
@@ -557,6 +707,12 @@ public sealed class RazorDocsOptionsTests
         Assert.Equal("https://example.com/edit/{branch}/{path}", options.Contributor.EditUrlTemplate);
         Assert.Equal("https://example.com/blob/{ref}/{path}#L{line}", options.Contributor.SymbolSourceUrlTemplate);
         Assert.Equal("abc123", options.Contributor.SourceRef);
+        Assert.Equal("en", options.Localization.DefaultLocale);
+        var locale = Assert.Single(options.Localization.Locales);
+        Assert.Equal("en", locale.Code);
+        Assert.Equal("English", locale.Label);
+        Assert.Equal("en-US", locale.Lang);
+        Assert.Equal("en", locale.RoutePrefix);
     }
 
     [Fact]
@@ -574,6 +730,7 @@ public sealed class RazorDocsOptionsTests
                 options.Bundle = null!;
                 options.Sidebar = null!;
                 options.Contributor = null!;
+                options.Localization = null!;
             });
 
         using var provider = services.BuildServiceProvider();
@@ -585,11 +742,16 @@ public sealed class RazorDocsOptionsTests
         Assert.NotNull(options.Bundle);
         Assert.NotNull(options.Sidebar);
         Assert.NotNull(options.Contributor);
+        Assert.NotNull(options.Localization);
         Assert.False(options.Harvest.FailOnFailure);
         Assert.Equal(RazorDocsHarvestHealthExposure.DevelopmentOnly, options.Harvest.Health.ExposeRoutes);
         Assert.Equal(RazorDocsHarvestHealthExposure.DevelopmentOnly, options.Harvest.Health.ShowChrome);
         Assert.NotNull(options.Sidebar.NamespacePrefixes);
         Assert.Empty(options.Sidebar.NamespacePrefixes);
+        Assert.False(options.Localization.Enabled);
+        Assert.Equal("en", options.Localization.DefaultLocale);
+        Assert.NotNull(options.Localization.Locales);
+        Assert.Empty(options.Localization.Locales);
     }
 
     [Fact]
@@ -814,7 +976,8 @@ public sealed class RazorDocsOptionsTests
             Sidebar = null!,
             Contributor = null!,
             Routing = null!,
-            Versioning = null!
+            Versioning = null!,
+            Localization = null!
         };
 
         var result = validator.Validate(Options.DefaultName, options);
@@ -826,6 +989,7 @@ public sealed class RazorDocsOptionsTests
         Assert.Contains(result.Failures, failure => failure.Contains("RazorDocs:Contributor must not be null.", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(result.Failures, failure => failure.Contains("RazorDocs:Routing must not be null.", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(result.Failures, failure => failure.Contains("RazorDocs:Versioning must not be null.", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("RazorDocs:Localization must not be null.", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
@@ -67,6 +67,7 @@ public sealed class RazorDocsOptionsTests
         Assert.Equal("razordocs.localization.duplicate_variant", DocHarvestDiagnosticCodes.LocalizationDuplicateVariant);
         Assert.Equal("razordocs.localization.locale_folder_conflict", DocHarvestDiagnosticCodes.LocalizationLocaleFolderConflict);
         Assert.Equal("razordocs.localization.fallback_disabled_missing_variant", DocHarvestDiagnosticCodes.LocalizationFallbackDisabledMissingVariant);
+        Assert.Equal("razordocs.localization.fallback_conflict", DocHarvestDiagnosticCodes.LocalizationFallbackConflict);
     }
 
     [Fact]

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
@@ -181,6 +181,40 @@ public sealed class RazorDocsOptionsTests
     }
 
     [Fact]
+    public void AddRazorDocs_ShouldSkipNullLocaleEntriesWhileNormalizingLocalizationOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.Configure<RazorDocsOptions>(
+            options =>
+            {
+                options.Localization.Locales =
+                [
+                    null!,
+                    new RazorDocsLocaleOptions
+                    {
+                        Code = " fr ",
+                        Label = " Français ",
+                        Lang = " fr-FR ",
+                        RoutePrefix = " français "
+                    }
+                ];
+            });
+
+        services.AddRazorDocs();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<RazorDocsOptions>>().Value;
+
+        Assert.Null(options.Localization.Locales[0]);
+        var locale = options.Localization.Locales[1];
+        Assert.Equal("fr", locale.Code);
+        Assert.Equal("Français", locale.Label);
+        Assert.Equal("fr-FR", locale.Lang);
+        Assert.Equal("français", locale.RoutePrefix);
+    }
+
+    [Fact]
     public void AddRazorDocs_ShouldRejectEnabledLocalizationWithoutLocales()
     {
         var services = new ServiceCollection();

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsOptionsTests.cs
@@ -205,12 +205,115 @@ public sealed class RazorDocsOptionsTests
             failure => failure.Contains("at least one configured locale", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void AddRazorDocs_ShouldRejectUnsupportedLocalizationEnumsAndNullLocales()
+    {
+        var result = new RazorDocsOptionsValidator().Validate(
+            null,
+            new RazorDocsOptions
+            {
+                Localization = new RazorDocsLocalizationOptions
+                {
+                    RouteMode = (RazorDocsLocaleRouteMode)42,
+                    FallbackMode = (RazorDocsLocaleFallbackMode)42,
+                    SearchMode = (RazorDocsLocaleSearchMode)42,
+                    Locales = null!
+                }
+            });
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, failure => failure.Contains("route mode", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("fallback mode", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("search mode", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("Localization:Locales", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AddRazorDocs_ShouldRejectInvalidLocalizationLocaleDefinitions()
+    {
+        var result = new RazorDocsOptionsValidator().Validate(
+            null,
+            new RazorDocsOptions
+            {
+                Localization = new RazorDocsLocalizationOptions
+                {
+                    Enabled = true,
+                    DefaultLocale = "de",
+                    Locales =
+                    [
+                        null!,
+                        new RazorDocsLocaleOptions(),
+                        new RazorDocsLocaleOptions
+                        {
+                            Code = "not_a_culture",
+                            Lang = "also_not_a_culture",
+                            Direction = (RazorDocsTextDirection)42,
+                            RoutePrefix = "shared"
+                        },
+                        new RazorDocsLocaleOptions
+                        {
+                            Code = "fr",
+                            RoutePrefix = "shared"
+                        },
+                        new RazorDocsLocaleOptions
+                        {
+                            Code = "fr",
+                            RoutePrefix = "fr-alt"
+                        }
+                    ]
+                }
+            });
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, failure => failure.Contains("Locales:0", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("Code is required", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("valid BCP-47 culture tag", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("Direction", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("configured more than once", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("route prefix 'shared'", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Failures, failure => failure.Contains("DefaultLocale must match", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AddRazorDocs_ShouldRejectBlankLocalizationDefaultLocale()
+    {
+        var result = new RazorDocsOptionsValidator().Validate(
+            null,
+            new RazorDocsOptions
+            {
+                Localization = new RazorDocsLocalizationOptions
+                {
+                    Enabled = true,
+                    DefaultLocale = " ",
+                    Locales =
+                    [
+                        new RazorDocsLocaleOptions { Code = "en" }
+                    ]
+                }
+            });
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, failure => failure.Contains("DefaultLocale is required", StringComparison.OrdinalIgnoreCase));
+    }
+
     [Theory]
     [InlineData("search")]
+    [InlineData("search-index.json")]
+    [InlineData("_health")]
+    [InlineData("_health.json")]
+    [InlineData("sections")]
     [InlineData("versions")]
     [InlineData("v")]
+    [InlineData("search.css")]
+    [InlineData("search-client.js")]
+    [InlineData("outline-client.js")]
+    [InlineData("minisearch.min.js")]
     [InlineData("fr/docs")]
     [InlineData("..")]
+    [InlineData("fr\\docs")]
+    [InlineData("fr?docs")]
+    [InlineData("fr#docs")]
+    [InlineData("fr.docs")]
     public void AddRazorDocs_ShouldRejectInvalidLocalizationRoutePrefixes(string routePrefix)
     {
         var services = new ServiceCollection();

--- a/Web/ForgeTrust.AppSurface.Docs/Models/DocModels.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Models/DocModels.cs
@@ -1,3 +1,5 @@
+using ForgeTrust.AppSurface.Docs;
+
 namespace ForgeTrust.AppSurface.Docs.Models;
 
 /// <summary>
@@ -130,6 +132,16 @@ public sealed record DocMetadata
     /// </summary>
     public DocContributorMetadata? Contributor { get; init; }
 
+    /// <summary>
+    /// Gets optional localization metadata used to connect translated variants of the same conceptual document.
+    /// </summary>
+    /// <remarks>
+    /// This nested contract keeps i18n-specific fields together while allowing friendly Markdown front matter aliases
+    /// such as <c>locale</c> and <c>translation_key</c>. <see cref="DocLocalizationMetadata.TranslationKey"/> is the
+    /// stable identity RazorDocs uses to switch languages without relying on matching localized paths.
+    /// </remarks>
+    public DocLocalizationMetadata? Localization { get; init; }
+
     internal bool? PageTypeIsDerived { get; init; }
 
     internal bool? AudienceIsDerived { get; init; }
@@ -215,7 +227,8 @@ public sealed record DocMetadata
             BreadcrumbsMatchPathTargets = breadcrumbsMatchPathTargets,
             FeaturedPageGroups = MergeLists(primary.FeaturedPageGroups, fallback.FeaturedPageGroups),
             Trust = DocTrustMetadata.Merge(primary.Trust, fallback.Trust),
-            Contributor = DocContributorMetadata.Merge(primary.Contributor, fallback.Contributor)
+            Contributor = DocContributorMetadata.Merge(primary.Contributor, fallback.Contributor),
+            Localization = DocLocalizationMetadata.Merge(primary.Localization, fallback.Localization)
         };
     }
 
@@ -261,6 +274,58 @@ public sealed record DocMetadata
         return fallbackValue is not null
             ? (fallbackValue, fallbackFlag)
             : (null, null);
+    }
+}
+
+/// <summary>
+/// Page-level localization metadata for one documentation node.
+/// </summary>
+/// <remarks>
+/// Authors can provide this metadata directly under <c>localization</c>, or with friendly flat front matter keys such
+/// as <c>locale</c>, <c>translation_key</c>, <c>localized_title</c>, and <c>locale_fallback</c>. The metadata does not
+/// make a page public on its own; the locale-aware document graph combines it with configured locales and route identity.
+/// </remarks>
+public sealed record DocLocalizationMetadata
+{
+    /// <summary>
+    /// Gets the authored or inferred BCP-47 locale code for this document variant.
+    /// </summary>
+    public string? Locale { get; init; }
+
+    /// <summary>
+    /// Gets the stable conceptual page identity shared by translated variants.
+    /// </summary>
+    public string? TranslationKey { get; init; }
+
+    /// <summary>
+    /// Gets an optional localized title override for language-switching and graph-derived navigation.
+    /// </summary>
+    public string? LocalizedTitle { get; init; }
+
+    /// <summary>
+    /// Gets an optional page-level missing-translation fallback policy.
+    /// </summary>
+    public RazorDocsLocaleFallbackMode? LocaleFallback { get; init; }
+
+    internal static DocLocalizationMetadata? Merge(DocLocalizationMetadata? primary, DocLocalizationMetadata? fallback)
+    {
+        if (primary is null)
+        {
+            return fallback;
+        }
+
+        if (fallback is null)
+        {
+            return primary;
+        }
+
+        return new DocLocalizationMetadata
+        {
+            Locale = DocTrustMergeHelpers.PreferNonBlank(primary.Locale, fallback.Locale),
+            TranslationKey = DocTrustMergeHelpers.PreferNonBlank(primary.TranslationKey, fallback.TranslationKey),
+            LocalizedTitle = DocTrustMergeHelpers.PreferNonBlank(primary.LocalizedTitle, fallback.LocalizedTitle),
+            LocaleFallback = primary.LocaleFallback ?? fallback.LocaleFallback
+        };
     }
 }
 
@@ -733,6 +798,31 @@ public static class DocHarvestDiagnosticCodes
     /// RazorDocs had to drop or fold characters while normalizing a public route slug.
     /// </summary>
     public const string DocLossySlugNormalization = "razordocs.routes.lossy_slug_normalization";
+
+    /// <summary>
+    /// A localized document variant declared or inferred an unsupported locale.
+    /// </summary>
+    public const string LocalizationUnsupportedLocale = "razordocs.localization.unsupported_locale";
+
+    /// <summary>
+    /// A localized document variant uses a colocated locale suffix but the base document is missing.
+    /// </summary>
+    public const string LocalizationMissingBase = "razordocs.localization.missing_base";
+
+    /// <summary>
+    /// Multiple localized variants resolved to the same translation identity and locale.
+    /// </summary>
+    public const string LocalizationDuplicateVariant = "razordocs.localization.duplicate_variant";
+
+    /// <summary>
+    /// Folder-inferred locale and authored locale metadata disagree.
+    /// </summary>
+    public const string LocalizationLocaleFolderConflict = "razordocs.localization.locale_folder_conflict";
+
+    /// <summary>
+    /// A document disables fallback but is missing one or more configured locale variants.
+    /// </summary>
+    public const string LocalizationFallbackDisabledMissingVariant = "razordocs.localization.fallback_disabled_missing_variant";
 }
 
 /// <summary>

--- a/Web/ForgeTrust.AppSurface.Docs/Models/DocModels.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Models/DocModels.cs
@@ -307,6 +307,16 @@ public sealed record DocLocalizationMetadata
     /// </summary>
     public RazorDocsLocaleFallbackMode? LocaleFallback { get; init; }
 
+    /// <summary>
+    /// Merges primary and fallback localization metadata using the same precedence rules as document metadata overlays.
+    /// </summary>
+    /// <remarks>
+    /// Primary <see cref="Locale"/>, <see cref="TranslationKey"/>, and <see cref="LocalizedTitle"/> values win only when
+    /// they are non-blank; otherwise <see cref="DocTrustMergeHelpers.PreferNonBlank"/> trims and selects the fallback
+    /// value. <see cref="LocaleFallback"/> uses nullable coalescing, so the primary enum value wins when present and the
+    /// fallback enum is used only when the primary omits a page-level policy. A blank primary string is therefore not a
+    /// deliberate override.
+    /// </remarks>
     internal static DocLocalizationMetadata? Merge(DocLocalizationMetadata? primary, DocLocalizationMetadata? fallback)
     {
         if (primary is null)
@@ -823,6 +833,11 @@ public static class DocHarvestDiagnosticCodes
     /// A document disables fallback but is missing one or more configured locale variants.
     /// </summary>
     public const string LocalizationFallbackDisabledMissingVariant = "razordocs.localization.fallback_disabled_missing_variant";
+
+    /// <summary>
+    /// Variants for the same translation identity declare conflicting fallback policies.
+    /// </summary>
+    public const string LocalizationFallbackConflict = "razordocs.localization.fallback_conflict";
 }
 
 /// <summary>

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -17,6 +17,7 @@ If you are evaluating RazorDocs for your own repository, start with [Use RazorDo
 - `DocsUrlBuilder` plus the MVC surface used by RazorDocs consumers so the live docs root, search shell, and archive routes stay in one shared contract
 - `RazorDocsVersionCatalog` plus `RazorDocsVersionCatalogService` for mounting exact published release trees and surfacing release-level status in the public archive
 - Structured trust metadata plus a built-in trust bar for release notes, upgrade guides, and other pages that need status and provenance near the top
+- A source-backed localization foundation with typed locale options, locale metadata, translation-set inference, and diagnostics for serious multi-language docs systems
 - Contributor provenance rendering with a `Source of truth` strip for source links, edit links, and relative `Last updated` timestamps on details pages
 - Precompiled Tailwind-powered styling with layout-time path resolution for root-module and embedded hosts
 
@@ -222,6 +223,11 @@ RazorDocs currently emits these codes:
 - `DocHarvestDiagnosticCodes.DocInvalidCanonicalSlug` (`razordocs.routes.invalid_canonical_slug`)
 - `DocHarvestDiagnosticCodes.DocInvalidRedirectAlias` (`razordocs.routes.invalid_redirect_alias`)
 - `DocHarvestDiagnosticCodes.DocLossySlugNormalization` (`razordocs.routes.lossy_slug_normalization`)
+- `DocHarvestDiagnosticCodes.LocalizationUnsupportedLocale` (`razordocs.localization.unsupported_locale`)
+- `DocHarvestDiagnosticCodes.LocalizationMissingBase` (`razordocs.localization.missing_base`)
+- `DocHarvestDiagnosticCodes.LocalizationDuplicateVariant` (`razordocs.localization.duplicate_variant`)
+- `DocHarvestDiagnosticCodes.LocalizationLocaleFolderConflict` (`razordocs.localization.locale_folder_conflict`)
+- `DocHarvestDiagnosticCodes.LocalizationFallbackDisabledMissingVariant` (`razordocs.localization.fallback_disabled_missing_variant`)
 
 An all-failed snapshot logs one critical message when that snapshot is generated. Reusing the cached health snapshot does not log again. Calling `InvalidateCache()` and then reading docs or harvest health can generate a new snapshot and, if every harvester still fails, a new critical log entry.
 
@@ -421,6 +427,96 @@ redirect_aliases:
 
 `canonical_slug` and `redirect_aliases` are docs-root-relative route paths. Do not include a query string, fragment, leading docs root, or host name. Canonical slugs use the same deterministic segment normalization as source-derived Markdown routes. Redirect aliases preserve their literal authored route text after separator cleanup, so legacy URLs such as `Old_Path/Guide.md.html` keep their existing shape instead of being slugified. Aliases redirect permanently to the public canonical route and preserve the request query string. Public Markdown source paths such as `/docs/foo.md` and `/docs/foo.md.html` also redirect to the clean route so GitHub-style copy-pasted links recover automatically. Use `redirect_aliases` for non-source legacy URLs, renamed pages, and old route shapes that are not already implied by the source path. Declared aliases that try to shadow another public Markdown source path are ignored with a `DocRedirectAliasCollision` diagnostic so copy-pasted source URLs keep pointing at their owning page.
 
+### Localization foundation
+
+RazorDocs has a source-backed localization foundation for hosts that need multilingual docs without changing the current browser-visible contract yet. Localization is disabled by default. When enabled, RazorDocs validates configured locales, reads locale metadata from Markdown front matter and sidecars, infers translation sets for colocated files such as `README.fr.md`, builds an internal locale graph, emits stable diagnostics, and reserves a search projection seam. Phase 1 does not add visible language switchers, fallback pages, localized route matching, localized SEO tags, or locale-filtered search results.
+
+Enable it under `RazorDocs:Localization`:
+
+```json
+{
+  "RazorDocs": {
+    "Localization": {
+      "Enabled": true,
+      "DefaultLocale": "en",
+      "Locales": [
+        {
+          "Code": "en",
+          "Label": "English",
+          "Lang": "en-US",
+          "Direction": "Ltr",
+          "RoutePrefix": "en"
+        },
+        {
+          "Code": "fr",
+          "Label": "Français",
+          "Lang": "fr-FR",
+          "Direction": "Ltr",
+          "RoutePrefix": "fr"
+        }
+      ],
+      "RouteMode": "LocalePrefix",
+      "FallbackMode": "DefaultLocaleWithNotice",
+      "SearchMode": "ActiveLocale"
+    }
+  }
+}
+```
+
+Author localization metadata either as friendly top-level keys or as a nested `localization:` block:
+
+```yaml
+---
+title: Getting started
+locale: fr
+translation_key: guides/getting-started
+localized_title: Démarrer
+locale_fallback: Disabled
+---
+```
+
+```yaml
+---
+title: Getting started
+localization:
+  locale: fr
+  translation_key: guides/getting-started
+  localized_title: Démarrer
+  locale_fallback: Disabled
+---
+```
+
+The supported metadata shape is:
+
+- `locale`: optional BCP-47 locale code. It must match a configured `Locales[].Code` when localization is enabled.
+- `translation_key`: optional stable identity shared by all translations of the same page. Use a route-like value such as `guides/getting-started`.
+- `localized_title`: optional title for locale-aware UI surfaces. The current page title still follows the existing `title`, H1, and fallback resolution.
+- `locale_fallback`: optional per-page fallback mode. Supported values are `DefaultLocaleWithNotice` and `Disabled`.
+
+Inference behavior:
+
+- A configured suffix such as `README.fr.md` infers locale `fr` and groups with `README.md`.
+- A suffix that looks like a culture tag but is not configured emits `LocalizationUnsupportedLocale` and is excluded from the locale graph so it cannot masquerade as default-locale content.
+- A locale-prefixed folder such as `fr/guides/start.md` infers locale only when the page also authors `translation_key`; this avoids treating ordinary folders as language roots by accident.
+- A locale-prefixed folder that disagrees with authored `locale` emits `LocalizationLocaleFolderConflict`, and authored metadata wins.
+- A localized suffix variant without its base/default-locale document emits `LocalizationMissingBase`.
+- Two documents with the same `translation_key` and locale emit `LocalizationDuplicateVariant`.
+- A translation set with `locale_fallback: Disabled` or global `FallbackMode: Disabled` emits `LocalizationFallbackDisabledMissingVariant` when a configured locale has no variant.
+
+Decision guidance:
+
+- Prefer colocated files such as `README.md` and `README.fr.md` when translations should stay next to the source page and remain readable in GitHub.
+- Prefer explicit `translation_key` when translated source paths differ substantially, when locale folders are used, or when the source file name is not stable enough to identify the concept.
+- Keep `RoutePrefix` to one safe segment such as `fr` or `pt-br`. RazorDocs rejects prefixes that collide with reserved docs routes such as `search`, `versions`, and `v`.
+- Keep exact published-version localization out of this contract for now. Localized release exports need their own immutable artifact design.
+
+Pitfalls:
+
+- Do not expect enabling localization to create visible `/fr/...` pages yet. The internal graph can produce route candidates, but request routing and fallback rendering are follow-up work.
+- Do not use locale folder inference without `translation_key`. RazorDocs deliberately fails closed so a folder named `fr` can still be ordinary content.
+- Do not reuse a `translation_key` for unrelated pages. It is the identity that future switchers, fallback routes, and search grouping will depend on.
+- Do not parse diagnostic messages. Branch on `DocHarvestDiagnosticCodes.Localization*` constants.
+
 ### Option reference
 
 - `RazorDocs:Mode`
@@ -467,6 +563,28 @@ redirect_aliases:
   - `/` is supported for single-purpose unversioned docs hosts.
   - The path must be app-relative, must not end with `/` except for `/`, and cannot contain query or fragment segments.
   - When versioning is on, it cannot equal the route root and cannot use the route root's reserved archive or exact-version children, such as `/foo/bar/versions`, `/foo/bar/v`, or `/foo/bar/v/1.2.3`.
+- `RazorDocs:Localization:Enabled`
+  - Defaults to `false`.
+  - When `false`, RazorDocs keeps existing routes, visible UI, and search payload behavior.
+  - When `true`, `DefaultLocale` and at least one configured locale are required.
+- `RazorDocs:Localization:DefaultLocale`
+  - Defaults to `en`.
+  - Must match one configured locale code when localization is enabled.
+- `RazorDocs:Localization:Locales`
+  - Defaults to an empty array.
+  - Each entry requires `Code` when localization is enabled. `Code` and optional `Lang` must be valid BCP-47 culture tags.
+  - `Label` is optional reader-facing text for future language UI.
+  - `Direction` supports `Ltr` and `Rtl`.
+  - `RoutePrefix` defaults to `Code`; it must be one safe segment and cannot collide with reserved docs routes.
+- `RazorDocs:Localization:RouteMode`
+  - Defaults to `LocalePrefix`.
+  - The enum is public and versioned for future route strategies, but `LocalePrefix` is the only supported value today.
+- `RazorDocs:Localization:FallbackMode`
+  - Defaults to `DefaultLocaleWithNotice`.
+  - `Disabled` means missing variants should not receive fallback pages once localized route rendering exists.
+- `RazorDocs:Localization:SearchMode`
+  - Defaults to `ActiveLocale`.
+  - Phase 1 preserves the existing v1 search payload for every projection; locale-filtered search is deferred.
 - `RazorDocs:Versioning:Enabled`
   - Turns on the published-version route contract and archive surface.
   - Does not switch the runtime into bundle mode.

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -228,6 +228,7 @@ RazorDocs currently emits these codes:
 - `DocHarvestDiagnosticCodes.LocalizationDuplicateVariant` (`razordocs.localization.duplicate_variant`)
 - `DocHarvestDiagnosticCodes.LocalizationLocaleFolderConflict` (`razordocs.localization.locale_folder_conflict`)
 - `DocHarvestDiagnosticCodes.LocalizationFallbackDisabledMissingVariant` (`razordocs.localization.fallback_disabled_missing_variant`)
+- `DocHarvestDiagnosticCodes.LocalizationFallbackConflict` (`razordocs.localization.fallback_conflict`)
 
 An all-failed snapshot logs one critical message when that snapshot is generated. Reusing the cached health snapshot does not log again. Calling `InvalidateCache()` and then reading docs or harvest health can generate a new snapshot and, if every harvester still fails, a new critical log entry.
 

--- a/Web/ForgeTrust.AppSurface.Docs/RazorDocsOptions.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/RazorDocsOptions.cs
@@ -450,34 +450,70 @@ public sealed class RazorDocsLocalizationOptions
 }
 
 /// <summary>
-/// Describes one configured RazorDocs locale.
+/// Describes one configured RazorDocs locale validated during RazorDocs startup.
 /// </summary>
+/// <remarks>
+/// Locale entries are runtime configuration, not loose display hints: <see cref="Code"/> values must be unique valid
+/// BCP-47 tags, and resolved route prefixes must be unique and avoid RazorDocs reserved route segments. Omitted
+/// <see cref="Lang"/> and <see cref="RoutePrefix"/> values fall back to <see cref="Code"/>, so duplicate codes or route
+/// aliases can fail startup validation even when those properties are not explicitly set.
+/// </remarks>
 public sealed class RazorDocsLocaleOptions
 {
     /// <summary>
-    /// Gets or sets the BCP-47 locale code, such as <c>en</c>, <c>fr</c>, or <c>pt-BR</c>.
+    /// Gets or sets the unique BCP-47 locale code, such as <c>en</c>, <c>fr</c>, or <c>pt-BR</c>.
     /// </summary>
+    /// <remarks>
+    /// The code is required, must parse as a culture name, and becomes the default <see cref="Lang"/> and
+    /// <see cref="RoutePrefix"/> when those properties are blank.
+    /// </remarks>
     public string Code { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the reader-facing locale label, such as <c>English</c> or <c>Français</c>.
     /// </summary>
+    /// <remarks>
+    /// The label is optional in Phase 1 and is not validated beyond normal configuration binding.
+    /// </remarks>
     public string? Label { get; set; }
 
     /// <summary>
     /// Gets or sets the HTML <c>lang</c> value. When omitted, <see cref="Code"/> is used.
     /// </summary>
+    /// <remarks>
+    /// Use this only when the rendered HTML language tag should differ from the configured RazorDocs locale code.
+    /// Blank values are treated as omitted and fall back to <see cref="Code"/>.
+    /// </remarks>
     public string? Lang { get; set; }
 
     /// <summary>
-    /// Gets or sets the text direction for this locale.
+    /// Gets or sets the text direction for this locale. Defaults to <see cref="RazorDocsTextDirection.Ltr"/>.
     /// </summary>
     public RazorDocsTextDirection Direction { get; set; } = RazorDocsTextDirection.Ltr;
 
     /// <summary>
     /// Gets or sets the route segment used for this locale. When omitted, <see cref="Code"/> is used.
     /// </summary>
+    /// <remarks>
+    /// The resolved route prefix must be unique across configured locales and must not collide with reserved RazorDocs
+    /// segments such as search, health, package, version, release, public-section, or asset endpoints. Collisions fail
+    /// startup validation.
+    /// </remarks>
     public string? RoutePrefix { get; set; }
+
+    /// <summary>
+    /// Resolves the locale route prefix after applying the documented fallback to <see cref="Code"/>.
+    /// </summary>
+    /// <remarks>
+    /// This helper centralizes prefix trimming so graph and route-candidate generation do not drift when
+    /// <see cref="RoutePrefix"/> is omitted.
+    /// </remarks>
+    internal string ResolveRoutePrefix()
+    {
+        return string.IsNullOrWhiteSpace(RoutePrefix)
+            ? Code.Trim()
+            : RoutePrefix!.Trim();
+    }
 }
 
 /// <summary>

--- a/Web/ForgeTrust.AppSurface.Docs/RazorDocsOptions.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/RazorDocsOptions.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using ForgeTrust.AppSurface.Docs.Services;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 
 namespace ForgeTrust.AppSurface.Docs;
 
@@ -90,6 +91,16 @@ public sealed class RazorDocsOptions
     /// Gets versioning settings used to mount exact release trees and the archive surface.
     /// </summary>
     public RazorDocsVersioningOptions Versioning { get; set; } = new();
+
+    /// <summary>
+    /// Gets localization settings for locale-aware live docs routes, metadata, search projections, and fallback policy.
+    /// </summary>
+    /// <remarks>
+    /// Localization is disabled by default so existing RazorDocs hosts keep their current routes, search payload shape,
+    /// and view behavior until they opt in. When enabled, this object defines the supported locales, the default locale,
+    /// route-prefix behavior, fallback policy, and search scoping defaults used by the locale-aware document graph.
+    /// </remarks>
+    public RazorDocsLocalizationOptions Localization { get; set; } = new();
 }
 
 /// <summary>
@@ -397,6 +408,145 @@ public sealed class RazorDocsVersioningOptions
 }
 
 /// <summary>
+/// Localization settings for the live RazorDocs source-backed documentation surface.
+/// </summary>
+/// <remarks>
+/// V1 localization applies only to the live source-backed docs surface. Published exact-version release trees keep the
+/// existing unlocalized route contract until localized release trees are designed as a separate feature. The built-in
+/// defaults keep localization off, use <c>en</c> as the default locale when enabled, prefix localized routes with the
+/// locale route segment, and default search to the active locale.
+/// </remarks>
+public sealed class RazorDocsLocalizationOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether RazorDocs builds locale-aware document graph data.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default locale code. Defaults to <c>en</c>.
+    /// </summary>
+    public string DefaultLocale { get; set; } = "en";
+
+    /// <summary>
+    /// Gets or sets the locales supported by the live docs surface.
+    /// </summary>
+    public RazorDocsLocaleOptions[] Locales { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets how locale prefixes are represented in public live docs routes.
+    /// </summary>
+    public RazorDocsLocaleRouteMode RouteMode { get; set; } = RazorDocsLocaleRouteMode.LocalePrefix;
+
+    /// <summary>
+    /// Gets or sets the global missing-translation fallback behavior.
+    /// </summary>
+    public RazorDocsLocaleFallbackMode FallbackMode { get; set; } = RazorDocsLocaleFallbackMode.DefaultLocaleWithNotice;
+
+    /// <summary>
+    /// Gets or sets the default localized search scope.
+    /// </summary>
+    public RazorDocsLocaleSearchMode SearchMode { get; set; } = RazorDocsLocaleSearchMode.ActiveLocale;
+}
+
+/// <summary>
+/// Describes one configured RazorDocs locale.
+/// </summary>
+public sealed class RazorDocsLocaleOptions
+{
+    /// <summary>
+    /// Gets or sets the BCP-47 locale code, such as <c>en</c>, <c>fr</c>, or <c>pt-BR</c>.
+    /// </summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the reader-facing locale label, such as <c>English</c> or <c>Français</c>.
+    /// </summary>
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTML <c>lang</c> value. When omitted, <see cref="Code"/> is used.
+    /// </summary>
+    public string? Lang { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text direction for this locale.
+    /// </summary>
+    public RazorDocsTextDirection Direction { get; set; } = RazorDocsTextDirection.Ltr;
+
+    /// <summary>
+    /// Gets or sets the route segment used for this locale. When omitted, <see cref="Code"/> is used.
+    /// </summary>
+    public string? RoutePrefix { get; set; }
+}
+
+/// <summary>
+/// Enumerates supported locale route modes.
+/// </summary>
+/// <remarks>
+/// Numeric values are part of the public configuration contract. Append new modes with new explicit values.
+/// </remarks>
+public enum RazorDocsLocaleRouteMode
+{
+    /// <summary>
+    /// Prefix live docs routes with a configured locale route segment.
+    /// </summary>
+    LocalePrefix = 0
+}
+
+/// <summary>
+/// Enumerates supported global localization fallback modes.
+/// </summary>
+/// <remarks>
+/// Numeric values are part of the public configuration contract. Append new modes with new explicit values.
+/// </remarks>
+public enum RazorDocsLocaleFallbackMode
+{
+    /// <summary>
+    /// Render default-locale content on the target-locale route with visible fallback context.
+    /// </summary>
+    DefaultLocaleWithNotice = 0,
+
+    /// <summary>
+    /// Do not create fallback pages for missing localized variants.
+    /// </summary>
+    Disabled = 1
+}
+
+/// <summary>
+/// Enumerates supported localized search defaults.
+/// </summary>
+/// <remarks>
+/// Numeric values are part of the public configuration contract. Append new modes with new explicit values.
+/// </remarks>
+public enum RazorDocsLocaleSearchMode
+{
+    /// <summary>
+    /// Search the active locale by default.
+    /// </summary>
+    ActiveLocale = 0
+}
+
+/// <summary>
+/// Enumerates supported text directions for localized docs pages.
+/// </summary>
+/// <remarks>
+/// Numeric values are part of the public configuration contract. Append new directions with new explicit values.
+/// </remarks>
+public enum RazorDocsTextDirection
+{
+    /// <summary>
+    /// Left-to-right text direction.
+    /// </summary>
+    Ltr = 0,
+
+    /// <summary>
+    /// Right-to-left text direction.
+    /// </summary>
+    Rtl = 1
+}
+
+/// <summary>
 /// Validates <see cref="RazorDocsOptions"/> and rejects unsupported or ambiguous startup configurations.
 /// </summary>
 public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOptions>
@@ -418,6 +568,7 @@ public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOption
         var contributor = options.Contributor;
         var routing = options.Routing;
         var versioning = options.Versioning;
+        var localization = options.Localization;
         string? normalizedRouteRootPath = null;
         string? normalizedDocsRootPath = null;
 
@@ -532,6 +683,8 @@ public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOption
         {
             failures.Add("RazorDocs:Versioning must not be null.");
         }
+
+        ValidateLocalization(localization, failures);
 
         if (options.Mode == RazorDocsMode.Bundle)
         {
@@ -705,5 +858,165 @@ public sealed class RazorDocsOptionsValidator : IValidateOptions<RazorDocsOption
         return string.Equals(docsRootPath, versionsRoot, StringComparison.OrdinalIgnoreCase)
                || string.Equals(docsRootPath, versionPrefix, StringComparison.OrdinalIgnoreCase)
                || docsRootPath.StartsWith(versionPrefix + "/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void ValidateLocalization(
+        RazorDocsLocalizationOptions? localization,
+        List<string> failures)
+    {
+        if (localization is null)
+        {
+            failures.Add("RazorDocs:Localization must not be null.");
+            return;
+        }
+
+        if (!Enum.IsDefined(localization.RouteMode))
+        {
+            failures.Add($"Unsupported RazorDocs localization route mode '{localization.RouteMode}'.");
+        }
+
+        if (!Enum.IsDefined(localization.FallbackMode))
+        {
+            failures.Add($"Unsupported RazorDocs localization fallback mode '{localization.FallbackMode}'.");
+        }
+
+        if (!Enum.IsDefined(localization.SearchMode))
+        {
+            failures.Add($"Unsupported RazorDocs localization search mode '{localization.SearchMode}'.");
+        }
+
+        if (localization.Locales is null)
+        {
+            failures.Add("RazorDocs:Localization:Locales must not be null.");
+            return;
+        }
+
+        if (!localization.Enabled)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(localization.DefaultLocale))
+        {
+            failures.Add("RazorDocs:Localization:DefaultLocale is required when localization is enabled.");
+        }
+
+        if (localization.Locales.Length == 0)
+        {
+            failures.Add("RazorDocs localization requires at least one configured locale when enabled.");
+            return;
+        }
+
+        var localeCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var routePrefixes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var defaultLocaleMatched = false;
+        for (var i = 0; i < localization.Locales.Length; i++)
+        {
+            var locale = localization.Locales[i];
+            var path = $"RazorDocs:Localization:Locales:{i}";
+            if (locale is null)
+            {
+                failures.Add($"{path} must not be null.");
+                continue;
+            }
+
+            var code = locale.Code;
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                failures.Add($"{path}:Code is required.");
+            }
+            else
+            {
+                if (!IsValidCultureTag(code))
+                {
+                    failures.Add($"{path}:Code must be a valid BCP-47 culture tag.");
+                }
+
+                if (!localeCodes.Add(code))
+                {
+                    failures.Add($"RazorDocs localization locale code '{code}' is configured more than once.");
+                }
+
+                if (string.Equals(code, localization.DefaultLocale, StringComparison.OrdinalIgnoreCase))
+                {
+                    defaultLocaleMatched = true;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(locale.Lang) && !IsValidCultureTag(locale.Lang))
+            {
+                failures.Add($"{path}:Lang must be a valid BCP-47 culture tag.");
+            }
+
+            if (!Enum.IsDefined(locale.Direction))
+            {
+                failures.Add($"{path}:Direction must be Ltr or Rtl.");
+            }
+
+            var routePrefix = string.IsNullOrWhiteSpace(locale.RoutePrefix) ? code : locale.RoutePrefix;
+            if (string.IsNullOrWhiteSpace(routePrefix))
+            {
+                failures.Add($"{path}:RoutePrefix is required when Code is blank.");
+            }
+            else if (!IsValidLocaleRoutePrefix(routePrefix))
+            {
+                failures.Add($"{path}:RoutePrefix must be a single safe route segment and must not contain '/', '?', '#', '.', or '..'.");
+            }
+            else if (IsReservedLocalizationRoutePrefix(routePrefix))
+            {
+                failures.Add($"{path}:RoutePrefix '{routePrefix}' collides with a reserved RazorDocs route segment.");
+            }
+            else if (!routePrefixes.Add(routePrefix))
+            {
+                failures.Add($"RazorDocs localization route prefix '{routePrefix}' is configured more than once.");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(localization.DefaultLocale)
+            && !defaultLocaleMatched)
+        {
+            failures.Add("RazorDocs:Localization:DefaultLocale must match one configured locale code.");
+        }
+    }
+
+    private static bool IsValidCultureTag(string value)
+    {
+        try
+        {
+            _ = System.Globalization.CultureInfo.GetCultureInfo(value.Trim());
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsValidLocaleRoutePrefix(string value)
+    {
+        var trimmed = value.Trim();
+        return trimmed.Length > 0
+               && !trimmed.Contains('/', StringComparison.Ordinal)
+               && !trimmed.Contains('\\', StringComparison.Ordinal)
+               && !trimmed.Contains('?', StringComparison.Ordinal)
+               && !trimmed.Contains('#', StringComparison.Ordinal)
+               && !trimmed.Contains('.', StringComparison.Ordinal)
+               && !string.Equals(trimmed, "..", StringComparison.Ordinal);
+    }
+
+    private static bool IsReservedLocalizationRoutePrefix(string value)
+    {
+        return value.Trim() is { } trimmed
+               && (trimmed.Equals("search", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("search-index.json", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("_health", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("_health.json", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("sections", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("versions", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("v", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("search.css", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("search-client.js", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("outline-client.js", StringComparison.OrdinalIgnoreCase)
+                   || trimmed.Equals("minisearch.min.js", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/Web/ForgeTrust.AppSurface.Docs/RazorDocsServiceCollectionExtensions.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/RazorDocsServiceCollectionExtensions.cs
@@ -73,7 +73,9 @@ public static class RazorDocsServiceCollectionExtensions
                     options.Contributor ??= new RazorDocsContributorOptions();
                     options.Routing ??= new RazorDocsRoutingOptions();
                     options.Versioning ??= new RazorDocsVersioningOptions();
+                    options.Localization ??= new RazorDocsLocalizationOptions();
                     options.Sidebar.NamespacePrefixes ??= [];
+                    options.Localization.Locales ??= [];
 
                     if (options.Source.RepositoryRoot is null)
                     {
@@ -102,6 +104,20 @@ public static class RazorDocsServiceCollectionExtensions
                     options.Versioning.CatalogPath = NormalizeOrNull(options.Versioning.CatalogPath);
                     options.Contributor.SymbolSourceUrlTemplate = NormalizeOrNull(options.Contributor.SymbolSourceUrlTemplate);
                     options.Contributor.SourceRef = NormalizeOrNull(options.Contributor.SourceRef);
+                    options.Localization.DefaultLocale = NormalizeOrNull(options.Localization.DefaultLocale) ?? "en";
+                    foreach (var locale in options.Localization.Locales)
+                    {
+                        if (locale is null)
+                        {
+                            continue;
+                        }
+
+                        locale.Code = NormalizeOrNull(locale.Code) ?? string.Empty;
+                        locale.Label = NormalizeOrNull(locale.Label);
+                        locale.Lang = NormalizeOrNull(locale.Lang);
+                        locale.RoutePrefix = NormalizeOrNull(locale.RoutePrefix);
+                    }
+
                     options.Sidebar.NamespacePrefixes = options.Sidebar.NamespacePrefixes
                         .Where(prefix => !string.IsNullOrWhiteSpace(prefix))
                         .Select(prefix => prefix.Trim())

--- a/Web/ForgeTrust.AppSurface.Docs/RazorDocsServiceCollectionExtensions.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/RazorDocsServiceCollectionExtensions.cs
@@ -33,9 +33,13 @@ public static class RazorDocsServiceCollectionExtensions
     /// <see cref="RazorDocsRoutingOptions.DocsRootPath"/> through
     /// <see cref="DocsUrlBuilder.NormalizeRouteRootPath(string?, string, bool)"/> and
     /// <see cref="DocsUrlBuilder.NormalizeDocsRootPath(string?, bool)"/>, trims
-    /// <see cref="RazorDocsVersioningOptions.CatalogPath"/>, and removes blank or duplicate sidebar namespace
-    /// prefixes. Callers that omit <see cref="RazorDocsOptions.Routing"/> or
-    /// <see cref="RazorDocsOptions.Versioning"/> can therefore still rely on a fully populated options object after
+    /// <see cref="RazorDocsVersioningOptions.CatalogPath"/>, normalizes
+    /// <see cref="RazorDocsLocalizationOptions.DefaultLocale"/> to <c>en</c> when blank, trims locale
+    /// <see cref="RazorDocsLocaleOptions.Code"/>, <see cref="RazorDocsLocaleOptions.Label"/>,
+    /// <see cref="RazorDocsLocaleOptions.Lang"/>, and <see cref="RazorDocsLocaleOptions.RoutePrefix"/> values while
+    /// skipping null locale entries, and removes blank or duplicate sidebar namespace prefixes. Callers that omit
+    /// <see cref="RazorDocsOptions.Routing"/>, <see cref="RazorDocsOptions.Versioning"/>, or
+    /// <see cref="RazorDocsOptions.Localization"/> can therefore still rely on a fully populated options object after
     /// registration. When <see cref="RazorDocsHarvestOptions.FailOnFailure"/> is enabled, the registered startup
     /// preflight fails the host only when the aggregate harvest health is failed.
     /// </para>

--- a/Web/ForgeTrust.AppSurface.Docs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/DocAggregator.cs
@@ -90,17 +90,43 @@ internal sealed record DocsSearchIndexDocument(
     [property: JsonPropertyName("breadcrumbs")] IReadOnlyList<string> Breadcrumbs,
     [property: JsonPropertyName("sourcePath")] string SourcePath = "");
 
+/// <summary>
+/// Describes a requested search-index projection for the cached docs snapshot.
+/// </summary>
+/// <param name="Locale">
+/// Optional active locale code. Blank values are treated as the default projection; non-blank values are trimmed and
+/// lower-cased before cache lookup so request casing does not create duplicate entries.
+/// </param>
+/// <param name="IncludeAllLocales">
+/// Reserved switch for a future all-locales search payload. Phase 1 preserves the existing default payload contract.
+/// </param>
 internal sealed record DocsSearchIndexProjection(
     string? Locale = null,
     bool IncludeAllLocales = false);
 
+/// <summary>
+/// Caches search-index payloads projected from one immutable docs snapshot.
+/// </summary>
+/// <remarks>
+/// Phase 1 always returns the default payload, but the cache reserves normalized per-locale keys so later slices can
+/// compute locale-specific payloads without changing <see cref="DocAggregator"/> callers. Access to the mutable
+/// projection dictionary is guarded by a private lock, and cache growth is capped because projection values can come
+/// from requests.
+/// </remarks>
 internal sealed class DocsSearchIndexProjectionCache
 {
+    private const int MaxProjectionCacheEntries = 64;
+
     private readonly DocsSearchIndexPayload _defaultPayload;
     private readonly LocalizedDocsGraph _localizedGraph;
     private readonly Dictionary<DocsSearchIndexProjection, DocsSearchIndexPayload> _payloads = [];
     private readonly object _gate = new();
 
+    /// <summary>
+    /// Initializes a projection cache for a single docs snapshot and seeds the default projection.
+    /// </summary>
+    /// <param name="defaultPayload">Non-null v1 search-index payload returned for the default projection.</param>
+    /// <param name="localizedGraph">Non-null locale graph that determines whether localized projections are active.</param>
     internal DocsSearchIndexProjectionCache(
         DocsSearchIndexPayload defaultPayload,
         LocalizedDocsGraph localizedGraph)
@@ -113,6 +139,16 @@ internal sealed class DocsSearchIndexProjectionCache
         _payloads[new DocsSearchIndexProjection()] = defaultPayload;
     }
 
+    /// <summary>
+    /// Gets the cached payload for a normalized projection.
+    /// </summary>
+    /// <remarks>
+    /// When localization is disabled, or when the projection has no locale, the default payload is returned without
+    /// growing the projection cache. During Phase 1, locale projections also return the default payload; the cache entry
+    /// is a bounded placeholder for later locale-specific payload generation.
+    /// </remarks>
+    /// <param name="projection">Projection request to normalize and resolve.</param>
+    /// <returns>The default payload in Phase 1, or a cached projection payload in later localization slices.</returns>
     internal DocsSearchIndexPayload GetPayload(DocsSearchIndexProjection projection)
     {
         ArgumentNullException.ThrowIfNull(projection);
@@ -131,12 +167,36 @@ internal sealed class DocsSearchIndexProjectionCache
             }
 
             // Phase 1 reserves the per-locale projection cache while preserving the existing v1 search payload contract.
+            if (_payloads.Count >= MaxProjectionCacheEntries)
+            {
+                return _defaultPayload;
+            }
+
             var projectionPayload = _defaultPayload;
             _payloads[normalizedProjection] = projectionPayload;
             return projectionPayload;
         }
     }
 
+    /// <summary>
+    /// Gets the number of seeded projection entries, exposed so tests can verify the cache bound without reflection.
+    /// </summary>
+    internal int CachedProjectionCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _payloads.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Normalizes a projection key before cache lookup.
+    /// </summary>
+    /// <param name="projection">Projection request supplied by the caller.</param>
+    /// <returns>A projection whose locale is null for blank input, or trimmed and lower-case invariant otherwise.</returns>
     private static DocsSearchIndexProjection NormalizeProjection(DocsSearchIndexProjection projection)
     {
         var locale = string.IsNullOrWhiteSpace(projection.Locale)

--- a/Web/ForgeTrust.AppSurface.Docs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/DocAggregator.cs
@@ -117,23 +117,32 @@ internal sealed class DocsSearchIndexProjectionCache
     {
         ArgumentNullException.ThrowIfNull(projection);
 
-        if (!_localizedGraph.Enabled || string.IsNullOrWhiteSpace(projection.Locale))
+        var normalizedProjection = NormalizeProjection(projection);
+        if (!_localizedGraph.Enabled || string.IsNullOrWhiteSpace(normalizedProjection.Locale))
         {
             return _defaultPayload;
         }
 
         lock (_gate)
         {
-            if (_payloads.TryGetValue(projection, out var payload))
+            if (_payloads.TryGetValue(normalizedProjection, out var payload))
             {
                 return payload;
             }
 
             // Phase 1 reserves the per-locale projection cache while preserving the existing v1 search payload contract.
-            _payloads[projection] = _defaultPayload;
+            var projectionPayload = _defaultPayload;
+            _payloads[normalizedProjection] = projectionPayload;
+            return projectionPayload;
         }
+    }
 
-        return _defaultPayload;
+    private static DocsSearchIndexProjection NormalizeProjection(DocsSearchIndexProjection projection)
+    {
+        var locale = string.IsNullOrWhiteSpace(projection.Locale)
+            ? null
+            : projection.Locale.Trim().ToLowerInvariant();
+        return projection with { Locale = locale };
     }
 }
 

--- a/Web/ForgeTrust.AppSurface.Docs/Services/DocAggregator.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/DocAggregator.cs
@@ -90,6 +90,53 @@ internal sealed record DocsSearchIndexDocument(
     [property: JsonPropertyName("breadcrumbs")] IReadOnlyList<string> Breadcrumbs,
     [property: JsonPropertyName("sourcePath")] string SourcePath = "");
 
+internal sealed record DocsSearchIndexProjection(
+    string? Locale = null,
+    bool IncludeAllLocales = false);
+
+internal sealed class DocsSearchIndexProjectionCache
+{
+    private readonly DocsSearchIndexPayload _defaultPayload;
+    private readonly LocalizedDocsGraph _localizedGraph;
+    private readonly Dictionary<DocsSearchIndexProjection, DocsSearchIndexPayload> _payloads = [];
+    private readonly object _gate = new();
+
+    internal DocsSearchIndexProjectionCache(
+        DocsSearchIndexPayload defaultPayload,
+        LocalizedDocsGraph localizedGraph)
+    {
+        ArgumentNullException.ThrowIfNull(defaultPayload);
+        ArgumentNullException.ThrowIfNull(localizedGraph);
+
+        _defaultPayload = defaultPayload;
+        _localizedGraph = localizedGraph;
+        _payloads[new DocsSearchIndexProjection()] = defaultPayload;
+    }
+
+    internal DocsSearchIndexPayload GetPayload(DocsSearchIndexProjection projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+
+        if (!_localizedGraph.Enabled || string.IsNullOrWhiteSpace(projection.Locale))
+        {
+            return _defaultPayload;
+        }
+
+        lock (_gate)
+        {
+            if (_payloads.TryGetValue(projection, out var payload))
+            {
+                return payload;
+            }
+
+            // Phase 1 reserves the per-locale projection cache while preserving the existing v1 search payload contract.
+            _payloads[projection] = _defaultPayload;
+        }
+
+        return _defaultPayload;
+    }
+}
+
 /// <summary>
 /// Service responsible for aggregating documentation from multiple harvesters and caching the results.
 /// </summary>
@@ -108,6 +155,7 @@ public class DocAggregator
     private readonly DocsUrlBuilder _docsUrlBuilder;
     private readonly ILogger<DocAggregator> _logger;
     private readonly RazorDocsContributorOptions _contributorOptions;
+    private readonly RazorDocsLocalizationOptions _localizationOptions;
     private readonly Func<string, CancellationToken, Task<DateTimeOffset?>> _resolveGitLastUpdatedUtcAsync;
     private readonly TimeSpan _harvesterTimeout;
     private readonly TimeSpan _contributorFreshnessTimeout;
@@ -145,8 +193,9 @@ public class DocAggregator
         Dictionary<string, DocNode> DocsByPath,
         DocPathResolver PathResolver,
         DocRouteIdentityCatalog RouteIdentityCatalog,
+        LocalizedDocsGraph LocalizedGraph,
         IReadOnlyList<DocSectionSnapshot> PublicSections,
-        DocsSearchIndexPayload SearchIndexPayload,
+        DocsSearchIndexProjectionCache SearchIndexProjections,
         Dictionary<string, DocContributorProvenanceViewModel> ContributorProvenanceByPath,
         DocHarvestHealthSnapshot HarvestHealth);
 
@@ -324,6 +373,7 @@ public class DocAggregator
         _docsUrlBuilder = docsUrlBuilder;
         _logger = logger;
         _contributorOptions = options.Contributor ?? throw new ArgumentNullException(nameof(options.Contributor));
+        _localizationOptions = options.Localization ?? throw new ArgumentNullException(nameof(options.Localization));
         SnapshotCacheDuration = ResolveSnapshotCacheDuration(options);
         _docsCachePolicy = CachePolicy.Absolute(SnapshotCacheDuration);
         _harvesterTimeout = ResolveHarvesterTimeout(harvesterTimeout);
@@ -533,7 +583,26 @@ public class DocAggregator
     internal async Task<DocsSearchIndexPayload> GetSearchIndexPayloadAsync(CancellationToken cancellationToken = default)
     {
         var snapshot = await GetCachedDocsSnapshotAsync().WaitAsync(cancellationToken);
-        return snapshot.SearchIndexPayload;
+        return snapshot.SearchIndexProjections.GetPayload(new DocsSearchIndexProjection());
+    }
+
+    /// <summary>
+    /// Returns a cached search-index projection for future locale-aware search consumers.
+    /// </summary>
+    /// <param name="projection">The requested search projection key.</param>
+    /// <param name="cancellationToken">An optional token to observe for cancellation requests.</param>
+    /// <returns>
+    /// The matching search payload. Phase 1 preserves the existing payload schema for every projection while reserving
+    /// the snapshot-owned cache seam that localized search will fill in Phase 3.
+    /// </returns>
+    internal async Task<DocsSearchIndexPayload> GetSearchIndexPayloadAsync(
+        DocsSearchIndexProjection projection,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+
+        var snapshot = await GetCachedDocsSnapshotAsync().WaitAsync(cancellationToken);
+        return snapshot.SearchIndexProjections.GetPayload(projection);
     }
 
     /// <summary>
@@ -595,6 +664,7 @@ public class DocAggregator
         var snapshotCacheDuration = SnapshotCacheDuration;
         var docsCachePolicy = _docsCachePolicy;
         var utcNow = _utcNow;
+        var localizationOptions = _localizationOptions;
 
         return await _memo.GetAsync(
                    _cacheScope,
@@ -680,6 +750,9 @@ public class DocAggregator
                            .ToDictionary(n => n.Path, n => n);
                        var finalRouteIdentityCatalog = DocRouteIdentityCatalog.Create(docsByPath.Values, _docsUrlBuilder);
                        var pathResolver = DocPathResolver.Create(docsByPath.Values);
+                       var localizedGraph = new LocalizedDocsGraphBuilder(localizationOptions).Build(
+                           docsByPath.Values,
+                           finalRouteIdentityCatalog);
 
                        var publicSections = BuildPublicSections(docsByPath.Values, logger);
                        var contributorProvenanceByPath = await BuildContributorProvenanceByPathAsync(
@@ -689,9 +762,10 @@ public class DocAggregator
                            docsByPath.Values,
                            publicSections,
                            finalRouteIdentityCatalog);
+                       var searchIndexProjections = new DocsSearchIndexProjectionCache(searchIndexPayload, localizedGraph);
                        var harvestHealth = BuildHarvestHealthSnapshot(
                            harvesterResults,
-                           finalRouteIdentityCatalog.Diagnostics,
+                           finalRouteIdentityCatalog.Diagnostics.Concat(localizedGraph.Diagnostics).ToArray(),
                            docsByPath.Count,
                            repositoryRoot,
                            utcNow(),
@@ -709,8 +783,9 @@ public class DocAggregator
                            docsByPath,
                            pathResolver,
                            finalRouteIdentityCatalog,
+                           localizedGraph,
                            publicSections,
-                           searchIndexPayload,
+                           searchIndexProjections,
                            contributorProvenanceByPath,
                            harvestHealth);
                    },

--- a/Web/ForgeTrust.AppSurface.Docs/Services/DocRouteIdentityCatalog.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/DocRouteIdentityCatalog.cs
@@ -261,9 +261,7 @@ internal sealed class DocRouteIdentityCatalog
             .GroupBy(locale => locale.Code.Trim(), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 group => group.Key,
-                group => string.IsNullOrWhiteSpace(group.First().RoutePrefix)
-                    ? group.First().Code.Trim()
-                    : group.First().RoutePrefix!.Trim(),
+                group => group.First().ResolveRoutePrefix(),
                 StringComparer.OrdinalIgnoreCase);
 
         var candidates = new List<LocalizedDocRouteCandidate>();

--- a/Web/ForgeTrust.AppSurface.Docs/Services/DocRouteIdentityCatalog.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/DocRouteIdentityCatalog.cs
@@ -26,6 +26,12 @@ internal sealed record DocRouteIdentity(
     bool SourcePathIsMarkdown,
     IReadOnlyList<string> RedirectAliasPaths);
 
+internal sealed record LocalizedDocRouteCandidate(
+    string SourcePath,
+    string Locale,
+    string TranslationKey,
+    string PublicRoutePath);
+
 /// <summary>
 /// Owns the route identity contract for one cached RazorDocs snapshot.
 /// </summary>
@@ -236,6 +242,58 @@ internal sealed class DocRouteIdentityCatalog
 
         publicRoutePath = string.Empty;
         return false;
+    }
+
+    internal IReadOnlyList<LocalizedDocRouteCandidate> BuildLocalizedRouteCandidates(
+        LocalizedDocsGraph graph,
+        RazorDocsLocalizationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!graph.Enabled)
+        {
+            return [];
+        }
+
+        var routePrefixByLocale = (options.Locales ?? [])
+            .Where(locale => locale is not null && !string.IsNullOrWhiteSpace(locale.Code))
+            .GroupBy(locale => locale.Code.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => string.IsNullOrWhiteSpace(group.First().RoutePrefix)
+                    ? group.First().Code.Trim()
+                    : group.First().RoutePrefix!.Trim(),
+                StringComparer.OrdinalIgnoreCase);
+
+        var candidates = new List<LocalizedDocRouteCandidate>();
+        foreach (var docSet in graph.DocSets)
+        {
+            foreach (var variant in docSet.Variants)
+            {
+                if (variant.PublicRoutePath is null)
+                {
+                    continue;
+                }
+
+                if (!routePrefixByLocale.TryGetValue(variant.Locale, out var routePrefix))
+                {
+                    continue;
+                }
+
+                candidates.Add(
+                    new LocalizedDocRouteCandidate(
+                        variant.SourcePath,
+                        variant.Locale,
+                        variant.TranslationKey,
+                        JoinLocalizedRoute(routePrefix, variant.PublicRoutePath)));
+            }
+        }
+
+        return candidates
+            .OrderBy(candidate => candidate.PublicRoutePath, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(candidate => candidate.SourcePath, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static DocRouteResolutionKind ResolveInternalPublicWinnerKind(DocRouteIdentity identity)
@@ -801,6 +859,15 @@ internal sealed class DocRouteIdentityCatalog
         {
             lookup[key] = identity;
         }
+    }
+
+    private static string JoinLocalizedRoute(string routePrefix, string publicRoutePath)
+    {
+        var normalizedPrefix = routePrefix.Trim().Trim('/');
+        var normalizedRoute = publicRoutePath.Trim().Trim('/');
+        return string.IsNullOrWhiteSpace(normalizedRoute)
+            ? normalizedPrefix
+            : $"{normalizedPrefix}/{normalizedRoute}";
     }
 
     private static HashSet<string> BuildReservedRoutePaths(DocsUrlBuilder docsUrlBuilder)

--- a/Web/ForgeTrust.AppSurface.Docs/Services/DocRouteIdentityCatalog.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/DocRouteIdentityCatalog.cs
@@ -26,6 +26,17 @@ internal sealed record DocRouteIdentity(
     bool SourcePathIsMarkdown,
     IReadOnlyList<string> RedirectAliasPaths);
 
+/// <summary>
+/// Represents one locale-prefixed public route candidate derived from a localized document variant.
+/// </summary>
+/// <remarks>
+/// Candidates are produced only for variants that have a public route and a configured locale route prefix. Source paths
+/// and public route paths are normalized relative docs paths, not absolute URLs.
+/// </remarks>
+/// <param name="SourcePath">Normalized source path for the localized variant.</param>
+/// <param name="Locale">Configured locale code associated with the variant.</param>
+/// <param name="TranslationKey">Stable translation identity shared by localized variants.</param>
+/// <param name="PublicRoutePath">Locale-prefixed browser route candidate for the variant.</param>
 internal sealed record LocalizedDocRouteCandidate(
     string SourcePath,
     string Locale,
@@ -244,6 +255,17 @@ internal sealed class DocRouteIdentityCatalog
         return false;
     }
 
+    /// <summary>
+    /// Builds locale-prefixed route candidates from a localized document graph.
+    /// </summary>
+    /// <remarks>
+    /// Returns an empty list when the graph is disabled. Variants are skipped when they have no public route, or when
+    /// their locale no longer maps to a configured route prefix. The method is snapshot-local and does not mutate catalog
+    /// state.
+    /// </remarks>
+    /// <param name="graph">Localized graph built for the same docs snapshot.</param>
+    /// <param name="options">Localization options used to resolve locale route prefixes.</param>
+    /// <returns>Sorted locale-prefixed candidates suitable for later route registration slices.</returns>
     internal IReadOnlyList<LocalizedDocRouteCandidate> BuildLocalizedRouteCandidates(
         LocalizedDocsGraph graph,
         RazorDocsLocalizationOptions options)

--- a/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
@@ -3,6 +3,18 @@ using ForgeTrust.AppSurface.Docs.Models;
 
 namespace ForgeTrust.AppSurface.Docs.Services;
 
+/// <summary>
+/// Captures locale identity, grouping, and diagnostics for one docs snapshot.
+/// </summary>
+/// <remarks>
+/// The graph is the Phase 1 localization handoff between harvesters, route identity, navigation, fallback, and search
+/// projection code. Consumers should use this graph instead of re-inferring locale state from source paths.
+/// </remarks>
+/// <param name="Enabled">Whether localization graph behavior was enabled when the snapshot was built.</param>
+/// <param name="DefaultLocale">Configured default locale, or <c>null</c> when disabled or unavailable.</param>
+/// <param name="DocSets">Translation-key groups ordered for deterministic consumption.</param>
+/// <param name="VariantsBySourcePath">Case-insensitive lookup from normalized source path to the first resolved variant.</param>
+/// <param name="Diagnostics">Non-fatal authoring diagnostics emitted while resolving localization facts.</param>
 internal sealed record LocalizedDocsGraph(
     bool Enabled,
     string? DefaultLocale,
@@ -10,12 +22,35 @@ internal sealed record LocalizedDocsGraph(
     IReadOnlyDictionary<string, LocalizedDocVariant> VariantsBySourcePath,
     IReadOnlyList<DocHarvestDiagnostic> Diagnostics);
 
+/// <summary>
+/// Groups localized variants that represent the same conceptual documentation page.
+/// </summary>
+/// <param name="TranslationKey">Stable page identity shared across locale variants.</param>
+/// <param name="DefaultLocaleSourcePath">Source path for the default-locale variant, or <c>null</c> when missing.</param>
+/// <param name="Variants">Resolved variants for this translation key, ordered by locale and source path.</param>
+/// <param name="FallbackMode">Effective missing-translation fallback behavior for the group.</param>
 internal sealed record LocalizedDocSet(
     string TranslationKey,
     string? DefaultLocaleSourcePath,
     IReadOnlyList<LocalizedDocVariant> Variants,
     RazorDocsLocaleFallbackMode FallbackMode);
 
+/// <summary>
+/// Describes one resolved localized document variant.
+/// </summary>
+/// <remarks>
+/// Locale and translation key may be authored in metadata, inferred from a configured filename suffix, inferred from a
+/// locale folder when a translation key is authored, or defaulted to the configured default locale. Public route paths are
+/// null when route identity rejected the source path.
+/// </remarks>
+/// <param name="SourcePath">Normalized source path for the variant.</param>
+/// <param name="Locale">Configured locale code selected for the variant.</param>
+/// <param name="TranslationKey">Stable translation identity used to group variants.</param>
+/// <param name="Title">Localized title, metadata title, or harvested title in precedence order.</param>
+/// <param name="PublicRoutePath">Existing public route path for the base document identity, or <c>null</c> when unavailable.</param>
+/// <param name="LocaleFallback">Optional page-level fallback override authored by the variant.</param>
+/// <param name="LocaleWasInferred">Whether locale came from inference/defaulting rather than explicit metadata.</param>
+/// <param name="TranslationKeyWasInferred">Whether translation key came from source path inference.</param>
 internal sealed record LocalizedDocVariant(
     string SourcePath,
     string Locale,
@@ -40,6 +75,10 @@ internal sealed class LocalizedDocsGraphBuilder
     private readonly IReadOnlyDictionary<string, RazorDocsLocaleOptions> _localesByCode;
     private readonly IReadOnlyDictionary<string, RazorDocsLocaleOptions> _localesByRoutePrefix;
 
+    /// <summary>
+    /// Initializes the graph builder with normalized locale lookups from the configured localization options.
+    /// </summary>
+    /// <param name="options">Localization options for the current RazorDocs host.</param>
     internal LocalizedDocsGraphBuilder(RazorDocsLocalizationOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
@@ -55,6 +94,17 @@ internal sealed class LocalizedDocsGraphBuilder
             .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Builds the localized graph for a docs snapshot.
+    /// </summary>
+    /// <remarks>
+    /// The builder skips fragment stub source paths, reports unsupported locale signals, duplicate variants, missing bases,
+    /// folder conflicts, disabled fallback gaps, and conflicting fallback overrides as diagnostics, then returns whatever
+    /// safe graph data it can derive.
+    /// </remarks>
+    /// <param name="docs">Harvested docs from the snapshot.</param>
+    /// <param name="routeIdentityCatalog">Route catalog for resolving public route candidates.</param>
+    /// <returns>A disabled empty graph when localization is off, otherwise the resolved localization graph.</returns>
     internal LocalizedDocsGraph Build(IEnumerable<DocNode> docs, DocRouteIdentityCatalog routeIdentityCatalog)
     {
         ArgumentNullException.ThrowIfNull(docs);

--- a/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
@@ -50,8 +50,8 @@ internal sealed class LocalizedDocsGraphBuilder
             .GroupBy(locale => locale.Code.Trim(), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
         _localesByRoutePrefix = (options.Locales ?? [])
-            .Where(locale => locale is not null && !string.IsNullOrWhiteSpace(GetRoutePrefix(locale)))
-            .GroupBy(GetRoutePrefix, StringComparer.OrdinalIgnoreCase)
+            .Where(locale => locale is not null && !string.IsNullOrWhiteSpace(locale.ResolveRoutePrefix()))
+            .GroupBy(locale => locale.ResolveRoutePrefix(), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
     }
 
@@ -63,15 +63,23 @@ internal sealed class LocalizedDocsGraphBuilder
         var docList = docs.ToList();
         if (!_options.Enabled)
         {
-            return new LocalizedDocsGraph(false, null, [], new Dictionary<string, LocalizedDocVariant>(), []);
+            return new LocalizedDocsGraph(
+                false,
+                null,
+                [],
+                new Dictionary<string, LocalizedDocVariant>(StringComparer.OrdinalIgnoreCase),
+                []);
         }
 
         var diagnostics = new List<DocHarvestDiagnostic>();
-        var normalizedSourcePaths = docList
+        var graphDocs = docList
+            .Where(doc => !IsFragmentStubSourcePath(doc.Path))
+            .ToList();
+        var normalizedSourcePaths = graphDocs
             .Select(doc => NormalizeSourcePath(doc.Path))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var variants = new List<LocalizedDocVariant>();
-        foreach (var doc in docList)
+        foreach (var doc in graphDocs)
         {
             var facts = ResolveFacts(doc, normalizedSourcePaths, diagnostics);
             if (facts is null)
@@ -124,7 +132,7 @@ internal sealed class LocalizedDocsGraphBuilder
                         $"Keep only one '{duplicateGroup.Key}' variant for translation_key '{group.Key}' or give the extra document a different translation_key."));
             }
 
-            var fallbackMode = ResolveDocSetFallbackMode(groupVariants);
+            var fallbackMode = ResolveDocSetFallbackMode(group.Key, groupVariants, diagnostics);
             var defaultSourcePath = groupVariants
                 .FirstOrDefault(variant => string.Equals(variant.Locale, _options.DefaultLocale, StringComparison.OrdinalIgnoreCase))
                 ?.SourcePath;
@@ -352,13 +360,6 @@ internal sealed class LocalizedDocsGraphBuilder
             : null;
     }
 
-    private static string GetRoutePrefix(RazorDocsLocaleOptions locale)
-    {
-        return string.IsNullOrWhiteSpace(locale.RoutePrefix)
-            ? locale.Code.Trim()
-            : locale.RoutePrefix!.Trim();
-    }
-
     private static string InferTranslationKey(string sourcePath)
     {
         var normalized = NormalizeSourcePath(sourcePath);
@@ -375,17 +376,31 @@ internal sealed class LocalizedDocsGraphBuilder
         return segments.Count == 0 ? "README" : string.Join('/', segments);
     }
 
-    private RazorDocsLocaleFallbackMode ResolveDocSetFallbackMode(IEnumerable<LocalizedDocVariant> variants)
+    private RazorDocsLocaleFallbackMode ResolveDocSetFallbackMode(
+        string translationKey,
+        IEnumerable<LocalizedDocVariant> variants,
+        List<DocHarvestDiagnostic> diagnostics)
     {
-        foreach (var variant in variants)
+        var fallbackModes = variants
+            .Where(variant => variant.LocaleFallback is not null)
+            .Select(variant => variant.LocaleFallback!.Value)
+            .ToList();
+        var distinctFallbackModes = fallbackModes
+            .Distinct()
+            .ToList();
+        if (distinctFallbackModes.Count > 1)
         {
-            if (variant.LocaleFallback is not null)
-            {
-                return variant.LocaleFallback.Value;
-            }
+            diagnostics.Add(
+                CreateDiagnostic(
+                    DocHarvestDiagnosticCodes.LocalizationFallbackConflict,
+                    $"Translation key '{translationKey}' declares conflicting locale fallback modes.",
+                    "Fallback behavior would otherwise depend on the first localized variant RazorDocs evaluates.",
+                    "Use the same locale_fallback value across variants for a translation key, or remove per-page fallback metadata to inherit the global setting."));
         }
 
-        return _options.FallbackMode;
+        return fallbackModes
+            .DefaultIfEmpty(_options.FallbackMode)
+            .First();
     }
 
     private static string ResolveTitle(DocNode doc)
@@ -409,6 +424,11 @@ internal sealed class LocalizedDocsGraphBuilder
     {
         return path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
                || path.EndsWith(".markdown", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsFragmentStubSourcePath(string path)
+    {
+        return path.Contains('#', StringComparison.Ordinal);
     }
 
     private static DocHarvestDiagnostic CreateDiagnostic(string code, string problem, string cause, string fix)

--- a/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
@@ -1,0 +1,425 @@
+using System.Globalization;
+using ForgeTrust.AppSurface.Docs.Models;
+
+namespace ForgeTrust.AppSurface.Docs.Services;
+
+internal sealed record LocalizedDocsGraph(
+    bool Enabled,
+    string? DefaultLocale,
+    IReadOnlyList<LocalizedDocSet> DocSets,
+    IReadOnlyDictionary<string, LocalizedDocVariant> VariantsBySourcePath,
+    IReadOnlyList<DocHarvestDiagnostic> Diagnostics);
+
+internal sealed record LocalizedDocSet(
+    string TranslationKey,
+    string? DefaultLocaleSourcePath,
+    IReadOnlyList<LocalizedDocVariant> Variants,
+    RazorDocsLocaleFallbackMode FallbackMode);
+
+internal sealed record LocalizedDocVariant(
+    string SourcePath,
+    string Locale,
+    string TranslationKey,
+    string Title,
+    string? PublicRoutePath,
+    RazorDocsLocaleFallbackMode? LocaleFallback,
+    bool LocaleWasInferred,
+    bool TranslationKeyWasInferred);
+
+/// <summary>
+/// Builds the locale-aware document graph used by later route, navigation, fallback, and search projections.
+/// </summary>
+/// <remarks>
+/// This Phase 1 builder is intentionally internal. It records document identity and locale facts without changing the
+/// existing visible route or search behavior. Later slices should consume this graph instead of re-inferring locale state
+/// in controllers, views, or JavaScript.
+/// </remarks>
+internal sealed class LocalizedDocsGraphBuilder
+{
+    private readonly RazorDocsLocalizationOptions _options;
+    private readonly IReadOnlyDictionary<string, RazorDocsLocaleOptions> _localesByCode;
+    private readonly IReadOnlyDictionary<string, RazorDocsLocaleOptions> _localesByRoutePrefix;
+
+    internal LocalizedDocsGraphBuilder(RazorDocsLocalizationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _options = options;
+        _localesByCode = (options.Locales ?? [])
+            .Where(locale => locale is not null && !string.IsNullOrWhiteSpace(locale.Code))
+            .GroupBy(locale => locale.Code.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        _localesByRoutePrefix = (options.Locales ?? [])
+            .Where(locale => locale is not null && !string.IsNullOrWhiteSpace(GetRoutePrefix(locale)))
+            .GroupBy(GetRoutePrefix, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal LocalizedDocsGraph Build(IEnumerable<DocNode> docs, DocRouteIdentityCatalog routeIdentityCatalog)
+    {
+        ArgumentNullException.ThrowIfNull(docs);
+        ArgumentNullException.ThrowIfNull(routeIdentityCatalog);
+
+        var docList = docs.ToList();
+        if (!_options.Enabled)
+        {
+            return new LocalizedDocsGraph(false, null, [], new Dictionary<string, LocalizedDocVariant>(), []);
+        }
+
+        var diagnostics = new List<DocHarvestDiagnostic>();
+        var normalizedSourcePaths = docList
+            .Select(doc => NormalizeSourcePath(doc.Path))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var variants = new List<LocalizedDocVariant>();
+        foreach (var doc in docList)
+        {
+            var facts = ResolveFacts(doc, normalizedSourcePaths, diagnostics);
+            if (facts is null)
+            {
+                continue;
+            }
+
+            string? publicRoutePath = null;
+            if (routeIdentityCatalog.TryGetPublicRoutePath(facts.RouteSourcePath, out var resolvedRoutePath))
+            {
+                publicRoutePath = resolvedRoutePath;
+            }
+            else if (routeIdentityCatalog.TryGetPublicRoutePath(doc.Path, out resolvedRoutePath))
+            {
+                publicRoutePath = resolvedRoutePath;
+            }
+
+            variants.Add(
+                new LocalizedDocVariant(
+                    NormalizeSourcePath(doc.Path),
+                    facts.Locale,
+                    facts.TranslationKey,
+                    ResolveTitle(doc),
+                    publicRoutePath,
+                    doc.Metadata?.Localization?.LocaleFallback,
+                    facts.LocaleWasInferred,
+                    facts.TranslationKeyWasInferred));
+        }
+
+        var docSets = new List<LocalizedDocSet>();
+        foreach (var group in variants.GroupBy(variant => variant.TranslationKey, StringComparer.OrdinalIgnoreCase))
+        {
+            var groupVariants = group
+                .OrderBy(variant => variant.Locale, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(variant => variant.SourcePath, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            foreach (var duplicateGroup in groupVariants.GroupBy(variant => variant.Locale, StringComparer.OrdinalIgnoreCase))
+            {
+                var duplicates = duplicateGroup.ToList();
+                if (duplicates.Count <= 1)
+                {
+                    continue;
+                }
+
+                diagnostics.Add(
+                    CreateDiagnostic(
+                        DocHarvestDiagnosticCodes.LocalizationDuplicateVariant,
+                        $"Multiple docs use translation key '{group.Key}' for locale '{duplicateGroup.Key}'.",
+                        "A language switch target must resolve to one document per locale.",
+                        $"Keep only one '{duplicateGroup.Key}' variant for translation_key '{group.Key}' or give the extra document a different translation_key."));
+            }
+
+            var fallbackMode = ResolveDocSetFallbackMode(groupVariants);
+            var defaultSourcePath = groupVariants
+                .FirstOrDefault(variant => string.Equals(variant.Locale, _options.DefaultLocale, StringComparison.OrdinalIgnoreCase))
+                ?.SourcePath;
+            if (fallbackMode == RazorDocsLocaleFallbackMode.Disabled)
+            {
+                foreach (var missingLocale in _localesByCode.Keys.Where(
+                             locale => groupVariants.All(variant => !string.Equals(variant.Locale, locale, StringComparison.OrdinalIgnoreCase))))
+                {
+                    diagnostics.Add(
+                        CreateDiagnostic(
+                            DocHarvestDiagnosticCodes.LocalizationFallbackDisabledMissingVariant,
+                            $"Translation key '{group.Key}' disables fallback but has no '{missingLocale}' variant.",
+                            "Readers switching to that locale would otherwise see a false page or a silent 404.",
+                            $"Add a '{missingLocale}' variant for translation_key '{group.Key}' or allow fallback."));
+                }
+            }
+
+            docSets.Add(
+                new LocalizedDocSet(
+                    group.Key,
+                    defaultSourcePath,
+                    groupVariants,
+                    fallbackMode));
+        }
+
+        return new LocalizedDocsGraph(
+            true,
+            _options.DefaultLocale,
+            docSets.OrderBy(set => set.TranslationKey, StringComparer.OrdinalIgnoreCase).ToArray(),
+            variants
+                .GroupBy(variant => variant.SourcePath, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase),
+            diagnostics);
+    }
+
+    private ResolvedLocalizationFacts? ResolveFacts(
+        DocNode doc,
+        HashSet<string> normalizedSourcePaths,
+        List<DocHarvestDiagnostic> diagnostics)
+    {
+        var sourcePath = NormalizeSourcePath(doc.Path);
+        var explicitLocale = Normalize(doc.Metadata?.Localization?.Locale);
+        var explicitTranslationKey = Normalize(doc.Metadata?.Localization?.TranslationKey);
+        var suffixLocale = TryGetConfiguredLocaleSuffix(sourcePath, out var sourceWithoutSuffix, out var suffix)
+            ? NormalizeConfiguredLocale(suffix)
+            : null;
+        if (ReportUnsupportedLocaleSuffix(sourcePath, sourceWithoutSuffix, suffixLocale, diagnostics))
+        {
+            return null;
+        }
+
+        var folderLocale = TryGetFolderLocale(sourcePath, explicitTranslationKey, out var inferredFolderLocale)
+            ? inferredFolderLocale
+            : null;
+
+        if (explicitLocale is not null
+            && folderLocale is not null
+            && !string.Equals(explicitLocale, folderLocale, StringComparison.OrdinalIgnoreCase))
+        {
+            diagnostics.Add(
+                CreateDiagnostic(
+                    DocHarvestDiagnosticCodes.LocalizationLocaleFolderConflict,
+                    $"Doc '{sourcePath}' declares locale '{explicitLocale}' but its folder implies '{folderLocale}'.",
+                    "Conflicting locale signals make language switching and fallback routing ambiguous.",
+                    "Make the locale metadata match the configured locale folder or move the file out of that locale folder."));
+        }
+
+        var locale = explicitLocale ?? suffixLocale ?? folderLocale ?? _options.DefaultLocale;
+        if (locale is null)
+        {
+            return null;
+        }
+
+        var normalizedLocale = NormalizeConfiguredLocale(locale);
+        if (normalizedLocale is null)
+        {
+            diagnostics.Add(
+                CreateDiagnostic(
+                    DocHarvestDiagnosticCodes.LocalizationUnsupportedLocale,
+                    $"Doc '{sourcePath}' uses unsupported locale '{locale}'.",
+                    "The locale is not configured for this RazorDocs host.",
+                    "Add the locale under RazorDocs:Localization:Locales or update the document metadata."));
+            return null;
+        }
+
+        var translationKey = explicitTranslationKey;
+        var translationKeyWasInferred = false;
+        if (translationKey is null)
+        {
+            translationKeyWasInferred = true;
+            if (suffixLocale is not null && sourceWithoutSuffix is not null)
+            {
+                if (!normalizedSourcePaths.Contains(sourceWithoutSuffix))
+                {
+                    diagnostics.Add(
+                        CreateDiagnostic(
+                            DocHarvestDiagnosticCodes.LocalizationMissingBase,
+                            $"Localized source '{sourcePath}' has no colocated base document '{sourceWithoutSuffix}'.",
+                            "RazorDocs can still infer an identity, but language switching may be incomplete.",
+                            $"Add '{sourceWithoutSuffix}' or author translation_key explicitly."));
+                }
+
+                translationKey = InferTranslationKey(sourceWithoutSuffix);
+            }
+            else
+            {
+                translationKey = InferTranslationKey(sourcePath);
+            }
+        }
+
+        var routeSourcePath = !string.IsNullOrWhiteSpace(doc.Metadata?.CanonicalSlug)
+            ? sourcePath
+            : sourceWithoutSuffix ?? sourcePath;
+
+        return new ResolvedLocalizationFacts(
+            normalizedLocale,
+            translationKey,
+            routeSourcePath,
+            LocaleWasInferred: explicitLocale is null,
+            TranslationKeyWasInferred: translationKeyWasInferred);
+    }
+
+    private bool ReportUnsupportedLocaleSuffix(
+        string sourcePath,
+        string? sourceWithoutSuffix,
+        string? configuredSuffixLocale,
+        List<DocHarvestDiagnostic> diagnostics)
+    {
+        if (configuredSuffixLocale is not null || sourceWithoutSuffix is not null)
+        {
+            return false;
+        }
+
+        if (!TryGetPotentialLocaleSuffix(sourcePath, out var suffix))
+        {
+            return false;
+        }
+
+        diagnostics.Add(
+            CreateDiagnostic(
+                DocHarvestDiagnosticCodes.LocalizationUnsupportedLocale,
+                $"Doc '{sourcePath}' uses unsupported locale suffix '{suffix}'.",
+                "The filename looks like a localized Markdown source, but the suffix is not one of the configured locales.",
+                "Add the locale under RazorDocs:Localization:Locales or rename the file if the suffix is not a locale."));
+        return true;
+    }
+
+    private bool TryGetConfiguredLocaleSuffix(string sourcePath, out string? sourceWithoutSuffix, out string suffix)
+    {
+        sourceWithoutSuffix = null;
+        suffix = string.Empty;
+        if (!IsMarkdownPath(sourcePath))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(sourcePath);
+        var withoutExtension = sourcePath[..^extension.Length];
+        var lastDot = withoutExtension.LastIndexOf('.');
+        if (lastDot < 0 || lastDot == withoutExtension.Length - 1)
+        {
+            return false;
+        }
+
+        suffix = withoutExtension[(lastDot + 1)..];
+        if (NormalizeConfiguredLocale(suffix) is null)
+        {
+            return false;
+        }
+
+        sourceWithoutSuffix = withoutExtension[..lastDot] + extension;
+        return true;
+    }
+
+    private static bool TryGetPotentialLocaleSuffix(string sourcePath, out string suffix)
+    {
+        suffix = string.Empty;
+        if (!IsMarkdownPath(sourcePath))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(sourcePath);
+        var withoutExtension = sourcePath[..^extension.Length];
+        var lastDot = withoutExtension.LastIndexOf('.');
+        if (lastDot < 0 || lastDot == withoutExtension.Length - 1)
+        {
+            return false;
+        }
+
+        suffix = withoutExtension[(lastDot + 1)..];
+        try
+        {
+            _ = CultureInfo.GetCultureInfo(suffix);
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    private bool TryGetFolderLocale(string sourcePath, string? explicitTranslationKey, out string locale)
+    {
+        locale = string.Empty;
+        if (explicitTranslationKey is null)
+        {
+            return false;
+        }
+
+        var firstSegment = sourcePath.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (firstSegment is null || !_localesByRoutePrefix.TryGetValue(firstSegment, out var configuredLocale))
+        {
+            return false;
+        }
+
+        locale = configuredLocale.Code;
+        return true;
+    }
+
+    private string? NormalizeConfiguredLocale(string value)
+    {
+        return _localesByCode.TryGetValue(value.Trim(), out var locale)
+            ? locale.Code
+            : null;
+    }
+
+    private static string GetRoutePrefix(RazorDocsLocaleOptions locale)
+    {
+        return string.IsNullOrWhiteSpace(locale.RoutePrefix)
+            ? locale.Code.Trim()
+            : locale.RoutePrefix!.Trim();
+    }
+
+    private static string InferTranslationKey(string sourcePath)
+    {
+        var normalized = NormalizeSourcePath(sourcePath);
+        var extension = Path.GetExtension(normalized);
+        var withoutExtension = extension.Length == 0 ? normalized : normalized[..^extension.Length];
+        var segments = withoutExtension.Split('/', StringSplitOptions.RemoveEmptyEntries).ToList();
+        if (segments.Count > 0
+            && (segments[^1].Equals("README", StringComparison.OrdinalIgnoreCase)
+                || segments[^1].Equals("index", StringComparison.OrdinalIgnoreCase)))
+        {
+            segments.RemoveAt(segments.Count - 1);
+        }
+
+        return segments.Count == 0 ? "README" : string.Join('/', segments);
+    }
+
+    private RazorDocsLocaleFallbackMode ResolveDocSetFallbackMode(IEnumerable<LocalizedDocVariant> variants)
+    {
+        foreach (var variant in variants)
+        {
+            if (variant.LocaleFallback is not null)
+            {
+                return variant.LocaleFallback.Value;
+            }
+        }
+
+        return _options.FallbackMode;
+    }
+
+    private static string ResolveTitle(DocNode doc)
+    {
+        return Normalize(doc.Metadata?.Localization?.LocalizedTitle)
+               ?? Normalize(doc.Metadata?.Title)
+               ?? doc.Title;
+    }
+
+    private static string NormalizeSourcePath(string path)
+    {
+        return path.Trim().Replace('\\', '/').Trim('/');
+    }
+
+    private static string? Normalize(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static bool IsMarkdownPath(string path)
+    {
+        return path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+               || path.EndsWith(".markdown", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static DocHarvestDiagnostic CreateDiagnostic(string code, string problem, string cause, string fix)
+    {
+        return new DocHarvestDiagnostic(code, DocHarvestDiagnosticSeverity.Warning, HarvesterType: null, problem, cause, fix);
+    }
+
+    private sealed record ResolvedLocalizationFacts(
+        string Locale,
+        string TranslationKey,
+        string RouteSourcePath,
+        bool LocaleWasInferred,
+        bool TranslationKeyWasInferred);
+}

--- a/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
@@ -293,7 +293,8 @@ internal sealed class LocalizedDocsGraphBuilder
             }
         }
 
-        var folderSourceWithoutLocalePrefix = explicitLocale is null && folderLocale is not null
+        var folderSourceWithoutLocalePrefix = folderLocale is not null
+            && (explicitLocale is null || string.Equals(explicitLocale, folderLocale, StringComparison.OrdinalIgnoreCase))
             ? StripFolderLocalePrefix(sourcePath, folderLocale)
             : null;
         var routeSourcePath = !string.IsNullOrWhiteSpace(doc.Metadata?.CanonicalSlug)

--- a/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/LocalizedDocsGraphBuilder.cs
@@ -293,9 +293,12 @@ internal sealed class LocalizedDocsGraphBuilder
             }
         }
 
+        var folderSourceWithoutLocalePrefix = explicitLocale is null && folderLocale is not null
+            ? StripFolderLocalePrefix(sourcePath, folderLocale)
+            : null;
         var routeSourcePath = !string.IsNullOrWhiteSpace(doc.Metadata?.CanonicalSlug)
             ? sourcePath
-            : sourceWithoutSuffix ?? sourcePath;
+            : sourceWithoutSuffix ?? folderSourceWithoutLocalePrefix ?? sourcePath;
 
         return new ResolvedLocalizationFacts(
             normalizedLocale,
@@ -401,6 +404,23 @@ internal sealed class LocalizedDocsGraphBuilder
 
         locale = configuredLocale.Code;
         return true;
+    }
+
+    private string? StripFolderLocalePrefix(string sourcePath, string folderLocale)
+    {
+        if (!_localesByCode.TryGetValue(folderLocale, out var configuredLocale))
+        {
+            return null;
+        }
+
+        var routePrefix = configuredLocale.ResolveRoutePrefix().Trim('/');
+        if (routePrefix.Length == 0
+            || !sourcePath.StartsWith(routePrefix + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return sourcePath[(routePrefix.Length + 1)..];
     }
 
     private string? NormalizeConfiguredLocale(string value)

--- a/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
@@ -477,10 +477,41 @@ internal static class MarkdownFrontMatterParser
         List<RazorDocsMetadataDiagnostic> diagnostics)
     {
         var nested = document.Localization;
-        var locale = Normalize(document.Locale) ?? Normalize(nested?.Locale);
-        var translationKey = Normalize(document.TranslationKey) ?? Normalize(nested?.TranslationKey);
-        var localizedTitle = Normalize(document.LocalizedTitle) ?? Normalize(nested?.LocalizedTitle);
-        var fallbackText = Normalize(document.LocaleFallback) ?? Normalize(nested?.LocaleFallback);
+        var flatLocale = Normalize(document.Locale);
+        var nestedLocale = Normalize(nested?.Locale);
+        var flatTranslationKey = Normalize(document.TranslationKey);
+        var nestedTranslationKey = Normalize(nested?.TranslationKey);
+        var flatLocalizedTitle = Normalize(document.LocalizedTitle);
+        var nestedLocalizedTitle = Normalize(nested?.LocalizedTitle);
+        var flatFallbackText = Normalize(document.LocaleFallback);
+        var nestedFallbackText = Normalize(nested?.LocaleFallback);
+        AddLocalizationConflictDiagnosticIfNeeded("locale", "locale", "localization.locale", flatLocale, nestedLocale, diagnostics);
+        AddLocalizationConflictDiagnosticIfNeeded(
+            "translation key",
+            "translation_key",
+            "localization.translation_key",
+            flatTranslationKey,
+            nestedTranslationKey,
+            diagnostics);
+        AddLocalizationConflictDiagnosticIfNeeded(
+            "localized title",
+            "localized_title",
+            "localization.localized_title",
+            flatLocalizedTitle,
+            nestedLocalizedTitle,
+            diagnostics);
+        AddLocalizationConflictDiagnosticIfNeeded(
+            "locale fallback",
+            "locale_fallback",
+            "localization.locale_fallback",
+            flatFallbackText,
+            nestedFallbackText,
+            diagnostics);
+
+        var locale = flatLocale ?? nestedLocale;
+        var translationKey = flatTranslationKey ?? nestedTranslationKey;
+        var localizedTitle = flatLocalizedTitle ?? nestedLocalizedTitle;
+        var fallbackText = flatFallbackText ?? nestedFallbackText;
         RazorDocsLocaleFallbackMode? fallback = null;
         if (fallbackText is not null)
         {
@@ -513,6 +544,30 @@ internal static class MarkdownFrontMatterParser
                 LocalizedTitle = localizedTitle,
                 LocaleFallback = fallback
             };
+    }
+
+    private static void AddLocalizationConflictDiagnosticIfNeeded(
+        string fieldName,
+        string flatFieldPath,
+        string nestedFieldPath,
+        string? flatValue,
+        string? nestedValue,
+        List<RazorDocsMetadataDiagnostic> diagnostics)
+    {
+        if (flatValue is null
+            || nestedValue is null
+            || string.Equals(flatValue, nestedValue, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        diagnostics.Add(
+            new RazorDocsMetadataDiagnostic(
+                "localization-field-conflict",
+                flatFieldPath,
+                $"The flat localization {fieldName} conflicts with {nestedFieldPath}.",
+                "RazorDocs prefers the flat front matter value and ignores the nested value for that field.",
+                $"Keep only {flatFieldPath} or {nestedFieldPath}, or make both values match."));
     }
 
     private sealed class FrontMatterDocument

--- a/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
@@ -515,6 +515,9 @@ internal static class MarkdownFrontMatterParser
         RazorDocsLocaleFallbackMode? fallback = null;
         if (fallbackText is not null)
         {
+            var fallbackFieldPath = flatFallbackText is not null
+                ? "locale_fallback"
+                : "localization.locale_fallback";
             if (Enum.TryParse<RazorDocsLocaleFallbackMode>(fallbackText, ignoreCase: true, out var parsedFallback)
                 && Enum.IsDefined(parsedFallback))
             {
@@ -525,7 +528,7 @@ internal static class MarkdownFrontMatterParser
                 diagnostics.Add(
                     new RazorDocsMetadataDiagnostic(
                         "invalid-locale-fallback",
-                        "locale_fallback",
+                        fallbackFieldPath,
                         "The locale fallback value is not supported.",
                         "RazorDocs only supports DefaultLocaleWithNotice or Disabled for page-level localization fallback.",
                         "Use locale_fallback: Disabled or remove the field to inherit the global fallback mode."));

--- a/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
@@ -150,6 +150,7 @@ internal static class MarkdownFrontMatterParser
                 diagnostics),
             Trust = NormalizeTrust(document.Trust),
             Contributor = NormalizeContributor(document.Contributor),
+            Localization = NormalizeLocalization(document, diagnostics),
             PageTypeIsDerived = document.PageType is not null ? false : null,
             AudienceIsDerived = document.Audience is not null ? false : null,
             ComponentIsDerived = document.Component is not null ? false : null,
@@ -471,6 +472,49 @@ internal static class MarkdownFrontMatterParser
             : contributor;
     }
 
+    private static DocLocalizationMetadata? NormalizeLocalization(
+        FrontMatterDocument document,
+        List<RazorDocsMetadataDiagnostic> diagnostics)
+    {
+        var nested = document.Localization;
+        var locale = Normalize(document.Locale) ?? Normalize(nested?.Locale);
+        var translationKey = Normalize(document.TranslationKey) ?? Normalize(nested?.TranslationKey);
+        var localizedTitle = Normalize(document.LocalizedTitle) ?? Normalize(nested?.LocalizedTitle);
+        var fallbackText = Normalize(document.LocaleFallback) ?? Normalize(nested?.LocaleFallback);
+        RazorDocsLocaleFallbackMode? fallback = null;
+        if (fallbackText is not null)
+        {
+            if (Enum.TryParse<RazorDocsLocaleFallbackMode>(fallbackText, ignoreCase: true, out var parsedFallback)
+                && Enum.IsDefined(parsedFallback))
+            {
+                fallback = parsedFallback;
+            }
+            else
+            {
+                diagnostics.Add(
+                    new RazorDocsMetadataDiagnostic(
+                        "invalid-locale-fallback",
+                        "locale_fallback",
+                        "The locale fallback value is not supported.",
+                        "RazorDocs only supports DefaultLocaleWithNotice or Disabled for page-level localization fallback.",
+                        "Use locale_fallback: Disabled or remove the field to inherit the global fallback mode."));
+            }
+        }
+
+        return locale is null
+               && translationKey is null
+               && localizedTitle is null
+               && fallback is null
+            ? null
+            : new DocLocalizationMetadata
+            {
+                Locale = locale,
+                TranslationKey = translationKey,
+                LocalizedTitle = localizedTitle,
+                LocaleFallback = fallback
+            };
+    }
+
     private sealed class FrontMatterDocument
     {
         public string? Title { get; init; }
@@ -518,6 +562,16 @@ internal static class MarkdownFrontMatterParser
         public FrontMatterTrustDocument? Trust { get; init; }
 
         public FrontMatterContributorDocument? Contributor { get; init; }
+
+        public FrontMatterLocalizationDocument? Localization { get; init; }
+
+        public string? Locale { get; init; }
+
+        public string? TranslationKey { get; init; }
+
+        public string? LocalizedTitle { get; init; }
+
+        public string? LocaleFallback { get; init; }
     }
 
     private sealed class FrontMatterFeaturedPageDefinition
@@ -585,6 +639,17 @@ internal static class MarkdownFrontMatterParser
         public string? EditUrlOverride { get; init; }
 
         public DateTimeOffset? LastUpdatedOverride { get; init; }
+    }
+
+    private sealed class FrontMatterLocalizationDocument
+    {
+        public string? Locale { get; init; }
+
+        public string? TranslationKey { get; init; }
+
+        public string? LocalizedTitle { get; init; }
+
+        public string? LocaleFallback { get; init; }
     }
 
     private sealed class FrontMatterTrustLinkDocument

--- a/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/Services/MarkdownFrontMatterParser.cs
@@ -557,9 +557,10 @@ internal static class MarkdownFrontMatterParser
         string? nestedValue,
         List<RazorDocsMetadataDiagnostic> diagnostics)
     {
+        var comparison = GetLocalizationConflictComparison(flatFieldPath);
         if (flatValue is null
             || nestedValue is null
-            || string.Equals(flatValue, nestedValue, StringComparison.Ordinal))
+            || string.Equals(flatValue, nestedValue, comparison))
         {
             return;
         }
@@ -571,6 +572,13 @@ internal static class MarkdownFrontMatterParser
                 $"The flat localization {fieldName} conflicts with {nestedFieldPath}.",
                 "RazorDocs prefers the flat front matter value and ignores the nested value for that field.",
                 $"Keep only {flatFieldPath} or {nestedFieldPath}, or make both values match."));
+    }
+
+    private static StringComparison GetLocalizationConflictComparison(string flatFieldPath)
+    {
+        return flatFieldPath is "locale" or "translation_key" or "locale_fallback"
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
     }
 
     private sealed class FrontMatterDocument

--- a/Web/ForgeTrust.AppSurface.Docs/use-razordocs.md
+++ b/Web/ForgeTrust.AppSurface.Docs/use-razordocs.md
@@ -119,9 +119,43 @@ Once the first pages render, improve the docs in layers:
 2. Add `summary`, `page_type`, `nav_group`, `aliases`, and `keywords` metadata to high-traffic pages.
 3. Add troubleshooting pages for the first support questions people ask.
 4. Add release notes and trust metadata when adoption depends on upgrade confidence.
-5. Add versioned published trees only after the live source-backed docs are useful.
+5. Add localization metadata when users need more than one language.
+6. Add versioned published trees only after the live source-backed docs are useful.
 
 That order matters. A beautiful archive of weak docs is still weak docs.
+
+## Prepare for multiple languages
+
+Localization is optional and disabled by default. Turn it on when the docs system needs to know which files are translations of the same page, even before you expose a language switcher or localized routes.
+
+```json
+{
+  "RazorDocs": {
+    "Localization": {
+      "Enabled": true,
+      "DefaultLocale": "en",
+      "Locales": [
+        { "Code": "en", "Label": "English", "Lang": "en-US", "RoutePrefix": "en" },
+        { "Code": "fr", "Label": "Français", "Lang": "fr-FR", "RoutePrefix": "fr" }
+      ]
+    }
+  }
+}
+```
+
+For colocated translations, files like `README.md` and `README.fr.md` are a good default. RazorDocs infers the `fr` locale from the configured suffix and groups the files under one translation key. When translated paths differ, author an explicit key:
+
+```yaml
+---
+title: Démarrer
+locale: fr
+translation_key: guides/getting-started
+---
+```
+
+Use locale folders only with explicit `translation_key` metadata. A file such as `fr/guides/demarrer.md` will not be treated as French just because it lives under `fr/`; that keeps ordinary folders from becoming language roots by accident.
+
+Phase 1 builds the locale graph, validates configuration, and reports diagnostics. Visible `/fr/...` routes, fallback pages, language switchers, localized SEO tags, and locale-filtered search are follow-up surfaces.
 
 ## Adoption checklist
 
@@ -130,6 +164,7 @@ That order matters. A beautiful archive of weak docs is still weak docs.
 - Keep `RazorDocs:Mode` set to `Source` unless a later bundle-hosting slice changes that contract.
 - Add sidecar metadata for repository and package README files.
 - Feature the first consumer paths through `featured_page_groups`.
+- Configure `RazorDocs:Localization` and `translation_key` metadata before adding translated files at scale.
 - Verify `/docs`, `/docs/search`, and `/docs/search-index.json`.
 - Run the standalone host or export pipeline in CI before publishing a public docs surface.
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -133,7 +133,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs now treats `Releases` as a first-class public section and suppresses breadcrumb links to generated parent routes that do not correspond to published docs pages, keeping static export warnings focused on actionable broken links.
 - RazorDocs wayfinding coverage now waits for docs content replacement before asserting sequence-link destinations, keeping the details-page proof path deterministic in CI.
 - RazorDocs Playwright integration coverage now hosts the standalone docs app in-process through the standalone host builder, avoiding fixture-time `dotnet run` rebuilds and stale standalone `bin` output during focused test runs.
-- RazorDocs now has the first localization foundation slice: disabled-by-default locale configuration, localized front matter metadata, inferred `README.fr.md`-style variant grouping, diagnostics for unsupported or ambiguous locale signals, and an internal route/search graph seam for later visible localized pages.
+- First localization foundation slice for RazorDocs: disabled-by-default locale configuration, localized front matter metadata, inferred `README.fr.md`-style variant grouping, diagnostics for unsupported or ambiguous locale signals, and an internal route/search graph seam for later visible localized pages.
 
 ### RazorWire form UX
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -133,6 +133,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs now treats `Releases` as a first-class public section and suppresses breadcrumb links to generated parent routes that do not correspond to published docs pages, keeping static export warnings focused on actionable broken links.
 - RazorDocs wayfinding coverage now waits for docs content replacement before asserting sequence-link destinations, keeping the details-page proof path deterministic in CI.
 - RazorDocs Playwright integration coverage now hosts the standalone docs app in-process through the standalone host builder, avoiding fixture-time `dotnet run` rebuilds and stale standalone `bin` output during focused test runs.
+- RazorDocs now has the first localization foundation slice: disabled-by-default locale configuration, localized front matter metadata, inferred `README.fr.md`-style variant grouping, diagnostics for unsupported or ambiguous locale signals, and an internal route/search graph seam for later visible localized pages.
 
 ### RazorWire form UX
 


### PR DESCRIPTION
Refs #144.

## Summary

- Add RazorDocs localization configuration options, metadata parsing, and locale graph primitives.
- Add localized route candidate plumbing without exposing visible localized routes yet.
- Document the first-pass authoring model, including examples like README.fr.md, while keeping shipped docs canonical/default-locale only.
- Add tests for option validation, front matter parsing, locale graph behavior, unsupported locale diagnostics, fallback diagnostics, and search projection stability.

## Product boundary

This is phase 1 infrastructure. It does not ship real localized production pages, a visible locale switcher, or /fr/... docs routes. The only localized files are test fixtures; user-facing docs explain localization support and conventions.

## Follow-up cases

- #297: Phase 2 i18n routes, fallback UI, and link rewriting.
- #298: Design localized exact-version and export i18n follow-up.

## Verification

- dotnet format Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj
- dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj, 1107 passed
- ./scripts/coverage-solution.sh, line 96.74%, branch 92.33%
- /qa browser pass on /docs, /docs/search, search query localization, /docs/_health.json, /docs/search-index.json, and mobile home