### PR TITLE
feat(docs): make search result rows tappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - AppSurface now treats the whole monorepo as one coordinated release surface. Packages, CLI tools, examples, and docs-facing behavior all roll into the same upcoming version.
 - Pull requests are expected to use Conventional Commits titles and to update `releases/unreleased.md` unless maintainers explicitly opt out.
 - Markdown-only changes on `main` now trigger the build-and-export workflow so release-note and policy updates publish with the docs surface.
+- RazorDocs search result rows now expose the whole visible result as one semantic link, making mobile taps easier while preserving keyboard focus, copied links, and open-in-new-tab browser behavior.
 - RazorWire CLI validation errors now include a concrete next command and `razorwire export --help` hint so failed exports are easier to recover from.
 - RazorWire CLI export now defaults to CDN-safe output: managed internal links, frames, scripts, stylesheets, images, `<img>` and `<source>` `srcset`, conventional `404.html`, and CSS `url(...)` references rewrite to emitted static artifacts, with `--mode hybrid` available for extensionless server-routed deployments.
 - Tailwind development watch mode now logs a warning, not a startup error, when the standalone CLI is unavailable and the app can continue serving existing CSS.

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
@@ -103,12 +103,18 @@ public class RazorDocsViewsTests
         Assert.Contains("function isPageTypeInGroup(doc, group)", searchClient);
         Assert.Contains("function getPageTypeDisplayLabel(doc)", searchClient);
         Assert.Contains("function createSearchResultArticle(doc, queryTokens, options = {})", searchClient);
+        Assert.Contains("const link = createElement('a', 'docs-search-result-link');", searchClient);
+        Assert.Contains("function createSearchResultLinkLabel(doc)", searchClient);
+        Assert.Contains("link.setAttribute('aria-label', createSearchResultLinkLabel(doc));", searchClient);
+        Assert.Contains("link.append(title);", searchClient);
+        Assert.Contains("article.append(link);", searchClient);
         Assert.Contains("docs-search-result-badges", searchClient);
         Assert.Contains("function createSearchResultPageTypeBadge(doc)", searchClient);
         Assert.Contains("createSearchResultBadge(formatFacetValue(doc.component))", searchClient);
         Assert.Contains("createSearchResultBadge(formatFacetValue(doc.audience), true)", searchClient);
         Assert.Contains("docs-search-result-meta-line", searchClient);
         Assert.Contains("docs-search-page-starter-docs", searchClient);
+        Assert.DoesNotContain("title.append(link);", searchClient);
     }
 
     [Fact]
@@ -231,6 +237,10 @@ public class RazorDocsViewsTests
         Assert.Contains("background: var(--docs-search-color-surface-canvas);", searchStylesheet);
         Assert.Contains("border: 1px solid var(--docs-search-color-border-default);", searchStylesheet);
         Assert.Contains("box-shadow: var(--docs-search-focus-ring-inset);", searchStylesheet);
+        Assert.Contains(".docs-search-result-link:focus-visible", searchStylesheet);
+        Assert.Contains(".docs-search-result-link:active", searchStylesheet);
+        Assert.Contains("background: var(--docs-search-color-state-active-fill);", searchStylesheet);
+        Assert.Contains("color: var(--docs-search-color-accent);", searchStylesheet);
         Assert.Contains(
             "background: linear-gradient(90deg, var(--docs-search-color-skeleton-edge), var(--docs-search-color-skeleton-mid), var(--docs-search-color-skeleton-edge));",
             searchStylesheet);

--- a/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
+++ b/Web/ForgeTrust.AppSurface.Docs/DESIGN.md
@@ -96,6 +96,8 @@ The search workspace renders semantic classes such as `docs-search-page`, `docs-
 
 That does not mean every heading, paragraph, or fallback-link wrapper inside `Search.cshtml` needs its own semantic class. Keep the stateful container and interactive hook semantic, then use local utilities for one-off typography and spacing inside that single view.
 
+JavaScript-rendered search result rows are a special case because the interactive surface is both styling hook and navigation contract. The row should contain one block-level `.docs-search-result-link` anchor that wraps the visible result content, so touch users can tap anywhere on the result while keyboard and assistive-technology users still get one normal link target. Because that anchor wraps rich row content, it should own a concise `aria-label` instead of letting breadcrumbs, paths, badges, and snippets become one long accessible name.
+
 #### Required `id` values
 
 Some search controls still need unique `id` values such as `docs-search-page-input` and `docs-search-page-filters-panel`. Those support uniqueness, accessibility relationships, and DOM targeting. They do not replace semantic classes as the reusable styling contract.
@@ -109,6 +111,7 @@ Avoid these by default:
 - pushing utility classes into harvested nested HTML that RazorDocs does not fully own
 - treating shared CSS and JavaScript hook classes as a failure of Tailwind instead of a legitimate integration seam
 - moving styles across the boundary without a concrete user-facing benefit
+- simulating whole-result search navigation with row click handlers when one semantic link can own the interaction
 
 ### Review Questions
 

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -44,6 +44,7 @@ This section is the normative source of truth for the boundary. `DESIGN.md` expl
 - New one-off page header spacing or typography in owned Razor markup: use Tailwind utilities in the view.
 - New reusable badge, metadata chip, page metadata row, trust/provenance surface, or page-local outline state: add or extend a semantic component class in `wwwroot/css/app.css`, then use utilities around it only when they are purely local.
 - For `Views/Docs/Search.cshtml`, keep the stateful search container or interactive hook semantic, but use local utilities for one-off header copy, helper layout, and fallback-link chrome inside that view.
+- JavaScript-rendered search result rows should expose one block-level anchor for the whole result, not a JavaScript-only click handler or nested links. Give that anchor a concise `aria-label` such as `Open RazorDocs Roadmap in How-to Guides` so screen reader link lists do not read every breadcrumb, badge, path, and snippet. This keeps mobile taps, keyboard focus, copy-link, and open-in-new-tab behavior aligned with normal browser expectations.
 - Restyling paragraphs, headings, or code blocks inside `.docs-content`: update wrapper-scoped CSS instead of pushing utility classes into harvested HTML.
 - Markdown pages with long-form prose use `.docs-content--markdown` for prose measure, paragraph rhythm, list spacing, links, blockquotes, and inline code. Generated non-Markdown docs and docs marked with `page_type: api` or `page_type: api-reference` use `.docs-content--api` so signatures and reference tables keep the wider base content measure.
 - New search filter pill, active-filter surface, or other stateful search UI: use a semantic hook class because CSS and JavaScript both need to recognize it.
@@ -89,6 +90,8 @@ Do not add broad fallbacks such as `var(--docs-color-text-default, #e2e8f0)` unl
 - Do not place non-search primitives in `wwwroot/docs/search.css` just because the layout loads search assets globally today. Use `wwwroot/css/app.css` for shared components so future theming can target one stable package layer.
 - Do not introduce new hardcoded slate/cyan literals inside shared selector groups. Add or reuse a `--docs-*` token instead.
 - Do not move syntax-highlight colors into the shared token layer until RazorDocs has a public code-theme story. Code block chrome can use shared tokens; syntax spans stay local.
+- Do not make search result rows feel tappable by adding a row-level `click` listener while the real anchor stays only on the title. That makes touch behavior work while breaking native link affordances.
+- Do not rely on the full wrapped row text as the accessible name for a full-row search result link. The row can be visually rich while the link name stays short.
 
 ## Details Page Heading Ownership
 

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/search-client.js
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/search-client.js
@@ -994,6 +994,19 @@
     );
   }
 
+  function createSearchResultLinkLabel(doc) {
+    const title = String(doc.title ?? '').trim() || 'Documentation result';
+    const titleKey = title.toLowerCase();
+    const context = [
+      doc.navGroup,
+      getPageTypeDisplayLabel(doc)
+    ]
+      .map((part) => String(part ?? '').trim())
+      .find((part) => part && part.toLowerCase() !== titleKey);
+
+    return context ? `Open ${title} in ${context}` : `Open ${title}`;
+  }
+
   function createSearchResultArticle(doc, queryTokens, options = {}) {
     const article = createElement(
       'article',
@@ -1001,6 +1014,10 @@
         ? 'docs-search-result docs-search-result-starter'
         : 'docs-search-result'
     );
+    const link = createElement('a', 'docs-search-result-link');
+    link.href = doc.path;
+    link.setAttribute('aria-label', createSearchResultLinkLabel(doc));
+    applyDocsNavigationTarget(link, doc.path);
 
     const breadcrumbs = buildBreadcrumbLabels(doc);
     if (breadcrumbs.length > 0) {
@@ -1012,16 +1029,12 @@
 
         breadcrumbRow.append(createElement('span', null, label));
       });
-      article.append(breadcrumbRow);
+      link.append(breadcrumbRow);
     }
 
     const title = createElement('h2', 'docs-search-result-title');
-    const link = createElement('a');
-    link.href = doc.path;
-    applyDocsNavigationTarget(link, doc.path);
-    link.append(createHighlightedFragment(doc.title, queryTokens));
-    title.append(link);
-    article.append(title);
+    title.append(createHighlightedFragment(doc.title, queryTokens));
+    link.append(title);
 
     const metaParts = [
       doc.navGroup,
@@ -1029,7 +1042,7 @@
       doc.path
     ].map((part) => String(part ?? '').trim()).filter(Boolean);
     if (metaParts.length > 0) {
-      article.append(createElement('p', 'docs-search-result-meta-line', [...new Set(metaParts)].join(' • ')));
+      link.append(createElement('p', 'docs-search-result-meta-line', [...new Set(metaParts)].join(' • ')));
     }
 
     const badgeRow = createElement('div', 'docs-search-result-badges');
@@ -1051,16 +1064,17 @@
     }
 
     if (badgeRow.childNodes.length > 0) {
-      article.append(badgeRow);
+      link.append(badgeRow);
     }
 
     const snippetText = doc.summary || doc.snippet || '';
     if (snippetText) {
       const snippet = createElement('p', 'docs-search-result-snippet');
       snippet.append(createHighlightedFragment(snippetText, queryTokens));
-      article.append(snippet);
+      link.append(snippet);
     }
 
+    article.append(link);
     return article;
   }
 

--- a/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/search.css
+++ b/Web/ForgeTrust.AppSurface.Docs/wwwroot/docs/search.css
@@ -312,30 +312,47 @@
 }
 
 .docs-search-result {
-    display: grid;
-    gap: 0.55rem;
-    padding: 0.05rem 0 1rem;
     border-bottom: 1px solid var(--docs-search-color-border-muted);
 }
 
 .docs-search-result:last-child {
     border-bottom: 0;
+}
+
+.docs-search-result:last-child .docs-search-result-link {
     padding-bottom: 0;
+}
+
+.docs-search-result-link {
+    display: grid;
+    gap: 0.55rem;
+    border-radius: 0.75rem;
+    margin-inline: -0.35rem;
+    padding: 0.05rem 0.35rem 1rem;
+    color: var(--docs-search-color-text-default);
+    text-decoration: none;
+}
+
+.docs-search-result-link:hover,
+.docs-search-result-link:focus-visible {
+    background: var(--docs-search-color-surface-overlay-soft);
+    color: var(--docs-search-color-accent);
+}
+
+.docs-search-result-link:active {
+    background: var(--docs-search-color-state-active-fill);
+}
+
+.docs-search-result-link:focus-visible {
+    outline: 0;
+    box-shadow: var(--docs-search-focus-ring-inset);
 }
 
 .docs-search-result-title {
     margin: 0;
     font-size: 1.1rem;
     line-height: 1.3;
-}
-
-.docs-search-result-title a {
-    color: var(--docs-search-color-text-default);
-    text-decoration: none;
-}
-
-.docs-search-result-title a:hover {
-    color: var(--docs-search-color-accent);
+    color: inherit;
 }
 
 .docs-search-result-breadcrumbs {
@@ -526,8 +543,8 @@
         padding: 0.9rem;
     }
 
-    .docs-search-result {
-        padding-bottom: 0.85rem;
+    .docs-search-result-link {
+        padding: 0.35rem 0.35rem 0.85rem;
     }
 
     .docs-search-result-title,

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsSearchPlaywrightTests.cs
@@ -397,6 +397,52 @@ public sealed class RazorDocsSearchPlaywrightTests
     }
 
     [Fact]
+    public async Task SearchPage_MobileResultRows_OpenWhenSnippetIsTapped()
+    {
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize
+            {
+                Width = 390,
+                Height = 844
+            }
+        });
+        var page = await context.NewPageAsync();
+        await RouteSearchPayloadAsync(
+            page,
+            BuildControlledSearchPayload(
+                SearchDoc(
+                    "docs-index",
+                    "Use RazorDocs",
+                    "guide",
+                    "Guide",
+                    "guide",
+                    "Adopt RazorDocs in your repository.",
+                    path: "/docs",
+                    breadcrumbs: ["Guides", "Adoption"])));
+
+        await page.GotoAsync($"{_fixture.DocsUrl}/search?q=razordocs");
+        await WaitForSearchPageSettledAsync(page);
+
+        var result = page.Locator("#docs-search-page-results .docs-search-result").First;
+        await Assertions.Expect(result).ToContainTextAsync("Use RazorDocs", new LocatorAssertionsToContainTextOptions
+        {
+            Timeout = 30_000
+        });
+        Assert.Equal(1, await result.Locator("a").CountAsync());
+        Assert.Equal("Open Use RazorDocs in Guides", await result.Locator(".docs-search-result-link").GetAttributeAsync("aria-label"));
+        await Assertions.Expect(result.Locator(".docs-search-result-link")).ToContainTextAsync(
+            "Adopt RazorDocs in your repository.",
+            new LocatorAssertionsToContainTextOptions
+            {
+                Timeout = 30_000
+            });
+
+        await result.Locator(".docs-search-result-snippet").ClickAsync();
+        await WaitForPathAsync(page, "/docs");
+    }
+
+    [Fact]
     public async Task SearchPage_NoResultsRecovery_ShowsSummaryAndClearsFilters()
     {
         await using var context = await _fixture.Browser.NewContextAsync();
@@ -737,16 +783,17 @@ public sealed class RazorDocsSearchPlaywrightTests
         string audience = "",
         string status = "",
         string bodyText = "",
+        string? path = null,
         string[]? breadcrumbs = null)
     {
-        var path = id.StartsWith("/docs/", StringComparison.Ordinal)
+        var resolvedPath = path ?? (id.StartsWith("/docs/", StringComparison.Ordinal)
             ? id
-            : $"/docs/{id}";
+            : $"/docs/{id}");
 
         return new
         {
             id,
-            path,
+            path = resolvedPath,
             title,
             summary,
             headings = Array.Empty<string>(),

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsStyleTokenPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorDocsStyleTokenPlaywrightTests.cs
@@ -55,7 +55,7 @@ public sealed class RazorDocsStyleTokenPlaywrightTests
               return [
                 style('#docs-search-page-input').borderTopColor,
                 style('#docs-search-page-input').boxShadow,
-                style('.docs-search-result-title a').color,
+                style('.docs-search-result-link').color,
                 style('.docs-search-page-active-filter').backgroundColor,
                 style('.docs-search-page-active-filter').color,
                 style('.docs-search-result mark').backgroundColor

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -136,6 +136,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs fenced Markdown code blocks now render server-side syntax highlighting through TextMateSharp with RazorDocs-owned token classes, language badges, and escaped plaintext fallback when a language is unknown, unsupported, oversized, or cannot be tokenized safely.
 - RazorDocs search now keeps failure recovery markup out of the active search shell until the index actually fails to load, so successful searches no longer expose hidden failure copy to text extraction tools.
 - RazorDocs search now opens as a richer workspace with representative starter rows, filter-first browsing, stronger no-results recovery, and normalized release badge aliases.
+- RazorDocs search result rows now use one semantic full-row link, so touch users can tap anywhere in a visible result while keyboard focus, copied links, and open-in-new-tab behavior stay native.
 - RazorDocs harvesting now excludes test-project docs and generated example-app API reference from the docs surface while keeping authored example README walkthroughs public.
 - RazorDocs now includes a repository root `LICENSE` file as a docs artifact when present, so repo-relative license links remain revision-correct and still pass CDN static export validation.
 - RazorDocs now documents the namespace README merge contract with positive and negative examples, while detail-page titles wrap on narrow screens so long package names do not clip on mobile.


### PR DESCRIPTION
# Summary
- Wrap each RazorDocs search result row in one semantic full-row link.
- Add concise aria labels so screen reader link lists do not read the whole rich result row.
- Document the full-row link contract and cover mobile snippet taps in Playwright.

# Tests
- `dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj`
- `dotnet test Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj --filter FullyQualifiedName~RazorDocsSearchPlaywrightTests`
- `dotnet test Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj --filter FullyQualifiedName~RazorDocsStyleTokenPlaywrightTests`
- `dotnet format`
- `git diff --check`

# Review
- Pre-landing review: clean

Fixes #286