### PR TITLE
chore: migrate test process helpers to CliWrap

### DIFF
--- a/Config/ForgeTrust.AppSurface.Config.Tests/ConfigValidationExampleSmokeTests.cs
+++ b/Config/ForgeTrust.AppSurface.Config.Tests/ConfigValidationExampleSmokeTests.cs
@@ -1,4 +1,5 @@
-using System.Diagnostics;
+using CliWrap;
+using CliWrap.Buffered;
 using ForgeTrust.AppSurface.Core;
 
 namespace ForgeTrust.AppSurface.Config.Tests;
@@ -9,62 +10,31 @@ public sealed class ConfigValidationExampleSmokeTests
     public async Task ConfigValidationExample_FailsWithScalarValidationMessage()
     {
         var repositoryRoot = PathUtils.FindRepositoryRoot(AppContext.BaseDirectory);
-        using var process = new Process();
-        process.StartInfo = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = "run --project examples/config-validation -p:NodeReuse=false",
-            WorkingDirectory = repositoryRoot,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false
-        };
-        process.StartInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
-        process.StartInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
-        process.StartInfo.Environment["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1";
-        process.StartInfo.Environment["DOTNET_NOLOGO"] = "1";
-        process.StartInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";
-
-        process.Start();
-
-        var stdout = process.StandardOutput.ReadToEndAsync();
-        var stderr = process.StandardError.ReadToEndAsync();
-        var timedOut = false;
         using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
+        BufferedCommandResult result;
         try
         {
-            await process.WaitForExitAsync(timeoutSource.Token);
+            result = await Cli.Wrap("dotnet")
+                .WithArguments(["run", "--project", "examples/config-validation", "-p:NodeReuse=false"])
+                .WithWorkingDirectory(repositoryRoot)
+                .WithEnvironmentVariables(new Dictionary<string, string?>
+                {
+                    ["MSBUILDDISABLENODEREUSE"] = "1",
+                    ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
+                    ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
+                    ["DOTNET_NOLOGO"] = "1",
+                    ["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1"
+                })
+                .WithValidation(CommandResultValidation.None)
+                .ExecuteBufferedAsync(timeoutSource.Token);
         }
-        catch (OperationCanceledException)
-        {
-            timedOut = true;
-            try
-            {
-                process.Kill(entireProcessTree: true);
-            }
-            catch (InvalidOperationException)
-            {
-                // The process can exit naturally between cancellation and kill.
-            }
-
-            await process.WaitForExitAsync();
-        }
-
-        var outputTask = Task.WhenAll(stdout, stderr);
-        var outputCompleted = await Task.WhenAny(outputTask, Task.Delay(TimeSpan.FromSeconds(5)));
-        if (outputCompleted != outputTask)
-        {
-            throw new TimeoutException("The config validation example output streams did not close within 5 seconds.");
-        }
-
-        var output = string.Concat(await stdout, await stderr);
-        if (timedOut)
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
         {
             throw new TimeoutException("The config validation example did not finish within 30 seconds.");
         }
 
-        Assert.NotEqual(0, process.ExitCode);
+        var output = result.StandardOutput + result.StandardError;
+        Assert.NotEqual(0, result.ExitCode);
         Assert.Contains("Configuration validation failed for key 'PortConfig'", output);
         Assert.Contains("- <value>: The configuration value must be between 1 and 65535.", output);
         Assert.Contains("Fix the configured value or relax the scalar rule", output);

--- a/Config/ForgeTrust.AppSurface.Config.Tests/ForgeTrust.AppSurface.Config.Tests.csproj
+++ b/Config/ForgeTrust.AppSurface.Config.Tests/ForgeTrust.AppSurface.Config.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="CliWrap" />
     <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Config/ForgeTrust.AppSurface.Config.Tests/packages.lock.json
+++ b/Config/ForgeTrust.AppSurface.Config.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
+      },
       "coverlet.msbuild": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -367,7 +373,7 @@
       "forgetrust.appsurface.config": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Options": "[9.0.6, )"
         }
       },

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ This command:
 - Produces one merged Cobertura file at `TestResults/coverage-merged/coverage.cobertura.xml`.
 - Writes a summary to `TestResults/coverage-merged/summary.txt`.
 
+When tests need to launch child processes, prefer CliWrap-backed helpers over raw `System.Diagnostics.Process` setup. Keep process-output capture in the helper result so CI failures include stdout and stderr, and reserve raw `Process` usage for tests that intentionally exercise process-wrapper behavior.
+
 Check out the examples to see how modules are composed in practice:
 
 ```bash

--- a/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/ForgeTrust.AppSurface.Web.Tailwind.Tests.csproj
+++ b/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/ForgeTrust.AppSurface.Web.Tailwind.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CliWrap" />
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="GitHubActionsTestLogger">
       <PrivateAssets>all</PrivateAssets>

--- a/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
@@ -1,6 +1,7 @@
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using CliWrap;
+using CliWrap.Buffered;
 
 namespace ForgeTrust.AppSurface.Web.Tailwind.Tests;
 
@@ -252,34 +253,16 @@ exit 0
 
     private static async Task<DotNetCommandResult> RunDotNetBuildAsync(string projectPath, string workingDirectory)
     {
-        using var process = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                WorkingDirectory = workingDirectory,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            }
-        };
-
-        process.StartInfo.ArgumentList.Add("build");
-        process.StartInfo.ArgumentList.Add(projectPath);
-        process.StartInfo.ArgumentList.Add("-nologo");
-        process.StartInfo.ArgumentList.Add("-v:minimal");
-
-        process.Start();
-
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-
-        await process.WaitForExitAsync();
+        var result = await Cli.Wrap("dotnet")
+            .WithArguments(["build", projectPath, "-nologo", "-v:minimal"])
+            .WithWorkingDirectory(workingDirectory)
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync();
 
         return new DotNetCommandResult(
-            process.ExitCode,
-            await stdoutTask,
-            await stderrTask);
+            result.ExitCode,
+            result.StandardOutput,
+            result.StandardError);
     }
 
     private static async Task AssertBuildManifestContainsGeneratedCssAsync(string manifestPath)

--- a/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
+      },
       "coverlet.msbuild": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -134,12 +140,12 @@
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/ForgeTrust.RazorWire.Cli.Tests.csproj
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/ForgeTrust.RazorWire.Cli.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="CliWrap" />
     <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/TargetAppProcessTests.cs
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/TargetAppProcessTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 
 namespace ForgeTrust.RazorWire.Cli.Tests;
 
+// Raw Process instances are intentional here because TargetAppProcess is the production process wrapper under test.
 public class TargetAppProcessTests
 {
     [Fact]

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
@@ -1,8 +1,9 @@
-using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 using System.Xml.Linq;
+using CliWrap;
+using CliCommand = CliWrap.Cli;
 
 namespace ForgeTrust.RazorWire.Cli.Tests;
 
@@ -29,6 +30,7 @@ public sealed class ToolPackageContractTests
             repositoryRoot,
             new Dictionary<string, string?>
             {
+                ["MSBUILDDISABLENODEREUSE"] = "1",
                 ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
                 ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
                 ["DOTNET_NOLOGO"] = "1",
@@ -41,6 +43,7 @@ public sealed class ToolPackageContractTests
                 ["DOTNET_CLI_HOME"] = cliHomeDirectory.Path,
                 // Keep package assets pointed at a stable cache while isolating .NET CLI first-run state.
                 ["NUGET_PACKAGES"] = nugetPackagesDirectory,
+                ["MSBUILDDISABLENODEREUSE"] = "1",
                 ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
                 ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
                 ["DOTNET_NOLOGO"] = "1",
@@ -208,85 +211,27 @@ public sealed class ToolPackageContractTests
             params string[] arguments)
         {
             using var timeoutSource = new CancellationTokenSource(timeout);
-            using var process = new Process();
-            process.StartInfo = new ProcessStartInfo
-            {
-                FileName = fileName,
-                WorkingDirectory = workingDirectory,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            foreach (var argument in arguments)
-            {
-                process.StartInfo.ArgumentList.Add(argument);
-            }
-
-            foreach (var (key, value) in environmentOverrides)
-            {
-                if (value == null)
-                {
-                    process.StartInfo.Environment.Remove(key);
-                }
-                else
-                {
-                    process.StartInfo.Environment[key] = value;
-                }
-            }
-
+            var stdout = new StringBuilder();
+            var stderr = new StringBuilder();
             var commandLine = BuildCommandLine(fileName, arguments);
-            if (!process.Start())
-            {
-                throw new InvalidOperationException($"Unable to start process: {commandLine}");
-            }
-
-            var stdoutTask = process.StandardOutput.ReadToEndAsync();
-            var stderrTask = process.StandardError.ReadToEndAsync();
-            var timedOut = false;
 
             try
             {
-                await process.WaitForExitAsync(timeoutSource.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                timedOut = true;
-                try
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-                catch (InvalidOperationException)
-                {
-                    // The process may have exited between the timeout and the kill attempt.
-                }
+                var result = await CliCommand.Wrap(fileName)
+                    .WithArguments(arguments)
+                    .WithWorkingDirectory(workingDirectory)
+                    .WithEnvironmentVariables(environmentOverrides)
+                    .WithValidation(CommandResultValidation.None)
+                    .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdout))
+                    .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stderr))
+                    .ExecuteAsync(timeoutSource.Token);
 
-                await process.WaitForExitAsync();
+                return new ToolProcessResult(commandLine, result.ExitCode, TimedOut: false, stdout.ToString(), stderr.ToString());
             }
-
-            string stdout;
-            string stderr;
-            try
+            catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
             {
-                stdout = await stdoutTask.WaitAsync(TimeSpan.FromSeconds(5));
+                return new ToolProcessResult(commandLine, ExitCode: null, TimedOut: true, stdout.ToString(), stderr.ToString());
             }
-            catch (TimeoutException)
-            {
-                stdout = string.Empty;
-            }
-
-            try
-            {
-                stderr = await stderrTask.WaitAsync(TimeSpan.FromSeconds(5));
-            }
-            catch (TimeoutException)
-            {
-                stderr = string.Empty;
-            }
-
-            int? exitCode = timedOut ? null : process.ExitCode;
-            return new ToolProcessResult(commandLine, exitCode, timedOut, stdout, stderr);
         }
 
         private static string BuildCommandLine(string fileName, IReadOnlyList<string> arguments)

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/packages.lock.json
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
+      },
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -387,7 +393,7 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
@@ -400,13 +406,13 @@
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.razorwire": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
         }
       },
@@ -414,9 +420,9 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Console": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "ForgeTrust.RazorWire": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Console": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )"
         }
       },
       "CliFx": {

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CliWrap" />
     <PackageReference Include="GitHubActionsTestLogger">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorWireMvcPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorWireMvcPlaywrightTests.cs
@@ -840,8 +840,7 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
     private readonly ConcurrentQueue<string> _appLogs = new();
     private readonly TaskCompletionSource<string> _boundBaseUrlSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    private CancellationTokenSource? _appProcessCancellation;
-    private Task<CliCommandResult>? _appProcessTask;
+    private CliWrapProcessLease? _appProcess;
     private IPlaywright? _playwright;
 
     public IBrowser Browser { get; private set; } = null!;
@@ -884,28 +883,7 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
         }
         finally
         {
-            if (_appProcessCancellation is not null)
-            {
-                await _appProcessCancellation.CancelAsync();
-            }
-
-            if (_appProcessTask is not null)
-            {
-                try
-                {
-                    await _appProcessTask.WaitAsync(TimeSpan.FromSeconds(10));
-                }
-                catch (OperationCanceledException) when (_appProcessCancellation?.IsCancellationRequested == true)
-                {
-                    // CliWrap converts cancellation into process-tree termination for this test child process.
-                }
-                catch (TimeoutException)
-                {
-                    // Best-effort fixture cleanup should not hide the original test failure.
-                }
-            }
-
-            _appProcessCancellation?.Dispose();
+            await DisposeAppProcessAsync();
         }
     }
 
@@ -949,9 +927,7 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
             throw new FileNotFoundException("Could not find RazorWire MVC example project.", projectPath);
         }
 
-        var appProcessCancellation = new CancellationTokenSource();
-        _appProcessCancellation = appProcessCancellation;
-        _appProcessTask = Cli.Wrap("dotnet")
+        var appProcess = CliWrapProcessLease.Start(Cli.Wrap("dotnet")
             .WithArguments(BuildExampleAppArguments(repoRoot, readmeProjectPath))
             .WithWorkingDirectory(repoRoot)
             .WithEnvironmentVariables(new Dictionary<string, string?>
@@ -962,14 +938,13 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
             })
             .WithValidation(CommandResultValidation.None)
             .WithStandardOutputPipe(PipeTarget.ToDelegate(CaptureAppLog))
-            .WithStandardErrorPipe(PipeTarget.ToDelegate(CaptureAppLog))
-            .ExecuteAsync(appProcessCancellation.Token)
-            .Task;
+            .WithStandardErrorPipe(PipeTarget.ToDelegate(CaptureAppLog)));
+        _appProcess = appProcess;
 
-        _ = _appProcessTask.ContinueWith(
+        _ = appProcess.Completion.ContinueWith(
             task =>
             {
-                if (appProcessCancellation.IsCancellationRequested)
+                if (appProcess.IsCancellationRequested)
                 {
                     return;
                 }
@@ -1016,6 +991,17 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
         }
 
         return $"exited with code {task.Result.ExitCode}";
+    }
+
+    private async ValueTask DisposeAppProcessAsync()
+    {
+        if (_appProcess is null)
+        {
+            return;
+        }
+
+        await _appProcess.DisposeAsync();
+        _appProcess = null;
     }
 
     private static string ResolveCurrentConfiguration()
@@ -1069,14 +1055,14 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
 
         while (!timeoutCts.Token.IsCancellationRequested)
         {
-            if (_appProcessTask is null)
+            if (_appProcess is null)
             {
                 throw new InvalidOperationException($"RazorWire MVC example exited before it became ready.{Environment.NewLine}{GetRecentLogs()}");
             }
 
-            if (_appProcessTask.IsCompleted)
+            if (_appProcess.Completion.IsCompleted)
             {
-                throw new InvalidOperationException($"RazorWire MVC example {DescribeExampleAppExit(_appProcessTask)} before it became ready.{Environment.NewLine}{GetRecentLogs()}");
+                throw new InvalidOperationException($"RazorWire MVC example {DescribeExampleAppExit(_appProcess.Completion)} before it became ready.{Environment.NewLine}{GetRecentLogs()}");
             }
 
             try
@@ -1238,6 +1224,47 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
     private string GetRecentLogs()
     {
         return string.Join(Environment.NewLine, _appLogs);
+    }
+
+    private sealed class CliWrapProcessLease : IAsyncDisposable
+    {
+        private readonly CancellationTokenSource _cancellation = new();
+        private readonly CommandTask<CliCommandResult> _commandTask;
+
+        private CliWrapProcessLease(CliWrap.Command command)
+        {
+            _commandTask = command.ExecuteAsync(_cancellation.Token);
+        }
+
+        public Task<CliCommandResult> Completion => _commandTask.Task;
+
+        public bool IsCancellationRequested => _cancellation.IsCancellationRequested;
+
+        public static CliWrapProcessLease Start(CliWrap.Command command)
+        {
+            return new CliWrapProcessLease(command);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            using var cancellation = _cancellation;
+            using var commandTask = _commandTask;
+
+            await cancellation.CancelAsync();
+
+            try
+            {
+                await commandTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+                // CliWrap converts cancellation into process-tree termination for this test child process.
+            }
+            catch (TimeoutException)
+            {
+                // Best-effort fixture cleanup should not hide the original test failure.
+            }
+        }
     }
 
 }

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/RazorWireMvcPlaywrightTests.cs
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/RazorWireMvcPlaywrightTests.cs
@@ -1,9 +1,10 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Net;
 using System.Text.RegularExpressions;
+using CliWrap;
 using ForgeTrust.AppSurface.Core;
 using Microsoft.Playwright;
+using CliCommandResult = CliWrap.CommandResult;
 
 namespace ForgeTrust.RazorWire.IntegrationTests;
 
@@ -839,7 +840,8 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
     private readonly ConcurrentQueue<string> _appLogs = new();
     private readonly TaskCompletionSource<string> _boundBaseUrlSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    private Process? _appProcess;
+    private CancellationTokenSource? _appProcessCancellation;
+    private Task<CliCommandResult>? _appProcessTask;
     private IPlaywright? _playwright;
 
     public IBrowser Browser { get; private set; } = null!;
@@ -857,7 +859,7 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
             Headless = true
         });
 
-        _appProcess = StartExampleApp("http://127.0.0.1:0");
+        StartExampleApp("http://127.0.0.1:0");
         var boundBaseUrl = await WaitForBoundBaseUrlAsync(TimeSpan.FromSeconds(60));
         var browserBaseUrl = ReplaceLoopbackIpHostWithLocalhost(boundBaseUrl);
 
@@ -882,13 +884,28 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
         }
         finally
         {
-            if (_appProcess is not null && !_appProcess.HasExited)
+            if (_appProcessCancellation is not null)
             {
-                _appProcess.Kill(entireProcessTree: true);
-                await _appProcess.WaitForExitAsync();
+                await _appProcessCancellation.CancelAsync();
             }
 
-            _appProcess?.Dispose();
+            if (_appProcessTask is not null)
+            {
+                try
+                {
+                    await _appProcessTask.WaitAsync(TimeSpan.FromSeconds(10));
+                }
+                catch (OperationCanceledException) when (_appProcessCancellation?.IsCancellationRequested == true)
+                {
+                    // CliWrap converts cancellation into process-tree termination for this test child process.
+                }
+                catch (TimeoutException)
+                {
+                    // Best-effort fixture cleanup should not hide the original test failure.
+                }
+            }
+
+            _appProcessCancellation?.Dispose();
         }
     }
 
@@ -921,7 +938,7 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
         }
     }
 
-    private Process StartExampleApp(string baseUrl)
+    private void StartExampleApp(string baseUrl)
     {
         const string readmeProjectPath = "examples/razorwire-mvc/RazorWireWebExample.csproj";
         var repoRoot = PathUtils.FindRepositoryRoot(AppContext.BaseDirectory);
@@ -932,38 +949,40 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
             throw new FileNotFoundException("Could not find RazorWire MVC example project.", projectPath);
         }
 
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            WorkingDirectory = repoRoot,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
+        var appProcessCancellation = new CancellationTokenSource();
+        _appProcessCancellation = appProcessCancellation;
+        _appProcessTask = Cli.Wrap("dotnet")
+            .WithArguments(BuildExampleAppArguments(repoRoot, readmeProjectPath))
+            .WithWorkingDirectory(repoRoot)
+            .WithEnvironmentVariables(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_URLS"] = baseUrl,
+                ["DOTNET_ENVIRONMENT"] = "Development",
+                ["ASPNETCORE_ENVIRONMENT"] = "Development"
+            })
+            .WithValidation(CommandResultValidation.None)
+            .WithStandardOutputPipe(PipeTarget.ToDelegate(CaptureAppLog))
+            .WithStandardErrorPipe(PipeTarget.ToDelegate(CaptureAppLog))
+            .ExecuteAsync(appProcessCancellation.Token)
+            .Task;
 
-        AddExampleAppArguments(startInfo, repoRoot, readmeProjectPath);
-        startInfo.Environment["ASPNETCORE_URLS"] = baseUrl;
-        startInfo.Environment["DOTNET_ENVIRONMENT"] = "Development";
-        startInfo.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
+        _ = _appProcessTask.ContinueWith(
+            task =>
+            {
+                if (appProcessCancellation.IsCancellationRequested)
+                {
+                    return;
+                }
 
-        var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
-        process.OutputDataReceived += (_, args) => CaptureAppLog(args.Data);
-        process.ErrorDataReceived += (_, args) => CaptureAppLog(args.Data);
-        process.Exited += (_, _) =>
-        {
-            _boundBaseUrlSource.TrySetException(
-                new InvalidOperationException($"RazorWire MVC example exited before publishing a listening URL.{Environment.NewLine}{GetRecentLogs()}"));
-        };
-
-        process.Start();
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        return process;
+                _boundBaseUrlSource.TrySetException(
+                    new InvalidOperationException($"RazorWire MVC example {DescribeExampleAppExit(task)} before publishing a listening URL.{Environment.NewLine}{GetRecentLogs()}"));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
-    private static void AddExampleAppArguments(ProcessStartInfo startInfo, string repoRoot, string projectPath)
+    private static IReadOnlyList<string> BuildExampleAppArguments(string repoRoot, string projectPath)
     {
         var configuration = ResolveCurrentConfiguration();
         var targetFramework = "net10.0";
@@ -978,16 +997,25 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
 
         if (File.Exists(builtAssemblyPath))
         {
-            startInfo.ArgumentList.Add(builtAssemblyPath);
-            return;
+            return [builtAssemblyPath];
         }
 
-        startInfo.ArgumentList.Add("run");
-        startInfo.ArgumentList.Add("--project");
-        startInfo.ArgumentList.Add(projectPath);
-        startInfo.ArgumentList.Add("--no-launch-profile");
-        startInfo.ArgumentList.Add("--configuration");
-        startInfo.ArgumentList.Add(configuration);
+        return ["run", "--project", projectPath, "--no-launch-profile", "--configuration", configuration];
+    }
+
+    private static string DescribeExampleAppExit(Task<CliCommandResult> task)
+    {
+        if (task.IsFaulted)
+        {
+            return $"failed with {task.Exception.GetBaseException().Message}";
+        }
+
+        if (task.IsCanceled)
+        {
+            return "was canceled";
+        }
+
+        return $"exited with code {task.Result.ExitCode}";
     }
 
     private static string ResolveCurrentConfiguration()
@@ -1041,9 +1069,14 @@ public sealed class RazorWireMvcPlaywrightFixture : IAsyncLifetime
 
         while (!timeoutCts.Token.IsCancellationRequested)
         {
-            if (_appProcess is null || _appProcess.HasExited)
+            if (_appProcessTask is null)
             {
                 throw new InvalidOperationException($"RazorWire MVC example exited before it became ready.{Environment.NewLine}{GetRecentLogs()}");
+            }
+
+            if (_appProcessTask.IsCompleted)
+            {
+                throw new InvalidOperationException($"RazorWire MVC example {DescribeExampleAppExit(_appProcessTask)} before it became ready.{Environment.NewLine}{GetRecentLogs()}");
             }
 
             try

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/packages.lock.json
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
+      },
       "coverlet.msbuild": {
         "type": "Direct",
         "requested": "[6.0.4, )",
@@ -427,7 +433,7 @@
       "forgetrust.appsurface.caching": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Caching.Memory": "[9.0.6, )"
         }
       },
@@ -438,18 +444,12 @@
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
       },
-      "forgetrust.appsurface.web": {
-        "type": "Project",
-        "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
-        }
-      },
       "forgetrust.appsurface.docs": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Caching": "[1.0.0, )",
-          "ForgeTrust.RazorWire": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Caching": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )",
           "HtmlSanitizer": "[9.0.892, )",
           "Markdig": "[0.44.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
@@ -461,25 +461,24 @@
       "forgetrust.appsurface.docs.standalone": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Docs": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Docs": "[0.1.0, )"
         }
       },
-      "forgetrust.razorwire": {
+      "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
@@ -496,6 +495,13 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
       },
       "HtmlSanitizer": {
         "type": "CentralTransitive",

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -29,6 +29,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 
 - Pull request titles are now expected to follow Conventional Commits so the merge history is machine-readable for future automation.
 - Pull requests are expected to update this page unless maintainers explicitly mark the change as outside the public release story.
+- Test and integration process helpers now use CliWrap for child-process execution, keeping stdout and stderr diagnostics available while aligning test infrastructure with the preferred process-launch abstraction.
 - The primary build workflow now declares explicit read-only `GITHUB_TOKEN` contents permissions, keeping CI aligned with least-privilege GitHub Actions defaults.
 - Markdown-only changes on `main` now republish the docs surface, so release-note and policy edits are treated as first-class product updates.
 - AppSurface now exposes focused GitHub issue forms for bug reports, feature requests, and docs/developer-experience feedback, with the root README and contribution guide pointing developers to that feedback path.


### PR DESCRIPTION
## Summary

- migrate test and integration child-process helpers to CliWrap
- preserve stdout and stderr capture for failure diagnostics
- document the test-process helper convention and keep raw Process usage only where the process wrapper itself is under test

Fixes #274

## Validation

- dotnet test Config/ForgeTrust.AppSurface.Config.Tests/ForgeTrust.AppSurface.Config.Tests.csproj --no-build
- dotnet test Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/ForgeTrust.AppSurface.Web.Tailwind.Tests.csproj --no-build
- dotnet test Web/ForgeTrust.RazorWire.Cli.Tests/ForgeTrust.RazorWire.Cli.Tests.csproj --no-build
- dotnet test Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj --no-build --filter FullyQualifiedName~RazorWireMvcPlaywrightTests
- dotnet format ForgeTrust.AppSurface.slnx --no-restore
- git diff --check