### PR TITLE
feat(cli): add AppSurface docs export command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,9 +99,9 @@ jobs:
         run: |
           dotnet run --project tools/ForgeTrust.AppSurface.MarkdownSnippets/ForgeTrust.AppSurface.MarkdownSnippets.csproj -- verify
 
-      - name: Build RazorWire CLI (Release)
+      - name: Build AppSurface CLI (Release)
         run: |
-          dotnet build Web/ForgeTrust.RazorWire.Cli/ForgeTrust.RazorWire.Cli.csproj -c Release
+          dotnet build Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release
 
       - name: Export RazorDocs static site with CDN validation
         env:
@@ -113,12 +113,13 @@ jobs:
           RazorDocs__Contributor__LastUpdatedMode: Git
         run: |
           printf '%s\n' '/' '/docs' > "$RUNNER_TEMP/razordocs-seeds.txt"
-          dotnet run --project Web/ForgeTrust.RazorWire.Cli/ForgeTrust.RazorWire.Cli.csproj -c Release -- \
-            export \
+          dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release -- \
+            docs export \
+            --repo . \
             --mode cdn \
             --seeds "$RUNNER_TEMP/razordocs-seeds.txt" \
             --output "$RUNNER_TEMP/razordocs-pages" \
-            --project Web/ForgeTrust.AppSurface.Docs.Standalone/ForgeTrust.AppSurface.Docs.Standalone.csproj
+            --strict
 
       - name: Upload Pages artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/DocsExportWorkflowContractTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/DocsExportWorkflowContractTests.cs
@@ -1,0 +1,115 @@
+using ForgeTrust.AppSurface.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace ForgeTrust.AppSurface.Cli.Tests;
+
+public sealed class DocsExportWorkflowContractTests
+{
+    [Fact]
+    public void BuildWorkflow_Should_Run_AppSurface_Docs_Export_On_PullRequests_And_Guard_Pages_Deploy()
+    {
+        var workflow = LoadBuildWorkflow();
+        var root = (YamlMappingNode)workflow.Documents[0].RootNode;
+        var on = GetMapping(root, "on");
+        var pullRequest = GetMapping(on, "pull_request");
+        var pullRequestBranches = GetSequence(pullRequest, "branches")
+            .Select(GetScalar)
+            .ToArray();
+
+        Assert.Contains("main", pullRequestBranches);
+
+        var jobs = GetMapping(root, "jobs");
+        var exportJob = GetMapping(jobs, "export-razordocs");
+
+        Assert.DoesNotContain(exportJob.Children.Keys.OfType<YamlScalarNode>(), key => key.Value == "if");
+
+        var steps = GetSequence(exportJob, "steps")
+            .Cast<YamlMappingNode>()
+            .ToArray();
+        var checkout = FindStep(steps, "Checkout code");
+        Assert.Equal("actions/checkout@v5", GetScalar(checkout, "uses"));
+        Assert.Equal("0", GetScalar(GetMapping(checkout, "with"), "fetch-depth"));
+
+        var exportStep = FindStep(steps, "Export RazorDocs static site with CDN validation");
+        var exportEnv = GetMapping(exportStep, "env");
+        Assert.Contains("RazorDocs__Contributor__DefaultBranch", ScalarKeys(exportEnv));
+        Assert.Contains("RazorDocs__Contributor__SourceRef", ScalarKeys(exportEnv));
+        Assert.Contains("RazorDocs__Contributor__SourceUrlTemplate", ScalarKeys(exportEnv));
+        Assert.Contains("RazorDocs__Contributor__SymbolSourceUrlTemplate", ScalarKeys(exportEnv));
+        Assert.Contains("RazorDocs__Contributor__EditUrlTemplate", ScalarKeys(exportEnv));
+        Assert.Contains("RazorDocs__Contributor__LastUpdatedMode", ScalarKeys(exportEnv));
+
+        var exportRun = GetScalar(exportStep, "run");
+        Assert.Contains("printf '%s\\n' '/' '/docs' > \"$RUNNER_TEMP/razordocs-seeds.txt\"", exportRun, StringComparison.Ordinal);
+        Assert.Contains("dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj", exportRun, StringComparison.Ordinal);
+        Assert.Contains("docs export", exportRun, StringComparison.Ordinal);
+        Assert.Contains("--repo .", exportRun, StringComparison.Ordinal);
+        Assert.Contains("--mode cdn", exportRun, StringComparison.Ordinal);
+        Assert.Contains("--strict", exportRun, StringComparison.Ordinal);
+        Assert.Contains("--seeds \"$RUNNER_TEMP/razordocs-seeds.txt\"", exportRun, StringComparison.Ordinal);
+        Assert.Contains("--output \"$RUNNER_TEMP/razordocs-pages\"", exportRun, StringComparison.Ordinal);
+
+        var uploadStep = FindStep(steps, "Upload Pages artifact");
+        Assert.Equal("${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}", GetScalar(uploadStep, "if"));
+        Assert.Equal("actions/upload-pages-artifact@v4", GetScalar(uploadStep, "uses"));
+        Assert.Equal("${{ runner.temp }}/razordocs-pages", GetScalar(GetMapping(uploadStep, "with"), "path"));
+
+        var deployJob = GetMapping(jobs, "deploy-razordocs");
+        Assert.Equal("${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}", GetScalar(deployJob, "if"));
+    }
+
+    private static YamlStream LoadBuildWorkflow()
+    {
+        var repoRoot = PathUtils.FindRepositoryRoot(AppContext.BaseDirectory);
+        using var reader = File.OpenText(Path.Combine(repoRoot, ".github", "workflows", "build.yml"));
+        var workflow = new YamlStream();
+        workflow.Load(reader);
+        return workflow;
+    }
+
+    private static YamlMappingNode FindStep(IEnumerable<YamlMappingNode> steps, string name)
+    {
+        return steps.Single(step => string.Equals(GetScalar(step, "name"), name, StringComparison.Ordinal));
+    }
+
+    private static IEnumerable<string> ScalarKeys(YamlMappingNode mapping)
+    {
+        return mapping.Children.Keys
+            .OfType<YamlScalarNode>()
+            .Select(key => key.Value)
+            .Where(value => value is not null)!;
+    }
+
+    private static YamlMappingNode GetMapping(YamlMappingNode mapping, string key)
+    {
+        return (YamlMappingNode)GetChild(mapping, key);
+    }
+
+    private static YamlSequenceNode GetSequence(YamlMappingNode mapping, string key)
+    {
+        return (YamlSequenceNode)GetChild(mapping, key);
+    }
+
+    private static string GetScalar(YamlMappingNode mapping, string key)
+    {
+        return GetScalar(GetChild(mapping, key));
+    }
+
+    private static string GetScalar(YamlNode node)
+    {
+        return ((YamlScalarNode)node).Value ?? string.Empty;
+    }
+
+    private static YamlNode GetChild(YamlMappingNode mapping, string key)
+    {
+        var match = mapping.Children.SingleOrDefault(
+            child => child.Key is YamlScalarNode scalar && string.Equals(scalar.Value, key, StringComparison.Ordinal));
+
+        if (match.Key is null)
+        {
+            throw new KeyNotFoundException($"YAML mapping did not contain key '{key}'.");
+        }
+
+        return match.Value;
+    }
+}

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj
@@ -19,6 +19,7 @@
     </PackageReference>
     <PackageReference Include="JunitXml.TestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="YamlDotNet" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -3,6 +3,9 @@ using CliFx.Infrastructure;
 using ForgeTrust.AppSurface.Console;
 using ForgeTrust.AppSurface.Core;
 using ForgeTrust.RazorWire.Cli;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -312,7 +315,7 @@ public sealed class ProgramEntryPointTests
     {
         using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
         using var output = TempDirectory.Create("appsurface-docs-output-");
-        var seedFile = System.IO.Path.Combine(repository.Path, "seeds.txt");
+        var seedFile = System.IO.Path.Join(repository.Path, "seeds.txt");
         await File.WriteAllLinesAsync(seedFile, ["/", "/reference/next"]);
         var runner = new CapturingRazorDocsExportRunner();
 
@@ -418,6 +421,24 @@ public sealed class ProgramEntryPointTests
     }
 
     [Fact]
+    public async Task DocsExportCommand_Should_Translate_Startup_Timeout_Failures()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        var runner = new CapturingRazorDocsExportRunner
+        {
+            Exception = new TimeoutException("RazorDocs export host did not start within 10 seconds.")
+        };
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "export", "--repo", repository.Path],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("RazorDocs export host did not start within 10 seconds.", result.AllText, StringComparison.Ordinal);
+        Assert.NotNull(runner.Args);
+    }
+
+    [Fact]
     public void RazorDocsInProcessExportRunner_Should_Resolve_Single_Bound_BaseUrl()
     {
         var result = RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(["http://127.0.0.1:51234"]);
@@ -441,6 +462,153 @@ public sealed class ProgramEntryPointTests
             () => RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(["http://127.0.0.1:1", "http://127.0.0.1:2"]));
 
         Assert.Contains("published 2 listening URLs", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RazorDocsInProcessExportRunner_Should_Reject_Invalid_Bound_BaseUrl()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(["not-a-url"]));
+
+        Assert.Contains("did not publish a valid listening URL", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Export_When_Startup_Timeout_Is_Disabled()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        var exporter = new CapturingStaticExporter();
+        var host = new TrackingHost("http://127.0.0.1:61234");
+        var hostStarter = new ImmediateExportHostStarter(host);
+        var runner = new RazorDocsInProcessExportRunner(
+            NullLogger<RazorDocsInProcessExportRunner>.Instance,
+            exporter,
+            hostStarter);
+
+        await runner.ExportAsync(CreateExportArgs(repository.Path, output.Path, startupTimeout: null), CancellationToken.None);
+
+        Assert.NotNull(exporter.Context);
+        Assert.Equal("http://127.0.0.1:61234", exporter.Context.BaseUrl);
+        Assert.Equal(output.Path, exporter.Context.OutputPath);
+        Assert.Equal(["/"], exporter.Context.InitialSeedRoutes);
+        Assert.Equal("Production", hostStarter.EnvironmentName);
+        Assert.False(hostStarter.StartupToken.CanBeCanceled);
+        Assert.True(host.StopCalled);
+        Assert.True(host.DisposeCalled);
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Translate_Startup_Cancellation_To_Startup_Timeout()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        var exporter = new CapturingStaticExporter();
+        var runner = new RazorDocsInProcessExportRunner(
+            NullLogger<RazorDocsInProcessExportRunner>.Instance,
+            exporter,
+            new CancelingExportHostStarter());
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(
+            () => runner.ExportAsync(
+                CreateExportArgs(repository.Path, output.Path, TimeSpan.FromSeconds(30)),
+                CancellationToken.None));
+
+        Assert.Contains("RazorDocs export host did not start within 30 seconds.", ex.Message, StringComparison.Ordinal);
+        Assert.IsType<OperationCanceledException>(ex.InnerException);
+        Assert.Null(exporter.Context);
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Preserve_External_Cancellation_During_Startup()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        using var cts = new CancellationTokenSource();
+        var exporter = new CapturingStaticExporter();
+        var hostStarter = new ControllableExportHostStarter();
+        var runner = new RazorDocsInProcessExportRunner(
+            NullLogger<RazorDocsInProcessExportRunner>.Instance,
+            exporter,
+            hostStarter);
+
+        var exportTask = runner.ExportAsync(
+            CreateExportArgs(repository.Path, output.Path, TimeSpan.FromSeconds(30)),
+            cts.Token);
+        await hostStarter.Started.WaitAsync(TimeSpan.FromSeconds(1));
+        cts.Cancel();
+
+        try
+        {
+            var completedTask = await Task.WhenAny(exportTask, Task.Delay(TimeSpan.FromSeconds(2)));
+            Assert.Same(exportTask, completedTask);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => exportTask);
+
+            Assert.True(hostStarter.StartupToken.IsCancellationRequested);
+            Assert.Null(exporter.Context);
+
+            var lateHost = new TrackingHost();
+            hostStarter.Complete(lateHost);
+
+            await lateHost.Disposed.WaitAsync(TimeSpan.FromSeconds(1));
+            Assert.True(lateHost.StopCalled);
+        }
+        finally
+        {
+            hostStarter.Complete(new TrackingHost());
+        }
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Log_When_Late_Startup_Faults_After_Timeout()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        var loggerProvider = new InMemoryLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(loggerProvider);
+        });
+        var hostStarter = new ControllableExportHostStarter();
+        var runner = new RazorDocsInProcessExportRunner(
+            loggerFactory.CreateLogger<RazorDocsInProcessExportRunner>(),
+            new CapturingStaticExporter(),
+            hostStarter);
+
+        var exportTask = runner.ExportAsync(
+            CreateExportArgs(repository.Path, output.Path, TimeSpan.FromMilliseconds(50)),
+            CancellationToken.None);
+        await hostStarter.Started.WaitAsync(TimeSpan.FromSeconds(1));
+
+        var completedTask = await Task.WhenAny(exportTask, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.Same(exportTask, completedTask);
+        await Assert.ThrowsAsync<TimeoutException>(() => exportTask);
+
+        hostStarter.Fail(new InvalidOperationException("Late startup fault."));
+        await WaitForLogMessageAsync(loggerProvider, "completed after the startup timeout.");
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Log_And_Dispose_When_Host_Stop_Fails()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        var loggerProvider = new InMemoryLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+        var host = new TrackingHost("http://127.0.0.1:61235", throwOnStop: true);
+        var runner = new RazorDocsInProcessExportRunner(
+            loggerFactory.CreateLogger<RazorDocsInProcessExportRunner>(),
+            new CapturingStaticExporter(),
+            new ImmediateExportHostStarter(host));
+
+        await runner.ExportAsync(CreateExportArgs(repository.Path, output.Path, startupTimeout: null), CancellationToken.None);
+
+        Assert.True(host.StopCalled);
+        Assert.True(host.DisposeCalled);
+        Assert.Contains(
+            loggerProvider.GetMessages(),
+            message => message.Contains("RazorDocs export host failed during shutdown.", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -475,6 +643,60 @@ public sealed class ProgramEntryPointTests
 
         Assert.Equal("Export canceled after startup.", ex.Message);
         Assert.NotNull(exporter.Context);
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Timeout_When_Host_Build_Does_Not_Complete()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        var exporter = new CapturingStaticExporter();
+        var hostStarter = new ControllableExportHostStarter();
+        var runner = new RazorDocsInProcessExportRunner(
+            NullLogger<RazorDocsInProcessExportRunner>.Instance,
+            exporter,
+            hostStarter);
+        var hostArgs = new RazorDocsHostArgs(
+            repository.Path,
+            [
+                "--RazorDocs:Source:RepositoryRoot",
+                repository.Path,
+                "--environment",
+                "Production"
+            ],
+            TimeSpan.FromMilliseconds(50),
+            "Production");
+        var exportArgs = new RazorDocsExportArgs(
+            hostArgs,
+            output.Path,
+            SeedRoutesPath: null,
+            InitialSeedRoutes: ["/"],
+            ExportMode.Cdn,
+            "http://127.0.0.1:0");
+
+        var exportTask = runner.ExportAsync(exportArgs, CancellationToken.None);
+        await hostStarter.Started.WaitAsync(TimeSpan.FromSeconds(1));
+
+        try
+        {
+            var completedTask = await Task.WhenAny(exportTask, Task.Delay(TimeSpan.FromSeconds(2)));
+            Assert.Same(exportTask, completedTask);
+            var ex = await Assert.ThrowsAsync<TimeoutException>(() => exportTask);
+
+            Assert.Contains("RazorDocs export host did not start within 0.05 seconds.", ex.Message, StringComparison.Ordinal);
+            Assert.True(hostStarter.StartupToken.IsCancellationRequested);
+            Assert.Null(exporter.Context);
+
+            var lateHost = new TrackingHost();
+            hostStarter.Complete(lateHost);
+
+            await lateHost.Disposed.WaitAsync(TimeSpan.FromSeconds(1));
+            Assert.True(lateHost.StopCalled);
+        }
+        finally
+        {
+            hostStarter.Complete(new TrackingHost());
+        }
     }
 
     [Fact]
@@ -614,6 +836,49 @@ public sealed class ProgramEntryPointTests
         options.CustomRegistrations.Add(services => services.AddSingleton<IRazorDocsExportRunner>(runner));
     }
 
+    private static RazorDocsExportArgs CreateExportArgs(
+        string repositoryPath,
+        string outputPath,
+        TimeSpan? startupTimeout)
+    {
+        var hostArgs = new RazorDocsHostArgs(
+            repositoryPath,
+            [
+                "--RazorDocs:Source:RepositoryRoot",
+                repositoryPath,
+                "--environment",
+                "Production"
+            ],
+            startupTimeout,
+            "Production");
+
+        return new RazorDocsExportArgs(
+            hostArgs,
+            outputPath,
+            SeedRoutesPath: null,
+            InitialSeedRoutes: ["/"],
+            ExportMode.Cdn,
+            "http://127.0.0.1:0");
+    }
+
+    private static async Task WaitForLogMessageAsync(InMemoryLoggerProvider loggerProvider, string expectedMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(1);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (loggerProvider.GetMessages().Any(message => message.Contains(expectedMessage, StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+
+        Assert.Contains(
+            loggerProvider.GetMessages(),
+            message => message.Contains(expectedMessage, StringComparison.Ordinal));
+    }
+
     private static string NormalizeDirectoryForComparison(string? path)
     {
         Assert.NotNull(path);
@@ -690,6 +955,150 @@ public sealed class ProgramEntryPointTests
         {
             Context = context;
             throw new OperationCanceledException("Export canceled after startup.");
+        }
+    }
+
+    private sealed class CapturingStaticExporter : IRazorWireStaticExporter
+    {
+        public ExportContext? Context { get; private set; }
+
+        public Task ExportAsync(ExportContext context, CancellationToken cancellationToken)
+        {
+            Context = context;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ImmediateExportHostStarter(IHost host) : IRazorDocsExportHostStarter
+    {
+        public string? EnvironmentName { get; private set; }
+
+        public CancellationToken StartupToken { get; private set; }
+
+        public Task<IHost> BuildAndStartAsync(
+            RazorDocsExportArgs args,
+            string environmentName,
+            CancellationToken cancellationToken)
+        {
+            EnvironmentName = environmentName;
+            StartupToken = cancellationToken;
+            return Task.FromResult(host);
+        }
+    }
+
+    private sealed class CancelingExportHostStarter : IRazorDocsExportHostStarter
+    {
+        public Task<IHost> BuildAndStartAsync(
+            RazorDocsExportArgs args,
+            string environmentName,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<IHost>(new OperationCanceledException(cancellationToken));
+        }
+    }
+
+    private sealed class ControllableExportHostStarter : IRazorDocsExportHostStarter
+    {
+        private readonly TaskCompletionSource<IHost> _hostCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Started => _started.Task;
+
+        public CancellationToken StartupToken { get; private set; }
+
+        public Task<IHost> BuildAndStartAsync(
+            RazorDocsExportArgs args,
+            string environmentName,
+            CancellationToken cancellationToken)
+        {
+            StartupToken = cancellationToken;
+            _started.TrySetResult(null);
+            return _hostCompletion.Task;
+        }
+
+        public void Complete(IHost host)
+        {
+            _hostCompletion.TrySetResult(host);
+        }
+
+        public void Fail(Exception exception)
+        {
+            _hostCompletion.TrySetException(exception);
+        }
+    }
+
+    private sealed class TrackingHost : IHost
+    {
+        private readonly bool _throwOnStop;
+        private readonly ServiceProvider _services;
+        private readonly TaskCompletionSource<object?> _disposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TrackingHost(string boundAddress = "http://127.0.0.1:51234", bool throwOnStop = false)
+        {
+            _throwOnStop = throwOnStop;
+            _services = new ServiceCollection()
+                .AddSingleton<IServer>(new FakeServer(boundAddress))
+                .BuildServiceProvider();
+        }
+
+        public IServiceProvider Services => _services;
+
+        public bool StopCalled { get; private set; }
+
+        public bool DisposeCalled { get; private set; }
+
+        public Task Disposed => _disposed.Task;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCalled = true;
+            if (_throwOnStop)
+            {
+                throw new InvalidOperationException("Host stop failed.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            DisposeCalled = true;
+            _services.Dispose();
+            _disposed.TrySetResult(null);
+        }
+    }
+
+    private sealed class FakeServer : IServer
+    {
+        public FakeServer(string boundAddress)
+        {
+            var addresses = new ServerAddressesFeature();
+            addresses.Addresses.Add(boundAddress);
+            Features.Set<IServerAddressesFeature>(addresses);
+        }
+
+        public IFeatureCollection Features { get; } = new FeatureCollection();
+
+        public Task StartAsync<TContext>(
+            Microsoft.AspNetCore.Hosting.Server.IHttpApplication<TContext> application,
+            CancellationToken cancellationToken)
+            where TContext : notnull
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
         }
     }
 

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -2,9 +2,11 @@ using System.Collections.Concurrent;
 using CliFx.Infrastructure;
 using ForgeTrust.AppSurface.Console;
 using ForgeTrust.AppSurface.Core;
+using ForgeTrust.RazorWire.Cli;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ForgeTrust.AppSurface.Cli.Tests;
 
@@ -19,6 +21,7 @@ public sealed class ProgramEntryPointTests
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("usage", result.AllText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("docs", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("docs export", result.AllText, StringComparison.Ordinal);
         Assert.DoesNotContain("Application started", result.AllText, StringComparison.Ordinal);
         Assert.DoesNotContain("Run Exited - Shutting down", result.AllText, StringComparison.Ordinal);
     }
@@ -30,6 +33,7 @@ public sealed class ProgramEntryPointTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("Preview RazorDocs for a repository.", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("docs export", result.AllText, StringComparison.Ordinal);
         Assert.Contains("--repo", result.AllText, StringComparison.Ordinal);
         Assert.Contains("--strict", result.AllText, StringComparison.Ordinal);
         Assert.Contains("--startup-timeout-seconds", result.AllText, StringComparison.Ordinal);
@@ -193,6 +197,218 @@ public sealed class ProgramEntryPointTests
     }
 
     [Fact]
+    public async Task EntryPoint_Should_Print_Docs_Export_Help_Without_Preview_Listener_Options()
+    {
+        var result = await InvokeEntryPointAsync(["docs", "export", "--help"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Export RazorDocs for a repository to static files.", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("--output", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("dist/docs", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("--mode", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("cdn", result.AllText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--seeds", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("--strict", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("--port", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("--urls", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Application started", result.AllText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Run Exited - Shutting down", result.AllText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DocsExportCommand_Should_Default_Output_Environment_Mode_And_Derived_Seeds()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        var runner = new CapturingRazorDocsExportRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "export", "--repo", repository.Path],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        Assert.Equal(Path.GetFullPath("dist/docs"), runner.Args.Value.OutputPath);
+        Assert.Equal(ExportMode.Cdn, runner.Args.Value.Mode);
+        Assert.Null(runner.Args.Value.SeedRoutesPath);
+        Assert.Equal(["/", "/docs"], runner.Args.Value.InitialSeedRoutes);
+        Assert.Equal("http://127.0.0.1:0", runner.Args.Value.RequestedBaseUrl);
+        Assert.Equal("Production", runner.Args.Value.HostArgs.EnvironmentName);
+        Assert.Contains("--environment", runner.Args.Value.HostArgs.Args);
+        Assert.Contains("Production", runner.Args.Value.HostArgs.Args);
+        Assert.DoesNotContain("--urls", runner.Args.Value.HostArgs.Args);
+        Assert.DoesNotContain("--port", runner.Args.Value.HostArgs.Args);
+        Assert.Equal(TimeSpan.FromSeconds(10), runner.Args.Value.HostArgs.StartupTimeout);
+    }
+
+    [Fact]
+    public async Task DocsExportCommand_Should_Forward_Explicit_Export_Arguments()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-output-");
+        var seedFile = System.IO.Path.Combine(repository.Path, "seeds.txt");
+        await File.WriteAllLinesAsync(seedFile, ["/", "/reference/next"]);
+        var runner = new CapturingRazorDocsExportRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            [
+                "docs", "export",
+                "-r", repository.Path,
+                "--output", output.Path,
+                "--mode", "hybrid",
+                "--seeds", seedFile,
+                "--strict",
+                "--route-root", "/reference",
+                "--docs-root", "/reference/next",
+                "--environment", "Development",
+                "--startup-timeout-seconds", "2"
+            ],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        Assert.Equal(output.Path, runner.Args.Value.OutputPath);
+        Assert.Equal(ExportMode.Hybrid, runner.Args.Value.Mode);
+        Assert.Equal(seedFile, runner.Args.Value.SeedRoutesPath);
+        Assert.Null(runner.Args.Value.InitialSeedRoutes);
+        Assert.Equal("http://127.0.0.1:0", runner.Args.Value.RequestedBaseUrl);
+        Assert.Equal("Development", runner.Args.Value.HostArgs.EnvironmentName);
+        Assert.Contains("--RazorDocs:Source:RepositoryRoot", runner.Args.Value.HostArgs.Args);
+        Assert.Contains(repository.Path, runner.Args.Value.HostArgs.Args);
+        Assert.Contains("--RazorDocs:Harvest:FailOnFailure", runner.Args.Value.HostArgs.Args);
+        Assert.Contains("true", runner.Args.Value.HostArgs.Args);
+        Assert.Contains("--RazorDocs:Routing:RouteRootPath", runner.Args.Value.HostArgs.Args);
+        Assert.Contains("/reference", runner.Args.Value.HostArgs.Args);
+        Assert.Contains("--RazorDocs:Routing:DocsRootPath", runner.Args.Value.HostArgs.Args);
+        Assert.Contains("/reference/next", runner.Args.Value.HostArgs.Args);
+        Assert.Equal(TimeSpan.FromSeconds(2), runner.Args.Value.HostArgs.StartupTimeout);
+    }
+
+    [Fact]
+    public async Task DocsExportCommand_Should_Derive_Default_Seed_From_Custom_DocsRoot()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        var runner = new CapturingRazorDocsExportRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "export", "--repo", repository.Path, "--route-root", "/foo/bar", "--docs-root", "/foo/bar/next"],
+            options => RegisterRunner(options, runner));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(runner.Args);
+        Assert.Equal(["/", "/foo/bar/next"], runner.Args.Value.InitialSeedRoutes);
+    }
+
+    [Fact]
+    public async Task DocsExportCommand_Should_Reject_Blank_Output()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        var runner = new CapturingRazorDocsExportRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "export", "--repo", repository.Path, "--output", " "],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("The --output value must point to an export directory.", result.AllText, StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Fact]
+    public async Task DocsExportCommand_Should_Reject_Seeds_Short_Alias()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        var runner = new CapturingRazorDocsExportRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "export", "--repo", repository.Path, "-s", "seeds.txt"],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("-s", result.AllText, StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Fact]
+    public async Task DocsExportCommand_Should_Translate_Export_Validation_Failures()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        var runner = new CapturingRazorDocsExportRunner
+        {
+            Exception = new ExportValidationException(
+                [new ExportDiagnostic("RWEXPORT004", "Managed URL could not be rewritten.", "/docs")])
+        };
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "export", "--repo", repository.Path],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("RWEXPORT004", result.AllText, StringComparison.Ordinal);
+        Assert.Contains("Managed URL could not be rewritten.", result.AllText, StringComparison.Ordinal);
+        Assert.NotNull(runner.Args);
+    }
+
+    [Fact]
+    public void RazorDocsInProcessExportRunner_Should_Resolve_Single_Bound_BaseUrl()
+    {
+        var result = RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(["http://127.0.0.1:51234"]);
+
+        Assert.Equal("http://127.0.0.1:51234", result);
+    }
+
+    [Fact]
+    public void RazorDocsInProcessExportRunner_Should_Reject_Missing_Bound_BaseUrl()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(Array.Empty<string>()));
+
+        Assert.Contains("did not publish a listening URL", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RazorDocsInProcessExportRunner_Should_Reject_Multiple_Bound_BaseUrls()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(["http://127.0.0.1:1", "http://127.0.0.1:2"]));
+
+        Assert.Contains("published 2 listening URLs", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Not_Translate_Exporter_Cancellation_To_Startup_Timeout()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        var exporter = new CancelingStaticExporter();
+        var runner = new RazorDocsInProcessExportRunner(
+            NullLogger<RazorDocsInProcessExportRunner>.Instance,
+            exporter);
+        var hostArgs = new RazorDocsHostArgs(
+            repository.Path,
+            [
+                "--RazorDocs:Source:RepositoryRoot",
+                repository.Path,
+                "--environment",
+                "Production"
+            ],
+            TimeSpan.FromSeconds(30),
+            "Production");
+        var exportArgs = new RazorDocsExportArgs(
+            hostArgs,
+            output.Path,
+            SeedRoutesPath: null,
+            InitialSeedRoutes: ["/"],
+            ExportMode.Cdn,
+            "http://127.0.0.1:0");
+
+        var ex = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => runner.ExportAsync(exportArgs, CancellationToken.None));
+
+        Assert.Equal("Export canceled after startup.", ex.Message);
+        Assert.NotNull(exporter.Context);
+    }
+
+    [Fact]
     public void PushConfigureOptionsOverrideForTests_Should_Throw_When_ConfigureOptions_IsNull()
     {
         Assert.Throws<ArgumentNullException>(() => ProgramEntryPoint.PushConfigureOptionsOverrideForTests(null!));
@@ -324,6 +540,11 @@ public sealed class ProgramEntryPointTests
         options.CustomRegistrations.Add(services => services.AddSingleton<IRazorDocsHostRunner>(runner));
     }
 
+    private static void RegisterRunner(ConsoleOptions options, CapturingRazorDocsExportRunner runner)
+    {
+        options.CustomRegistrations.Add(services => services.AddSingleton<IRazorDocsExportRunner>(runner));
+    }
+
     private sealed record CapturedCliRun(
         string RawStdout,
         string RawStderr,
@@ -356,6 +577,35 @@ public sealed class ProgramEntryPointTests
             Args = args;
             StartupTimeout = startupTimeout;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CapturingRazorDocsExportRunner : IRazorDocsExportRunner
+    {
+        public RazorDocsExportArgs? Args { get; private set; }
+
+        public Exception? Exception { get; init; }
+
+        public Task ExportAsync(RazorDocsExportArgs args, CancellationToken cancellationToken)
+        {
+            Args = args;
+            if (Exception is not null)
+            {
+                throw Exception;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CancelingStaticExporter : IRazorWireStaticExporter
+    {
+        public ExportContext? Context { get; private set; }
+
+        public Task ExportAsync(ExportContext context, CancellationToken cancellationToken)
+        {
+            Context = context;
+            throw new OperationCanceledException("Export canceled after startup.");
         }
     }
 

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -386,6 +386,26 @@ public sealed class ProgramEntryPointTests
     }
 
     [Fact]
+    public async Task DocsExportCommand_Should_Reject_Output_File()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        var outputFile = System.IO.Path.Join(repository.Path, "docs.html");
+        await File.WriteAllTextAsync(outputFile, "not a directory");
+        var runner = new CapturingRazorDocsExportRunner();
+
+        var result = await InvokeProgramEntryPointAsync(
+            ["docs", "export", "--repo", repository.Path, "--output", outputFile],
+            options => RegisterRunner(options, runner));
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(
+            $"The --output value must point to an export directory, but an existing file was found: {outputFile}",
+            result.AllText,
+            StringComparison.Ordinal);
+        Assert.Null(runner.Args);
+    }
+
+    [Fact]
     public async Task DocsExportCommand_Should_Reject_Missing_Seed_File()
     {
         using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
@@ -573,6 +593,39 @@ public sealed class ProgramEntryPointTests
         {
             hostStarter.Complete(new TrackingHost());
         }
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_Log_When_Late_Startup_Faults_After_External_Cancellation()
+    {
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        using var cts = new CancellationTokenSource();
+        var loggerProvider = new InMemoryLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(loggerProvider);
+        });
+        var hostStarter = new ControllableExportHostStarter();
+        var runner = new RazorDocsInProcessExportRunner(
+            loggerFactory.CreateLogger<RazorDocsInProcessExportRunner>(),
+            new CapturingStaticExporter(),
+            hostStarter);
+
+        var exportTask = runner.ExportAsync(
+            CreateExportArgs(repository.Path, output.Path, TimeSpan.FromSeconds(30)),
+            cts.Token);
+        await hostStarter.Started.WaitAsync(TimeSpan.FromSeconds(1));
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => exportTask);
+
+        hostStarter.Fail(new InvalidOperationException("Late startup fault."));
+
+        await WaitForLogMessageAsync(loggerProvider, "completed after external cancellation.");
+        Assert.DoesNotContain(
+            loggerProvider.GetMessages(),
+            message => message.Contains("completed after the startup timeout.", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/ProgramEntryPointTests.cs
@@ -483,6 +483,14 @@ public sealed class ProgramEntryPointTests
     }
 
     [Fact]
+    public void RazorDocsInProcessExportRunner_Should_Resolve_Localhost_Bound_BaseUrl()
+    {
+        var result = RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(["http://localhost:51234"]);
+
+        Assert.Equal("http://localhost:51234", result);
+    }
+
+    [Fact]
     public void RazorDocsInProcessExportRunner_Should_Reject_Missing_Bound_BaseUrl()
     {
         var ex = Assert.Throws<InvalidOperationException>(
@@ -510,6 +518,15 @@ public sealed class ProgramEntryPointTests
     }
 
     [Fact]
+    public void RazorDocsInProcessExportRunner_Should_Reject_NonLoopback_Bound_BaseUrl()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RazorDocsInProcessExportRunner.ResolveBoundBaseUrl(["http://0.0.0.0:51234"]));
+
+        Assert.Contains("published non-loopback URL", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task RazorDocsInProcessExportRunner_Should_Export_When_Startup_Timeout_Is_Disabled()
     {
         using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
@@ -532,6 +549,42 @@ public sealed class ProgramEntryPointTests
         Assert.False(hostStarter.StartupToken.CanBeCanceled);
         Assert.True(host.StopCalled);
         Assert.True(host.DisposeCalled);
+    }
+
+    [Fact]
+    public async Task RazorDocsInProcessExportRunner_Should_RunHost_And_Export_FromRepositoryRoot()
+    {
+        using var callerDirectory = TempDirectory.Create("appsurface-docs-export-caller-");
+        using var repository = TempDirectory.Create("appsurface-docs-export-repo-");
+        using var output = TempDirectory.Create("appsurface-docs-export-output-");
+        var previousDirectory = Directory.GetCurrentDirectory();
+        var exporter = new CapturingStaticExporter();
+        var hostStarter = new ImmediateExportHostStarter(new TrackingHost());
+        var runner = new RazorDocsInProcessExportRunner(
+            NullLogger<RazorDocsInProcessExportRunner>.Instance,
+            exporter,
+            hostStarter);
+
+        try
+        {
+            Directory.SetCurrentDirectory(callerDirectory.Path);
+
+            await runner.ExportAsync(CreateExportArgs(repository.Path, output.Path, startupTimeout: null), CancellationToken.None);
+
+            Assert.Equal(
+                NormalizeDirectoryForComparison(repository.Path),
+                NormalizeDirectoryForComparison(hostStarter.WorkingDirectoryDuringStart));
+            Assert.Equal(
+                NormalizeDirectoryForComparison(repository.Path),
+                NormalizeDirectoryForComparison(exporter.WorkingDirectoryDuringExport));
+            Assert.Equal(
+                NormalizeDirectoryForComparison(callerDirectory.Path),
+                NormalizeDirectoryForComparison(Directory.GetCurrentDirectory()));
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(previousDirectory);
+        }
     }
 
     [Fact]
@@ -1031,9 +1084,12 @@ public sealed class ProgramEntryPointTests
     {
         public ExportContext? Context { get; private set; }
 
+        public string? WorkingDirectoryDuringExport { get; private set; }
+
         public Task ExportAsync(ExportContext context, CancellationToken cancellationToken)
         {
             Context = context;
+            WorkingDirectoryDuringExport = Directory.GetCurrentDirectory();
             return Task.CompletedTask;
         }
     }
@@ -1044,6 +1100,8 @@ public sealed class ProgramEntryPointTests
 
         public CancellationToken StartupToken { get; private set; }
 
+        public string? WorkingDirectoryDuringStart { get; private set; }
+
         public Task<IHost> BuildAndStartAsync(
             RazorDocsExportArgs args,
             string environmentName,
@@ -1051,6 +1109,7 @@ public sealed class ProgramEntryPointTests
         {
             EnvironmentName = environmentName;
             StartupToken = cancellationToken;
+            WorkingDirectoryDuringStart = Directory.GetCurrentDirectory();
             return Task.FromResult(host);
         }
     }

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/packages.lock.json
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/packages.lock.json
@@ -56,6 +56,12 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
+      "YamlDotNet": {
+        "type": "Direct",
+        "requested": "[17.0.1, )",
+        "resolved": "17.0.1",
+        "contentHash": "qVir5fehR/W5nTJyoJUibypETXaW4iRAF9cQa0FQIC9TJ3VC0qDOwm4o/RxANewj8KzPF8WMF2abBfUgi6LC4w=="
+      },
       "AngleSharp": {
         "type": "Transitive",
         "resolved": "0.17.1",
@@ -404,7 +410,8 @@
         "dependencies": {
           "CliFx": "[2.3.6, )",
           "ForgeTrust.AppSurface.Console": "[0.1.0, )",
-          "ForgeTrust.AppSurface.Docs.Standalone": "[0.1.0, )"
+          "ForgeTrust.AppSurface.Docs.Standalone": "[0.1.0, )",
+          "ForgeTrust.RazorWire.Cli": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.console": {
@@ -478,6 +485,15 @@
         "dependencies": {
           "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
+      },
+      "forgetrust.razorwire.cli": {
+        "type": "Project",
+        "dependencies": {
+          "CliFx": "[2.3.6, )",
+          "ForgeTrust.AppSurface.Console": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )"
         }
       },
       "CliFx": {
@@ -639,12 +655,6 @@
         "dependencies": {
           "TextMateSharp": "2.0.3"
         }
-      },
-      "YamlDotNet": {
-        "type": "CentralTransitive",
-        "requested": "[17.0.1, )",
-        "resolved": "17.0.1",
-        "contentHash": "qVir5fehR/W5nTJyoJUibypETXaW4iRAF9cQa0FQIC9TJ3VC0qDOwm4o/RxANewj8KzPF8WMF2abBfUgi6LC4w=="
       }
     }
   }

--- a/Cli/ForgeTrust.AppSurface.Cli/AppSurfaceCliApp.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/AppSurfaceCliApp.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using CliFx;
 using ForgeTrust.AppSurface.Console;
 using ForgeTrust.AppSurface.Core;
+using ForgeTrust.RazorWire.Cli;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -55,6 +56,10 @@ internal static class AppSurfaceCliApp
         services.AddSingleton(context.EnvironmentProvider);
         services.AddSingleton<IOptionSuggester, LevenshteinOptionSuggester>();
         services.AddSingleton<IRazorDocsHostRunner, RazorDocsStandaloneHostRunner>();
+        services.AddSingleton<IRazorDocsExportRunner, RazorDocsInProcessExportRunner>();
+        services.AddSingleton<IRazorWireStaticExporter, RazorWireExportEngineAdapter>();
+        services.AddSingleton<ExportEngine>();
+        services.AddHttpClient("ExportEngine", client => { client.Timeout = TimeSpan.FromSeconds(60); });
         services.AddLogging(builder =>
         {
             builder.AddConsole();

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -175,6 +175,12 @@ internal sealed class DocsExportCommand : RazorDocsRepositoryCommand, ICommand
             throw new CommandException("The --output value must point to an export directory.");
         }
 
+        var outputPath = Path.GetFullPath(OutputPath);
+        if (File.Exists(outputPath))
+        {
+            throw new CommandException($"The --output value must point to an export directory, but an existing file was found: {outputPath}");
+        }
+
         var hostArgs = BuildHostArgs(defaultEnvironmentName: Environments.Production);
         var seedRoutesPath = string.IsNullOrWhiteSpace(SeedRoutesPath)
             ? null
@@ -190,7 +196,7 @@ internal sealed class DocsExportCommand : RazorDocsRepositoryCommand, ICommand
 
         return new RazorDocsExportArgs(
             hostArgs,
-            Path.GetFullPath(OutputPath),
+            outputPath,
             seedRoutesPath,
             initialSeedRoutes,
             Mode,
@@ -749,7 +755,7 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         }
         catch (OperationCanceledException)
         {
-            ObserveTimedOutStartupTask(startTask, startupTimeoutCts.Transfer());
+            ObserveCanceledStartupTask(startTask, startupTimeoutCts.Transfer());
             throw;
         }
     }
@@ -763,10 +769,24 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
 
     private void ObserveTimedOutStartupTask(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
     {
-        _ = ObserveTimedOutStartupTaskAsync(startTask, startupTimeoutCts);
+        _ = ObserveStartupTaskAsync(
+            startTask,
+            startupTimeoutCts,
+            "RazorDocs export host startup task completed after the startup timeout.");
     }
 
-    private async Task ObserveTimedOutStartupTaskAsync(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
+    private void ObserveCanceledStartupTask(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
+    {
+        _ = ObserveStartupTaskAsync(
+            startTask,
+            startupTimeoutCts,
+            "RazorDocs export host startup task completed after external cancellation.");
+    }
+
+    private async Task ObserveStartupTaskAsync(
+        Task<IHost> startTask,
+        CancellationTokenSource startupTimeoutCts,
+        string lateCompletionMessage)
     {
         using var cts = startupTimeoutCts;
 
@@ -777,7 +797,7 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         }
         catch (Exception ex) when (IsNonFatalException(ex))
         {
-            _logger.LogDebug(ex, "RazorDocs export host startup task completed after the startup timeout.");
+            _logger.LogDebug(ex, lateCompletionMessage);
         }
     }
 

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -714,10 +714,10 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
             return await _hostStarter.BuildAndStartAsync(args, environmentName, cancellationToken);
         }
 
-        var startCts = CreateStartupTimeout(startupTimeout.Value, cancellationToken);
-        CancellationTokenSource? startupTimeoutCts = startCts;
+        using var startupTimeoutCts = CreateStartupTimeout(startupTimeout.Value, cancellationToken);
+        var startupToken = startupTimeoutCts.Token;
         var startTask = Task.Run(
-            () => _hostStarter.BuildAndStartAsync(args, environmentName, startCts.Token),
+            () => _hostStarter.BuildAndStartAsync(args, environmentName, startupToken),
             CancellationToken.None);
 
         try
@@ -731,9 +731,8 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
                     return await startTask;
                 }
 
-                await startCts.CancelAsync();
-                ObserveTimedOutStartupTask(startTask, startCts);
-                startupTimeoutCts = null;
+                await startupTimeoutCts.CancelAsync();
+                ObserveTimedOutStartupTask(startTask, startupTimeoutCts.Transfer());
                 throw CreateStartupTimeoutException(startupTimeout.Value, innerException: null);
             }
 
@@ -745,21 +744,16 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         }
         catch (OperationCanceledException)
         {
-            ObserveTimedOutStartupTask(startTask, startCts);
-            startupTimeoutCts = null;
+            ObserveTimedOutStartupTask(startTask, startupTimeoutCts.Transfer());
             throw;
-        }
-        finally
-        {
-            startupTimeoutCts?.Dispose();
         }
     }
 
-    private static CancellationTokenSource CreateStartupTimeout(TimeSpan startupTimeout, CancellationToken cancellationToken)
+    private static StartupTimeoutCancellationLease CreateStartupTimeout(TimeSpan startupTimeout, CancellationToken cancellationToken)
     {
         var startupTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         startupTimeoutCts.CancelAfter(startupTimeout);
-        return startupTimeoutCts;
+        return new StartupTimeoutCancellationLease(startupTimeoutCts);
     }
 
     private void ObserveTimedOutStartupTask(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
@@ -769,6 +763,8 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
 
     private async Task ObserveTimedOutStartupTaskAsync(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
     {
+        using var cts = startupTimeoutCts;
+
         try
         {
             var startedHost = await startTask.ConfigureAwait(false);
@@ -777,10 +773,6 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         catch (Exception ex) when (IsNonFatalException(ex))
         {
             _logger.LogDebug(ex, "RazorDocs export host startup task completed after the startup timeout.");
-        }
-        finally
-        {
-            startupTimeoutCts.Dispose();
         }
     }
 
@@ -814,6 +806,36 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
             and not CannotUnloadAppDomainException
             and not InvalidProgramException
             and not ThreadAbortException;
+    }
+
+    private sealed class StartupTimeoutCancellationLease : IDisposable
+    {
+        private CancellationTokenSource? _source;
+
+        public StartupTimeoutCancellationLease(CancellationTokenSource source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            _source = source;
+        }
+
+        public CancellationToken Token => (_source ?? throw new ObjectDisposedException(nameof(StartupTimeoutCancellationLease))).Token;
+
+        public Task CancelAsync()
+        {
+            return (_source ?? throw new ObjectDisposedException(nameof(StartupTimeoutCancellationLease))).CancelAsync();
+        }
+
+        public CancellationTokenSource Transfer()
+        {
+            var source = _source ?? throw new ObjectDisposedException(nameof(StartupTimeoutCancellationLease));
+            _source = null;
+            return source;
+        }
+
+        public void Dispose()
+        {
+            _source?.Dispose();
+        }
     }
 
 }

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using CliFx;
@@ -609,6 +608,7 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
 {
     private readonly ILogger<RazorDocsInProcessExportRunner> _logger;
     private readonly IRazorWireStaticExporter _exporter;
+    private readonly IRazorDocsExportHostStarter _hostStarter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RazorDocsInProcessExportRunner"/> class.
@@ -618,12 +618,22 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
     public RazorDocsInProcessExportRunner(
         ILogger<RazorDocsInProcessExportRunner> logger,
         IRazorWireStaticExporter exporter)
+        : this(logger, exporter, new RazorDocsStandaloneExportHostStarter())
+    {
+    }
+
+    internal RazorDocsInProcessExportRunner(
+        ILogger<RazorDocsInProcessExportRunner> logger,
+        IRazorWireStaticExporter exporter,
+        IRazorDocsExportHostStarter hostStarter)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(exporter);
+        ArgumentNullException.ThrowIfNull(hostStarter);
 
         _logger = logger;
         _exporter = exporter;
+        _hostStarter = hostStarter;
     }
 
     /// <inheritdoc />
@@ -632,33 +642,11 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         cancellationToken.ThrowIfCancellationRequested();
 
         var environmentName = args.HostArgs.EnvironmentName ?? Environments.Production;
-        var stopwatch = Stopwatch.StartNew();
-        using var startupTimeout = CreateStartupTimeout(args.HostArgs.StartupTimeout, cancellationToken);
-        var startupToken = startupTimeout?.Token ?? cancellationToken;
         IHost? host = null;
-        var startupCompleted = false;
 
         try
         {
-            var builder = RazorDocsStandaloneHost.CreateBuilder(
-                args.HostArgs.Args,
-                new FixedEnvironmentProvider(environmentName),
-                options => RazorDocsCliHost.ConfigurePackagedToolHost(options, args.HostArgs.StartupTimeout));
-
-            builder.UseContentRoot(args.HostArgs.RepositoryRoot);
-            builder.ConfigureWebHost(webHost =>
-            {
-                webHost.UseEnvironment(environmentName);
-                webHost.UseUrls(args.RequestedBaseUrl);
-            });
-
-            ThrowIfStartupTimeoutElapsed(args.HostArgs.StartupTimeout, stopwatch);
-            host = builder.Build();
-            ThrowIfStartupTimeoutElapsed(args.HostArgs.StartupTimeout, stopwatch);
-
-            await host.StartAsync(startupToken);
-            ThrowIfStartupTimeoutElapsed(args.HostArgs.StartupTimeout, stopwatch);
-            startupCompleted = true;
+            host = await BuildAndStartHostWithTimeoutAsync(args, environmentName, cancellationToken);
 
             var baseUrl = ResolveBoundBaseUrl(host);
             _logger.LogInformation("RazorDocs export host started at {BaseUrl}.", baseUrl);
@@ -672,13 +660,8 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
 
             await _exporter.ExportAsync(context, cancellationToken);
         }
-        catch (OperationCanceledException ex) when (!startupCompleted && !cancellationToken.IsCancellationRequested && args.HostArgs.StartupTimeout is not null)
-        {
-            throw CreateStartupTimeoutException(args.HostArgs.StartupTimeout.Value, ex);
-        }
         finally
         {
-            stopwatch.Stop();
             if (host is not null)
             {
                 await StopAndDisposeHostAsync(host);
@@ -720,23 +703,84 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         return uri.GetLeftPart(UriPartial.Authority);
     }
 
-    private static CancellationTokenSource? CreateStartupTimeout(TimeSpan? startupTimeout, CancellationToken cancellationToken)
+    private async Task<IHost> BuildAndStartHostWithTimeoutAsync(
+        RazorDocsExportArgs args,
+        string environmentName,
+        CancellationToken cancellationToken)
     {
+        var startupTimeout = args.HostArgs.StartupTimeout;
         if (startupTimeout is null)
         {
-            return null;
+            return await _hostStarter.BuildAndStartAsync(args, environmentName, cancellationToken);
         }
 
+        var startCts = CreateStartupTimeout(startupTimeout.Value, cancellationToken);
+        CancellationTokenSource? startupTimeoutCts = startCts;
+        var startTask = Task.Run(
+            () => _hostStarter.BuildAndStartAsync(args, environmentName, startCts.Token),
+            CancellationToken.None);
+
+        try
+        {
+            var completedTask = await Task.WhenAny(startTask, Task.Delay(startupTimeout.Value, cancellationToken));
+            if (completedTask != startTask)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (startTask.IsCompleted)
+                {
+                    return await startTask;
+                }
+
+                await startCts.CancelAsync();
+                ObserveTimedOutStartupTask(startTask, startCts);
+                startupTimeoutCts = null;
+                throw CreateStartupTimeoutException(startupTimeout.Value, innerException: null);
+            }
+
+            return await startTask;
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw CreateStartupTimeoutException(startupTimeout.Value, ex);
+        }
+        catch (OperationCanceledException)
+        {
+            ObserveTimedOutStartupTask(startTask, startCts);
+            startupTimeoutCts = null;
+            throw;
+        }
+        finally
+        {
+            startupTimeoutCts?.Dispose();
+        }
+    }
+
+    private static CancellationTokenSource CreateStartupTimeout(TimeSpan startupTimeout, CancellationToken cancellationToken)
+    {
         var startupTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        startupTimeoutCts.CancelAfter(startupTimeout.Value);
+        startupTimeoutCts.CancelAfter(startupTimeout);
         return startupTimeoutCts;
     }
 
-    private static void ThrowIfStartupTimeoutElapsed(TimeSpan? startupTimeout, Stopwatch stopwatch)
+    private void ObserveTimedOutStartupTask(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
     {
-        if (startupTimeout is not null && stopwatch.Elapsed > startupTimeout.Value)
+        _ = ObserveTimedOutStartupTaskAsync(startTask, startupTimeoutCts);
+    }
+
+    private async Task ObserveTimedOutStartupTaskAsync(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
+    {
+        try
         {
-            throw CreateStartupTimeoutException(startupTimeout.Value, innerException: null);
+            var startedHost = await startTask.ConfigureAwait(false);
+            await StopAndDisposeHostAsync(startedHost).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsNonFatalException(ex))
+        {
+            _logger.LogDebug(ex, "RazorDocs export host startup task completed after the startup timeout.");
+        }
+        finally
+        {
+            startupTimeoutCts.Dispose();
         }
     }
 
@@ -754,17 +798,92 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         {
             await host.StopAsync(CancellationToken.None);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException
+        catch (Exception ex) when (IsNonFatalException(ex))
+        {
+            _logger.LogWarning(ex, "RazorDocs export host failed during shutdown.");
+        }
+    }
+
+    private static bool IsNonFatalException(Exception ex)
+    {
+        return ex is not OutOfMemoryException
             and not StackOverflowException
             and not AccessViolationException
             and not AppDomainUnloadedException
             and not BadImageFormatException
             and not CannotUnloadAppDomainException
             and not InvalidProgramException
-            and not ThreadAbortException)
+            and not ThreadAbortException;
+    }
+
+}
+
+/// <summary>
+/// Builds and starts the in-process AppSurface Docs export host.
+/// </summary>
+internal interface IRazorDocsExportHostStarter
+{
+    /// <summary>
+    /// Builds the standalone docs host, starts Kestrel, and returns the started host for export.
+    /// </summary>
+    /// <param name="args">Resolved export arguments.</param>
+    /// <param name="environmentName">Resolved host environment.</param>
+    /// <param name="cancellationToken">Token observed while starting the host.</param>
+    /// <returns>The started host.</returns>
+    Task<IHost> BuildAndStartAsync(
+        RazorDocsExportArgs args,
+        string environmentName,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Production <see cref="IRazorDocsExportHostStarter"/> that uses the RazorDocs standalone host builder.
+/// </summary>
+[ExcludeFromCodeCoverage(
+    Justification = "Production adapter delegates into the real standalone host builder and Kestrel; command and runner tests cover behavior before this boundary.")]
+internal sealed class RazorDocsStandaloneExportHostStarter : IRazorDocsExportHostStarter
+{
+    /// <inheritdoc />
+    public async Task<IHost> BuildAndStartAsync(
+        RazorDocsExportArgs args,
+        string environmentName,
+        CancellationToken cancellationToken)
+    {
+        var builder = RazorDocsStandaloneHost.CreateBuilder(
+            args.HostArgs.Args,
+            new FixedEnvironmentProvider(environmentName),
+            options => RazorDocsCliHost.ConfigurePackagedToolHost(options, args.HostArgs.StartupTimeout));
+
+        builder.UseContentRoot(args.HostArgs.RepositoryRoot);
+        builder.ConfigureWebHost(webHost =>
         {
-            _logger.LogWarning(ex, "RazorDocs export host failed during shutdown.");
+            webHost.UseEnvironment(environmentName);
+            webHost.UseUrls(args.RequestedBaseUrl);
+        });
+
+        var host = builder.Build();
+        try
+        {
+            await host.StartAsync(cancellationToken);
+            return host;
         }
+        catch (Exception ex) when (IsNonFatalException(ex))
+        {
+            host.Dispose();
+            throw;
+        }
+    }
+
+    private static bool IsNonFatalException(Exception ex)
+    {
+        return ex is not OutOfMemoryException
+            and not StackOverflowException
+            and not AccessViolationException
+            and not AppDomainUnloadedException
+            and not BadImageFormatException
+            and not CannotUnloadAppDomainException
+            and not InvalidProgramException
+            and not ThreadAbortException;
     }
 
     private sealed class FixedEnvironmentProvider : IEnvironmentProvider

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -203,6 +203,10 @@ internal sealed class DocsExportCommand : RazorDocsRepositoryCommand, ICommand
             DefaultExportUrl);
     }
 
+    /// <summary>
+    /// Builds the default export seed routes from the resolved RazorDocs routing options.
+    /// </summary>
+    /// <returns>The root route plus the live docs root, with duplicates removed.</returns>
     private IReadOnlyList<string> BuildDefaultSeedRoutes()
     {
         var docsUrlBuilder = new DocsUrlBuilder(new RazorDocsOptions
@@ -471,15 +475,31 @@ internal abstract class RazorDocsRepositoryCommand
             : TimeSpan.FromSeconds(StartupTimeoutSeconds);
     }
 
+    /// <summary>
+    /// Restores the previous process current directory when disposed.
+    /// </summary>
+    /// <remarks>
+    /// The standalone host resolves some relative paths from the current directory, so preview temporarily scopes it to
+    /// the repository root while the host runner executes.
+    /// </remarks>
     protected sealed class CurrentDirectoryScope : IDisposable
     {
         private readonly string _previousDirectory;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurrentDirectoryScope"/> class.
+        /// </summary>
+        /// <param name="previousDirectory">Directory to restore when the scope is disposed.</param>
         private CurrentDirectoryScope(string previousDirectory)
         {
             _previousDirectory = previousDirectory;
         }
 
+        /// <summary>
+        /// Changes the process current directory and returns a scope that restores the previous value.
+        /// </summary>
+        /// <param name="directory">Directory to make current for the scope lifetime.</param>
+        /// <returns>A disposable scope that restores the previous current directory.</returns>
         public static CurrentDirectoryScope ChangeTo(string directory)
         {
             var previousDirectory = Directory.GetCurrentDirectory();
@@ -487,6 +507,9 @@ internal abstract class RazorDocsRepositoryCommand
             return new CurrentDirectoryScope(previousDirectory);
         }
 
+        /// <summary>
+        /// Restores the current directory captured when the scope was created.
+        /// </summary>
         public void Dispose()
         {
             Directory.SetCurrentDirectory(_previousDirectory);
@@ -633,6 +656,12 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RazorDocsInProcessExportRunner"/> class with an explicit host starter.
+    /// </summary>
+    /// <param name="logger">Logger used for host lifecycle diagnostics.</param>
+    /// <param name="exporter">Static exporter invoked after the in-process host starts.</param>
+    /// <param name="hostStarter">Host starter used to build and start the docs application.</param>
     internal RazorDocsInProcessExportRunner(
         ILogger<RazorDocsInProcessExportRunner> logger,
         IRazorWireStaticExporter exporter,
@@ -680,6 +709,12 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         }
     }
 
+    /// <summary>
+    /// Resolves the single bound loopback base URL published by the started export host.
+    /// </summary>
+    /// <param name="host">Started host that exposes Kestrel server addresses.</param>
+    /// <returns>The scheme and authority used by the export crawler.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the host does not publish exactly one valid URL.</exception>
     internal static string ResolveBoundBaseUrl(IHost host)
     {
         ArgumentNullException.ThrowIfNull(host);
@@ -693,6 +728,12 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         return ResolveBoundBaseUrl(addresses);
     }
 
+    /// <summary>
+    /// Resolves the crawler base URL from a Kestrel address collection.
+    /// </summary>
+    /// <param name="addresses">Published server addresses.</param>
+    /// <returns>The absolute URL authority to crawl.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no URL, multiple URLs, or an invalid URL is published.</exception>
     internal static string ResolveBoundBaseUrl(ICollection<string>? addresses)
     {
         if (addresses is null || addresses.Count == 0)
@@ -714,6 +755,14 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         return uri.GetLeftPart(UriPartial.Authority);
     }
 
+    /// <summary>
+    /// Builds and starts the docs host while enforcing the configured startup watchdog.
+    /// </summary>
+    /// <param name="args">Resolved export arguments.</param>
+    /// <param name="environmentName">Environment name applied to the standalone host.</param>
+    /// <param name="cancellationToken">External cancellation token for the export operation.</param>
+    /// <returns>The started host.</returns>
+    /// <exception cref="TimeoutException">Thrown when the host does not start before the startup timeout.</exception>
     private async Task<IHost> BuildAndStartHostWithTimeoutAsync(
         RazorDocsExportArgs args,
         string environmentName,
@@ -760,6 +809,12 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         }
     }
 
+    /// <summary>
+    /// Creates the linked cancellation source used to distinguish startup timeout from external cancellation.
+    /// </summary>
+    /// <param name="startupTimeout">Startup timeout to enforce.</param>
+    /// <param name="cancellationToken">External cancellation token to link.</param>
+    /// <returns>A disposable lease for the linked startup cancellation source.</returns>
     private static StartupTimeoutCancellationLease CreateStartupTimeout(TimeSpan startupTimeout, CancellationToken cancellationToken)
     {
         var startupTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -767,6 +822,11 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         return new StartupTimeoutCancellationLease(startupTimeoutCts);
     }
 
+    /// <summary>
+    /// Observes a startup task that outlived the configured timeout so late completion can stop or log the host.
+    /// </summary>
+    /// <param name="startTask">Background startup task to observe.</param>
+    /// <param name="startupTimeoutCts">Cancellation source transferred from the timeout branch.</param>
     private void ObserveTimedOutStartupTask(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
     {
         _ = ObserveStartupTaskAsync(
@@ -775,6 +835,11 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
             "RazorDocs export host startup task completed after the startup timeout.");
     }
 
+    /// <summary>
+    /// Observes a startup task that outlived external cancellation so late completion can stop or log the host.
+    /// </summary>
+    /// <param name="startTask">Background startup task to observe.</param>
+    /// <param name="startupTimeoutCts">Cancellation source transferred from the external cancellation branch.</param>
     private void ObserveCanceledStartupTask(Task<IHost> startTask, CancellationTokenSource startupTimeoutCts)
     {
         _ = ObserveStartupTaskAsync(
@@ -783,6 +848,13 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
             "RazorDocs export host startup task completed after external cancellation.");
     }
 
+    /// <summary>
+    /// Awaits a late startup task and disposes the host if startup eventually succeeds.
+    /// </summary>
+    /// <param name="startTask">Background startup task to observe.</param>
+    /// <param name="startupTimeoutCts">Cancellation source owned by the observation task.</param>
+    /// <param name="lateCompletionMessage">Debug message used when late startup faults.</param>
+    /// <returns>A task that completes after the late startup task is observed.</returns>
     private async Task ObserveStartupTaskAsync(
         Task<IHost> startTask,
         CancellationTokenSource startupTimeoutCts,
@@ -801,12 +873,23 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         }
     }
 
+    /// <summary>
+    /// Creates the user-facing timeout exception for a host that failed to start in time.
+    /// </summary>
+    /// <param name="startupTimeout">Timeout that elapsed.</param>
+    /// <param name="innerException">Optional cancellation exception that came from the startup token.</param>
+    /// <returns>The timeout exception reported to command execution.</returns>
     private static TimeoutException CreateStartupTimeoutException(TimeSpan startupTimeout, Exception? innerException)
     {
         var seconds = startupTimeout.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
         return new TimeoutException($"RazorDocs export host did not start within {seconds} seconds.", innerException);
     }
 
+    /// <summary>
+    /// Stops the export host and always disposes it, logging non-fatal shutdown failures.
+    /// </summary>
+    /// <param name="host">Host to stop and dispose.</param>
+    /// <returns>A task that completes after shutdown and disposal.</returns>
     private async Task StopAndDisposeHostAsync(IHost host)
     {
         using var disposableHost = host;
@@ -821,6 +904,11 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         }
     }
 
+    /// <summary>
+    /// Determines whether an exception is safe to catch for cleanup or diagnostic logging.
+    /// </summary>
+    /// <param name="ex">Exception to classify.</param>
+    /// <returns><see langword="true"/> when the exception is non-fatal and can be handled locally.</returns>
     private static bool IsNonFatalException(Exception ex)
     {
         return ex is not OutOfMemoryException
@@ -833,23 +921,41 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
             and not ThreadAbortException;
     }
 
+    /// <summary>
+    /// Owns a startup cancellation source until timeout observation needs to transfer that ownership.
+    /// </summary>
     private sealed class StartupTimeoutCancellationLease : IDisposable
     {
         private CancellationTokenSource? _source;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartupTimeoutCancellationLease"/> class.
+        /// </summary>
+        /// <param name="source">Linked cancellation source to own.</param>
         public StartupTimeoutCancellationLease(CancellationTokenSource source)
         {
             ArgumentNullException.ThrowIfNull(source);
             _source = source;
         }
 
+        /// <summary>
+        /// Gets the token exposed by the owned startup cancellation source.
+        /// </summary>
         public CancellationToken Token => (_source ?? throw new ObjectDisposedException(nameof(StartupTimeoutCancellationLease))).Token;
 
+        /// <summary>
+        /// Requests cancellation of the owned startup cancellation source.
+        /// </summary>
+        /// <returns>A task that completes after cancellation callbacks have run.</returns>
         public Task CancelAsync()
         {
             return (_source ?? throw new ObjectDisposedException(nameof(StartupTimeoutCancellationLease))).CancelAsync();
         }
 
+        /// <summary>
+        /// Transfers cancellation source ownership to a late-startup observer.
+        /// </summary>
+        /// <returns>The owned cancellation source.</returns>
         public CancellationTokenSource Transfer()
         {
             var source = _source ?? throw new ObjectDisposedException(nameof(StartupTimeoutCancellationLease));
@@ -857,6 +963,9 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
             return source;
         }
 
+        /// <summary>
+        /// Disposes the owned cancellation source unless ownership has been transferred.
+        /// </summary>
         public void Dispose()
         {
             _source?.Dispose();
@@ -933,20 +1042,39 @@ internal sealed class RazorDocsStandaloneExportHostStarter : IRazorDocsExportHos
             and not ThreadAbortException;
     }
 
+    /// <summary>
+    /// Provides a fixed environment name to the standalone host builder during export startup.
+    /// </summary>
     private sealed class FixedEnvironmentProvider : IEnvironmentProvider
     {
         private readonly string _environmentName;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedEnvironmentProvider"/> class.
+        /// </summary>
+        /// <param name="environmentName">Environment name exposed to the host builder.</param>
         public FixedEnvironmentProvider(string environmentName)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(environmentName);
             _environmentName = environmentName;
         }
 
+        /// <summary>
+        /// Gets the fixed environment name.
+        /// </summary>
         public string Environment => _environmentName;
 
+        /// <summary>
+        /// Gets a value indicating whether the fixed environment is Development.
+        /// </summary>
         public bool IsDevelopment => string.Equals(_environmentName, Environments.Development, StringComparison.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Gets environment variable values while overriding ASP.NET and .NET environment variables.
+        /// </summary>
+        /// <param name="name">Environment variable name.</param>
+        /// <param name="defaultValue">Fallback value when the variable is not set.</param>
+        /// <returns>The fixed host environment for environment-name variables, otherwise the process value or fallback.</returns>
         public string? GetEnvironmentVariable(string name, string? defaultValue = null)
         {
             if (string.Equals(name, "ASPNETCORE_ENVIRONMENT", StringComparison.OrdinalIgnoreCase)

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -479,10 +479,10 @@ internal abstract class RazorDocsRepositoryCommand
     /// Restores the previous process current directory when disposed.
     /// </summary>
     /// <remarks>
-    /// The standalone host resolves some relative paths from the current directory, so preview temporarily scopes it to
-    /// the repository root while the host runner executes.
+    /// The standalone host resolves some relative paths from the current directory, so preview and export temporarily
+    /// scope it to the repository root while the host runs.
     /// </remarks>
-    protected sealed class CurrentDirectoryScope : IDisposable
+    internal sealed class CurrentDirectoryScope : IDisposable
     {
         private readonly string _previousDirectory;
 
@@ -683,6 +683,7 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
 
         var environmentName = args.HostArgs.EnvironmentName ?? Environments.Production;
         IHost? host = null;
+        using var currentDirectory = RazorDocsRepositoryCommand.CurrentDirectoryScope.ChangeTo(args.HostArgs.RepositoryRoot);
 
         try
         {
@@ -714,7 +715,7 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
     /// </summary>
     /// <param name="host">Started host that exposes Kestrel server addresses.</param>
     /// <returns>The scheme and authority used by the export crawler.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the host does not publish exactly one valid URL.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the host does not publish exactly one valid loopback URL.</exception>
     internal static string ResolveBoundBaseUrl(IHost host)
     {
         ArgumentNullException.ThrowIfNull(host);
@@ -733,7 +734,7 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
     /// </summary>
     /// <param name="addresses">Published server addresses.</param>
     /// <returns>The absolute URL authority to crawl.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when no URL, multiple URLs, or an invalid URL is published.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no URL, multiple URLs, an invalid URL, or a non-loopback URL is published.</exception>
     internal static string ResolveBoundBaseUrl(ICollection<string>? addresses)
     {
         if (addresses is null || addresses.Count == 0)
@@ -750,6 +751,12 @@ internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
         if (!Uri.TryCreate(baseAddress, UriKind.Absolute, out var uri))
         {
             throw new InvalidOperationException($"RazorDocs export host did not publish a valid listening URL. Value: '{baseAddress}'.");
+        }
+
+        if (!uri.IsLoopback)
+        {
+            throw new InvalidOperationException(
+                $"RazorDocs export host published non-loopback URL '{baseAddress}'; expected a single loopback listener.");
         }
 
         return uri.GetLeftPart(UriPartial.Authority);

--- a/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/DocsCommand.cs
@@ -1,11 +1,21 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Exceptions;
 using CliFx.Infrastructure;
+using ForgeTrust.AppSurface.Core;
+using ForgeTrust.AppSurface.Docs;
+using ForgeTrust.AppSurface.Docs.Services;
 using ForgeTrust.AppSurface.Docs.Standalone;
 using ForgeTrust.AppSurface.Web;
+using ForgeTrust.RazorWire.Cli;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.AppSurface.Cli;
@@ -17,7 +27,7 @@ namespace ForgeTrust.AppSurface.Cli;
 /// This command starts the RazorDocs standalone host with CLI-friendly defaults and delegates option validation and
 /// argument construction to <see cref="RazorDocsPreviewCommand"/>.
 /// </remarks>
-[Command("docs", Description = "Preview RazorDocs for a repository.")]
+[Command("docs", Description = "Preview RazorDocs for a repository. Related: docs preview, docs export.")]
 internal sealed class DocsCommand : RazorDocsPreviewCommand
 {
     /// <summary>
@@ -53,13 +63,161 @@ internal sealed class DocsPreviewCommand : RazorDocsPreviewCommand
 }
 
 /// <summary>
+/// Exports RazorDocs for a local repository through the <c>appsurface docs export</c> command.
+/// </summary>
+/// <remarks>
+/// This command owns the AppSurface Docs source-host lifecycle and delegates static crawling, URL rewriting, CDN
+/// validation, and materialization to the RazorWire export engine.
+/// </remarks>
+[Command("docs export", Description = "Export RazorDocs for a repository to static files.")]
+internal sealed class DocsExportCommand : RazorDocsRepositoryCommand, ICommand
+{
+    private const string DefaultExportUrl = "http://127.0.0.1:0";
+    private const string DefaultOutputPath = "dist/docs";
+
+    private readonly ILogger<DocsExportCommand> _logger;
+    private readonly IRazorDocsExportRunner _exportRunner;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocsExportCommand"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used for command diagnostics.</param>
+    /// <param name="exportRunner">Runner that starts the docs host and performs static export.</param>
+    public DocsExportCommand(ILogger<DocsExportCommand> logger, IRazorDocsExportRunner exportRunner)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(exportRunner);
+
+        _logger = logger;
+        _exportRunner = exportRunner;
+    }
+
+    /// <summary>
+    /// Gets the directory where static docs files will be written.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>dist/docs</c> for local use. CI should pass an explicit output path so upload artifacts and export
+    /// output stay tied together.
+    /// </remarks>
+    [CommandOption("output", 'o', Description = "Output directory for exported static docs (default: dist/docs).")]
+    public string OutputPath { get; init; } = DefaultOutputPath;
+
+    /// <summary>
+    /// Gets the export mode used by the underlying RazorWire exporter.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ExportMode.Cdn"/> validates and rewrites output for static CDN hosting. <see cref="ExportMode.Hybrid"/>
+    /// preserves application-style internal URLs for server-backed deployments.
+    /// </remarks>
+    [CommandOption("mode", 'm', Description = "Export mode: cdn (default) or hybrid.")]
+    public ExportMode Mode { get; init; } = ExportMode.Cdn;
+
+    /// <summary>
+    /// Gets an optional path to a seed-route file.
+    /// </summary>
+    /// <remarks>
+    /// This option is long-only because <c>-r</c> is reserved for <c>--repo</c> across AppSurface docs commands. When
+    /// omitted, export derives default seeds from the configured docs routing surface.
+    /// </remarks>
+    [CommandOption("seeds", Description = "Path to a file containing seed routes. Defaults to / and the configured docs root.")]
+    public string? SeedRoutesPath { get; init; }
+
+    /// <summary>
+    /// Executes the command through the CliFx console integration.
+    /// </summary>
+    /// <param name="console">Console abstraction used to register cancellation handling.</param>
+    /// <returns>A value task that completes when export finishes or command validation fails.</returns>
+    [ExcludeFromCodeCoverage]
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        var cancellationToken = console.RegisterCancellationHandler();
+        await ExecuteAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes the command using an explicit cancellation token.
+    /// </summary>
+    /// <param name="cancellationToken">Token observed while starting the host and exporting static output.</param>
+    /// <returns>A value task that completes when export finishes.</returns>
+    internal async ValueTask ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var exportArgs = BuildExportArgs();
+        _logger.LogInformation(
+            "Exporting RazorDocs for {RepositoryRoot} to {OutputPath}.",
+            exportArgs.HostArgs.RepositoryRoot,
+            exportArgs.OutputPath);
+
+        try
+        {
+            await _exportRunner.ExportAsync(exportArgs, cancellationToken);
+        }
+        catch (ExportValidationException ex)
+        {
+            throw new CommandException(ex.Message);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new CommandException(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Translates CLI options into an AppSurface Docs export invocation.
+    /// </summary>
+    /// <returns>The export runner arguments.</returns>
+    /// <remarks>
+    /// Export defaults to Production and binds a loopback ephemeral port internally. It does not expose preview's
+    /// <c>--urls</c> or <c>--port</c> options because humans and CI should not manage export listener ports.
+    /// </remarks>
+    internal RazorDocsExportArgs BuildExportArgs()
+    {
+        if (string.IsNullOrWhiteSpace(OutputPath))
+        {
+            throw new CommandException("The --output value must point to an export directory.");
+        }
+
+        var hostArgs = BuildHostArgs(defaultEnvironmentName: Environments.Production);
+        var seedRoutesPath = string.IsNullOrWhiteSpace(SeedRoutesPath)
+            ? null
+            : Path.GetFullPath(SeedRoutesPath);
+        var initialSeedRoutes = seedRoutesPath is null
+            ? BuildDefaultSeedRoutes()
+            : null;
+
+        return new RazorDocsExportArgs(
+            hostArgs,
+            Path.GetFullPath(OutputPath),
+            seedRoutesPath,
+            initialSeedRoutes,
+            Mode,
+            DefaultExportUrl);
+    }
+
+    private IReadOnlyList<string> BuildDefaultSeedRoutes()
+    {
+        var docsUrlBuilder = new DocsUrlBuilder(new RazorDocsOptions
+        {
+            Routing = new RazorDocsRoutingOptions
+            {
+                RouteRootPath = RouteRootPath,
+                DocsRootPath = DocsRootPath
+            }
+        });
+
+        return new[] { "/", docsUrlBuilder.CurrentDocsRootPath }
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+}
+
+/// <summary>
 /// Shared implementation for RazorDocs preview commands.
 /// </summary>
 /// <remarks>
 /// The base command translates CLI options into RazorDocs standalone host arguments. It keeps command parsing separate
 /// from process hosting so tests can verify validation and argument forwarding without starting Kestrel.
 /// </remarks>
-internal abstract class RazorDocsPreviewCommand : ICommand
+internal abstract class RazorDocsPreviewCommand : RazorDocsRepositoryCommand, ICommand
 {
     private readonly ILogger _logger;
     private readonly IRazorDocsHostRunner _hostRunner;
@@ -82,16 +240,6 @@ internal abstract class RazorDocsPreviewCommand : ICommand
     }
 
     /// <summary>
-    /// Gets the repository root to harvest and preview.
-    /// </summary>
-    /// <remarks>
-    /// Defaults to the current directory. Use this when running the CLI from a parent directory, script workspace, or
-    /// package output folder. The value must resolve to an existing directory.
-    /// </remarks>
-    [CommandOption("repo", 'r', Description = "Repository root to preview (default: current directory).")]
-    public string RepositoryRoot { get; init; } = ".";
-
-    /// <summary>
     /// Gets the explicit URL binding forwarded to the RazorDocs host.
     /// </summary>
     /// <remarks>
@@ -110,57 +258,6 @@ internal abstract class RazorDocsPreviewCommand : ICommand
     /// </remarks>
     [CommandOption("port", 'p', Description = "Port shortcut forwarded to the RazorDocs host.")]
     public int? Port { get; init; }
-
-    /// <summary>
-    /// Gets a value indicating whether startup should fail when every configured RazorDocs harvester fails.
-    /// </summary>
-    /// <remarks>
-    /// Keep this off for exploratory local preview. Enable it in CI or release checks where a completely failed harvest
-    /// should stop the command before the site starts.
-    /// </remarks>
-    [CommandOption("strict", Description = "Fail startup when every configured RazorDocs harvester fails.")]
-    public bool StrictHarvest { get; init; }
-
-    /// <summary>
-    /// Gets the route-family root for RazorDocs version and archive routes.
-    /// </summary>
-    /// <remarks>
-    /// Use this when the docs route family is mounted somewhere other than <c>/docs</c>, for example
-    /// <c>--route-root /reference</c>. Pair it with <see cref="DocsRootPath"/> when the live preview path should differ
-    /// from archive/version routes.
-    /// </remarks>
-    [CommandOption("route-root", Description = "Route-family root for RazorDocs version and archive routes.")]
-    public string? RouteRootPath { get; init; }
-
-    /// <summary>
-    /// Gets the live docs preview root path.
-    /// </summary>
-    /// <remarks>
-    /// Use this to preview current docs under a nested route, for example <c>--route-root /reference --docs-root
-    /// /reference/next</c>. Leave unset to use RazorDocs defaults.
-    /// </remarks>
-    [CommandOption("docs-root", Description = "Live docs preview root path.")]
-    public string? DocsRootPath { get; init; }
-
-    /// <summary>
-    /// Gets the host environment forwarded to the RazorDocs standalone host.
-    /// </summary>
-    /// <remarks>
-    /// Use <c>Development</c> for local preview diagnostics and development defaults. Leave unset to let the host choose
-    /// its normal environment from command-line and process configuration.
-    /// </remarks>
-    [CommandOption("environment", 'e', Description = "Host environment forwarded to the RazorDocs host.")]
-    public string? EnvironmentName { get; init; }
-
-    /// <summary>
-    /// Gets the number of seconds to wait for the web host to start before failing fast.
-    /// </summary>
-    /// <remarks>
-    /// Defaults to 10 seconds. Set to <c>0</c> to disable the startup watchdog. Negative, infinite, and NaN values are
-    /// rejected before the host starts.
-    /// </remarks>
-    [CommandOption("startup-timeout-seconds", Description = "Seconds to wait for the RazorDocs web host to start before failing fast. Use 0 to disable.")]
-    public double StartupTimeoutSeconds { get; init; } = 10;
 
     /// <summary>
     /// Executes the command through the CliFx console integration.
@@ -184,20 +281,100 @@ internal abstract class RazorDocsPreviewCommand : ICommand
     /// </remarks>
     internal async ValueTask ExecuteAsync(CancellationToken cancellationToken)
     {
-        var hostArgs = BuildHostArgs();
+        var hostArgs = BuildHostArgs(Urls, Port, defaultEnvironmentName: null);
         _logger.LogInformation("Starting RazorDocs preview for {RepositoryRoot}.", hostArgs.RepositoryRoot);
         await _hostRunner.RunAsync(hostArgs.Args, hostArgs.StartupTimeout, cancellationToken);
     }
+}
+
+/// <summary>
+/// Shared repository, routing, strict-harvest, environment, and startup-timeout options for AppSurface docs commands.
+/// </summary>
+/// <remarks>
+/// Preview and export share these options so route and source configuration cannot drift. Preview adds listener binding
+/// options, while export keeps listener management internal and adds output/export options instead.
+/// </remarks>
+internal abstract class RazorDocsRepositoryCommand
+{
+    /// <summary>
+    /// Gets the repository root to harvest.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to the current directory. Use this when running the CLI from a parent directory, script workspace, or
+    /// package output folder. The value must resolve to an existing directory.
+    /// </remarks>
+    [CommandOption("repo", 'r', Description = "Repository root to harvest (default: current directory).")]
+    public string RepositoryRoot { get; init; } = ".";
 
     /// <summary>
-    /// Translates CLI options into standalone RazorDocs host arguments.
+    /// Gets a value indicating whether startup should fail when every configured RazorDocs harvester fails.
     /// </summary>
-    /// <returns>The repository root, forwarded host arguments, and startup timeout for the preview run.</returns>
     /// <remarks>
-    /// This method performs command-level validation so users receive <see cref="CommandException"/> errors before the
-    /// web host starts. It is internal so tests can verify the translation contract without opening a listener.
+    /// This is a source-harvest fail-closed gate. Static artifact validation is controlled separately by
+    /// <c>docs export --mode cdn</c>.
     /// </remarks>
-    internal RazorDocsHostArgs BuildHostArgs()
+    [CommandOption("strict", Description = "Fail startup when every configured RazorDocs harvester fails.")]
+    public bool StrictHarvest { get; init; }
+
+    /// <summary>
+    /// Gets the route-family root for RazorDocs version and archive routes.
+    /// </summary>
+    /// <remarks>
+    /// Use this when the docs route family is mounted somewhere other than <c>/docs</c>, for example
+    /// <c>--route-root /reference</c>. Pair it with <see cref="DocsRootPath"/> when the live docs path should differ from
+    /// archive/version routes.
+    /// </remarks>
+    [CommandOption("route-root", Description = "Route-family root for RazorDocs version and archive routes.")]
+    public string? RouteRootPath { get; init; }
+
+    /// <summary>
+    /// Gets the live docs root path.
+    /// </summary>
+    /// <remarks>
+    /// Use this to serve current docs under a nested route, for example <c>--route-root /reference --docs-root
+    /// /reference/next</c>. Leave unset to use RazorDocs defaults.
+    /// </remarks>
+    [CommandOption("docs-root", Description = "Live docs root path.")]
+    public string? DocsRootPath { get; init; }
+
+    /// <summary>
+    /// Gets the host environment forwarded to the RazorDocs standalone host.
+    /// </summary>
+    /// <remarks>
+    /// Preview leaves this unset by default so the host can choose its normal environment. Export defaults it to
+    /// Production before starting the in-process host.
+    /// </remarks>
+    [CommandOption("environment", 'e', Description = "Host environment forwarded to the RazorDocs host.")]
+    public string? EnvironmentName { get; init; }
+
+    /// <summary>
+    /// Gets the number of seconds to wait for the web host to start before failing fast.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to 10 seconds. Set to <c>0</c> to disable the startup watchdog. Negative, infinite, and NaN values are
+    /// rejected before the host starts.
+    /// </remarks>
+    [CommandOption("startup-timeout-seconds", Description = "Seconds to wait for the RazorDocs web host to start before failing fast. Use 0 to disable.")]
+    public double StartupTimeoutSeconds { get; init; } = 10;
+
+    /// <summary>
+    /// Translates shared CLI options into standalone RazorDocs host arguments.
+    /// </summary>
+    /// <param name="defaultEnvironmentName">Environment to use when <see cref="EnvironmentName"/> is blank.</param>
+    /// <returns>The repository root, forwarded host arguments, startup timeout, and resolved environment.</returns>
+    internal RazorDocsHostArgs BuildHostArgs(string? defaultEnvironmentName)
+    {
+        return BuildHostArgs(urls: null, port: null, defaultEnvironmentName);
+    }
+
+    /// <summary>
+    /// Translates shared and preview-only CLI options into standalone RazorDocs host arguments.
+    /// </summary>
+    /// <param name="urls">Optional explicit preview URL binding.</param>
+    /// <param name="port">Optional preview port shortcut.</param>
+    /// <param name="defaultEnvironmentName">Environment to use when <see cref="EnvironmentName"/> is blank.</param>
+    /// <returns>The repository root, forwarded host arguments, startup timeout, and resolved environment.</returns>
+    internal RazorDocsHostArgs BuildHostArgs(string? urls, int? port, string? defaultEnvironmentName)
     {
         if (string.IsNullOrWhiteSpace(RepositoryRoot))
         {
@@ -210,22 +387,23 @@ internal abstract class RazorDocsPreviewCommand : ICommand
             throw new CommandException($"The RazorDocs repository root does not exist: {repositoryRoot}");
         }
 
+        var environmentName = ResolveEnvironmentName(defaultEnvironmentName);
         var args = new List<string>
         {
             "--RazorDocs:Source:RepositoryRoot",
             repositoryRoot
         };
 
-        AddOptional(args, "--urls", Urls);
-        if (Port is not null)
+        AddOptional(args, "--urls", urls);
+        if (port is not null)
         {
-            if (Port is < 1 or > 65535)
+            if (port is < 1 or > 65535)
             {
                 throw new CommandException("The --port value must be between 1 and 65535.");
             }
 
             args.Add("--port");
-            args.Add(Port.Value.ToString(CultureInfo.InvariantCulture));
+            args.Add(port.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         if (StrictHarvest)
@@ -236,9 +414,9 @@ internal abstract class RazorDocsPreviewCommand : ICommand
 
         AddOptional(args, "--RazorDocs:Routing:RouteRootPath", RouteRootPath);
         AddOptional(args, "--RazorDocs:Routing:DocsRootPath", DocsRootPath);
-        AddOptional(args, "--environment", EnvironmentName);
+        AddOptional(args, "--environment", environmentName);
 
-        return new RazorDocsHostArgs(repositoryRoot, args.ToArray(), ResolveStartupTimeout());
+        return new RazorDocsHostArgs(repositoryRoot, args.ToArray(), ResolveStartupTimeout(), environmentName);
     }
 
     private static void AddOptional(List<string> args, string name, string? value)
@@ -250,6 +428,18 @@ internal abstract class RazorDocsPreviewCommand : ICommand
 
         args.Add(name);
         args.Add(value);
+    }
+
+    private string? ResolveEnvironmentName(string? defaultEnvironmentName)
+    {
+        if (!string.IsNullOrWhiteSpace(EnvironmentName))
+        {
+            return EnvironmentName.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(defaultEnvironmentName)
+            ? null
+            : defaultEnvironmentName.Trim();
     }
 
     private TimeSpan? ResolveStartupTimeout()
@@ -277,7 +467,50 @@ internal abstract class RazorDocsPreviewCommand : ICommand
 /// <param name="RepositoryRoot">Absolute repository root that the RazorDocs host should harvest.</param>
 /// <param name="Args">Command-line arguments forwarded to the standalone RazorDocs host.</param>
 /// <param name="StartupTimeout">Startup watchdog timeout, or <see langword="null"/> when disabled.</param>
-internal readonly record struct RazorDocsHostArgs(string RepositoryRoot, string[] Args, TimeSpan? StartupTimeout);
+/// <param name="EnvironmentName">Resolved host environment, or <see langword="null"/> when the host should use its default.</param>
+internal readonly record struct RazorDocsHostArgs(
+    string RepositoryRoot,
+    string[] Args,
+    TimeSpan? StartupTimeout,
+    string? EnvironmentName);
+
+/// <summary>
+/// Describes a one-shot AppSurface Docs static export request.
+/// </summary>
+/// <param name="HostArgs">Standalone RazorDocs host arguments.</param>
+/// <param name="OutputPath">Absolute output directory for exported files.</param>
+/// <param name="SeedRoutesPath">Optional absolute seed-route file path.</param>
+/// <param name="InitialSeedRoutes">Optional in-memory seed routes used when <paramref name="SeedRoutesPath"/> is null.</param>
+/// <param name="Mode">RazorWire static export mode.</param>
+/// <param name="RequestedBaseUrl">Loopback URL passed to Kestrel. The default uses port 0 so the OS chooses a free port.</param>
+internal readonly record struct RazorDocsExportArgs(
+    RazorDocsHostArgs HostArgs,
+    string OutputPath,
+    string? SeedRoutesPath,
+    IReadOnlyList<string>? InitialSeedRoutes,
+    ExportMode Mode,
+    string RequestedBaseUrl);
+
+/// <summary>
+/// Applies shared host options required by packaged AppSurface docs tooling.
+/// </summary>
+internal static class RazorDocsCliHost
+{
+    /// <summary>
+    /// Configures the standalone RazorDocs host shape used by packaged preview and export commands.
+    /// </summary>
+    /// <param name="options">Web startup options to mutate.</param>
+    /// <param name="startupTimeout">Startup watchdog timeout, or <see langword="null"/> when disabled.</param>
+    public static void ConfigurePackagedToolHost(WebOptions options, TimeSpan? startupTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Packaged .NET tools often lack static web asset manifests; RazorWireWebModule and RazorDocs endpoint
+        // fallbacks serve embedded assets instead so global/local tool distributions remain self-contained.
+        options.StaticFiles.EnableStaticWebAssets = false;
+        options.StartupTimeout = startupTimeout;
+    }
+}
 
 /// <summary>
 /// Starts a RazorDocs host for CLI preview commands.
@@ -299,6 +532,34 @@ internal interface IRazorDocsHostRunner
 }
 
 /// <summary>
+/// Starts the AppSurface Docs host and exports it to static files.
+/// </summary>
+internal interface IRazorDocsExportRunner
+{
+    /// <summary>
+    /// Starts the docs host, runs static export, and stops the host.
+    /// </summary>
+    /// <param name="args">Resolved export arguments.</param>
+    /// <param name="cancellationToken">Token observed during host startup and export.</param>
+    /// <returns>A task that completes when export finishes.</returns>
+    Task ExportAsync(RazorDocsExportArgs args, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Adapts the RazorWire static exporter behind a small AppSurface CLI test seam.
+/// </summary>
+internal interface IRazorWireStaticExporter
+{
+    /// <summary>
+    /// Exports the started docs host described by <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">RazorWire export context.</param>
+    /// <param name="cancellationToken">Token observed by the export operation.</param>
+    /// <returns>A task that completes when export finishes.</returns>
+    Task ExportAsync(ExportContext context, CancellationToken cancellationToken);
+}
+
+/// <summary>
 /// Production <see cref="IRazorDocsHostRunner"/> that delegates to the standalone RazorDocs web host.
 /// </summary>
 /// <remarks>
@@ -314,14 +575,218 @@ internal sealed class RazorDocsStandaloneHostRunner : IRazorDocsHostRunner
     public Task RunAsync(string[] args, TimeSpan? startupTimeout, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return RazorDocsStandaloneHost.RunAsync(args, options => ConfigurePackagedToolHost(options, startupTimeout));
+        return RazorDocsStandaloneHost.RunAsync(args, options => RazorDocsCliHost.ConfigurePackagedToolHost(options, startupTimeout));
+    }
+}
+
+/// <summary>
+/// Production export runner that starts the standalone RazorDocs host in-process and exports it over real loopback HTTP.
+/// </summary>
+internal sealed class RazorDocsInProcessExportRunner : IRazorDocsExportRunner
+{
+    private readonly ILogger<RazorDocsInProcessExportRunner> _logger;
+    private readonly IRazorWireStaticExporter _exporter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RazorDocsInProcessExportRunner"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used for host lifecycle diagnostics.</param>
+    /// <param name="exporter">Static exporter invoked after the in-process host starts.</param>
+    public RazorDocsInProcessExportRunner(
+        ILogger<RazorDocsInProcessExportRunner> logger,
+        IRazorWireStaticExporter exporter)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(exporter);
+
+        _logger = logger;
+        _exporter = exporter;
     }
 
-    private static void ConfigurePackagedToolHost(WebOptions options, TimeSpan? startupTimeout)
+    /// <inheritdoc />
+    public async Task ExportAsync(RazorDocsExportArgs args, CancellationToken cancellationToken)
     {
-        // Packaged .NET tools often lack static web asset manifests; RazorWireWebModule and RazorDocs endpoint
-        // fallbacks serve embedded assets instead so global/local tool distributions remain self-contained.
-        options.StaticFiles.EnableStaticWebAssets = false;
-        options.StartupTimeout = startupTimeout;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var environmentName = args.HostArgs.EnvironmentName ?? Environments.Production;
+        var stopwatch = Stopwatch.StartNew();
+        using var startupTimeout = CreateStartupTimeout(args.HostArgs.StartupTimeout, cancellationToken);
+        var startupToken = startupTimeout?.Token ?? cancellationToken;
+        IHost? host = null;
+        var startupCompleted = false;
+
+        try
+        {
+            var builder = RazorDocsStandaloneHost.CreateBuilder(
+                args.HostArgs.Args,
+                new FixedEnvironmentProvider(environmentName),
+                options => RazorDocsCliHost.ConfigurePackagedToolHost(options, args.HostArgs.StartupTimeout));
+
+            builder.UseContentRoot(args.HostArgs.RepositoryRoot);
+            builder.ConfigureWebHost(webHost =>
+            {
+                webHost.UseEnvironment(environmentName);
+                webHost.UseUrls(args.RequestedBaseUrl);
+            });
+
+            ThrowIfStartupTimeoutElapsed(args.HostArgs.StartupTimeout, stopwatch);
+            host = builder.Build();
+            ThrowIfStartupTimeoutElapsed(args.HostArgs.StartupTimeout, stopwatch);
+
+            await host.StartAsync(startupToken);
+            ThrowIfStartupTimeoutElapsed(args.HostArgs.StartupTimeout, stopwatch);
+            startupCompleted = true;
+
+            var baseUrl = ResolveBoundBaseUrl(host);
+            _logger.LogInformation("RazorDocs export host started at {BaseUrl}.", baseUrl);
+
+            var context = new ExportContext(
+                args.OutputPath,
+                args.SeedRoutesPath,
+                args.InitialSeedRoutes,
+                baseUrl,
+                args.Mode);
+
+            await _exporter.ExportAsync(context, cancellationToken);
+        }
+        catch (OperationCanceledException ex) when (!startupCompleted && !cancellationToken.IsCancellationRequested && args.HostArgs.StartupTimeout is not null)
+        {
+            throw CreateStartupTimeoutException(args.HostArgs.StartupTimeout.Value, ex);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            if (host is not null)
+            {
+                await StopAndDisposeHostAsync(host);
+            }
+        }
+    }
+
+    internal static string ResolveBoundBaseUrl(IHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        var addresses = host.Services
+            .GetRequiredService<IServer>()
+            .Features
+            .Get<IServerAddressesFeature>()
+            ?.Addresses;
+
+        return ResolveBoundBaseUrl(addresses);
+    }
+
+    internal static string ResolveBoundBaseUrl(ICollection<string>? addresses)
+    {
+        if (addresses is null || addresses.Count == 0)
+        {
+            throw new InvalidOperationException("RazorDocs export host did not publish a listening URL. No addresses were published.");
+        }
+
+        if (addresses.Count != 1)
+        {
+            throw new InvalidOperationException($"RazorDocs export host published {addresses.Count} listening URLs; expected exactly one. Values: '{string.Join("', '", addresses)}'.");
+        }
+
+        var baseAddress = addresses.Single();
+        if (!Uri.TryCreate(baseAddress, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException($"RazorDocs export host did not publish a valid listening URL. Value: '{baseAddress}'.");
+        }
+
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
+
+    private static CancellationTokenSource? CreateStartupTimeout(TimeSpan? startupTimeout, CancellationToken cancellationToken)
+    {
+        if (startupTimeout is null)
+        {
+            return null;
+        }
+
+        var startupTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        startupTimeoutCts.CancelAfter(startupTimeout.Value);
+        return startupTimeoutCts;
+    }
+
+    private static void ThrowIfStartupTimeoutElapsed(TimeSpan? startupTimeout, Stopwatch stopwatch)
+    {
+        if (startupTimeout is not null && stopwatch.Elapsed > startupTimeout.Value)
+        {
+            throw CreateStartupTimeoutException(startupTimeout.Value, innerException: null);
+        }
+    }
+
+    private static TimeoutException CreateStartupTimeoutException(TimeSpan startupTimeout, Exception? innerException)
+    {
+        var seconds = startupTimeout.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
+        return new TimeoutException($"RazorDocs export host did not start within {seconds} seconds.", innerException);
+    }
+
+    private async Task StopAndDisposeHostAsync(IHost host)
+    {
+        try
+        {
+            await host.StopAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "RazorDocs export host failed during shutdown.");
+        }
+        finally
+        {
+            host.Dispose();
+        }
+    }
+
+    private sealed class FixedEnvironmentProvider : IEnvironmentProvider
+    {
+        private readonly string _environmentName;
+
+        public FixedEnvironmentProvider(string environmentName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(environmentName);
+            _environmentName = environmentName;
+        }
+
+        public string Environment => _environmentName;
+
+        public bool IsDevelopment => string.Equals(_environmentName, Environments.Development, StringComparison.OrdinalIgnoreCase);
+
+        public string? GetEnvironmentVariable(string name, string? defaultValue = null)
+        {
+            if (string.Equals(name, "ASPNETCORE_ENVIRONMENT", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "DOTNET_ENVIRONMENT", StringComparison.OrdinalIgnoreCase))
+            {
+                return _environmentName;
+            }
+
+            var value = System.Environment.GetEnvironmentVariable(name);
+            return value ?? defaultValue;
+        }
+    }
+}
+
+/// <summary>
+/// Production <see cref="IRazorWireStaticExporter"/> that delegates to RazorWire's <see cref="ExportEngine"/>.
+/// </summary>
+internal sealed class RazorWireExportEngineAdapter : IRazorWireStaticExporter
+{
+    private readonly ExportEngine _engine;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RazorWireExportEngineAdapter"/> class.
+    /// </summary>
+    /// <param name="engine">RazorWire export engine.</param>
+    public RazorWireExportEngineAdapter(ExportEngine engine)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        _engine = engine;
+    }
+
+    /// <inheritdoc />
+    public Task ExportAsync(ExportContext context, CancellationToken cancellationToken)
+    {
+        return _engine.RunAsync(context, cancellationToken);
     }
 }

--- a/Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj
+++ b/Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Console\ForgeTrust.AppSurface.Console\ForgeTrust.AppSurface.Console.csproj" />
     <ProjectReference Include="..\..\Web\ForgeTrust.AppSurface.Docs.Standalone\ForgeTrust.AppSurface.Docs.Standalone.csproj" />
+    <ProjectReference Include="..\..\Web\ForgeTrust.RazorWire.Cli\ForgeTrust.RazorWire.Cli.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -2,13 +2,14 @@
 
 The **AppSurface CLI** is the command-line home for repository-level AppSurface workflows. It is packaged as a .NET tool with the command name `appsurface`.
 
-The first public verb is `docs`, which replaces the earlier standalone `razordocs preview --repo .` idea with an AppSurface-owned command:
+The first public verb family is `docs`, which replaces the earlier standalone `razordocs preview --repo .` idea with AppSurface-owned preview and export commands:
 
 ```bash
 appsurface docs --repo . --urls http://127.0.0.1:5189
+appsurface docs export --repo . --output ./dist/docs --mode cdn --strict
 ```
 
-`appsurface docs` runs the same RazorDocs standalone host used by CI and integration tests. It forwards RazorDocs configuration into that host instead of duplicating harvesting, routing, static web asset, or MVC setup in the CLI.
+`appsurface docs` runs the same RazorDocs standalone host used by CI and integration tests. It forwards RazorDocs configuration into that host instead of duplicating harvesting, routing, static web asset, or MVC setup in the CLI. `appsurface docs export` starts that same host in-process, binds an internal loopback listener, and delegates static crawling plus CDN validation to the RazorWire export engine.
 
 ## Commands
 
@@ -33,6 +34,39 @@ Options:
 
 `appsurface docs preview` is an alias for the same behavior, kept so the old deferred shape maps cleanly to the new AppSurface command family.
 
+### `appsurface docs export`
+
+Export RazorDocs for a repository checkout to static files.
+
+```bash
+appsurface docs export --repo . --output ./dist/docs --mode cdn --strict
+```
+
+Options:
+
+- `--repo`, `-r`: Repository root to harvest. Defaults to the current directory.
+- `--output`, `-o`: Output directory for exported static docs. Defaults to `dist/docs`; CI should pass this explicitly.
+- `--mode`, `-m`: Export mode. `cdn` is the default and validates plus rewrites managed URLs for plain static hosts. Use `hybrid` only when the output still sits behind application-aware routing.
+- `--seeds`: Optional path to a seed-route file. This is long-only because `-r` means `--repo` in AppSurface CLI commands.
+- `--strict`: Enables `RazorDocs:Harvest:FailOnFailure=true`, which fails startup when every configured harvester fails. This is separate from `--mode cdn`, which validates the emitted static artifact and preserves `RWEXPORT00x` diagnostics.
+- `--route-root`: Route-family root for version and archive routes.
+- `--docs-root`: Live docs root. When `--seeds` is omitted, export seeds `/` and this resolved docs root, `/docs` by default.
+- `--environment`, `-e`: Host environment forwarded to the RazorDocs host. Defaults to `Production` for export.
+- `--startup-timeout-seconds`: Seconds to wait for the in-process RazorDocs host to start before failing fast. Defaults to `10`; use `0` to disable while investigating intentional pre-bind delays.
+
+Export does not expose `--port` or `--urls`. It binds `http://127.0.0.1:0` internally, resolves the actual Kestrel listener, crawls that URL, then stops the host. Use the generic `razorwire export` command when exporting arbitrary RazorWire apps via `--url`, `--project`, or `--dll`; use `appsurface docs export` when AppSurface owns the RazorDocs repository host.
+
+Migration map for repo-owned AppSurface Docs export:
+
+| Old path | New path |
+| --- | --- |
+| `razorwire export --project Web/ForgeTrust.AppSurface.Docs.Standalone/...` | `appsurface docs export --repo .` |
+| `RazorDocs__Harvest__FailOnFailure=true` | `--strict` |
+| `--mode cdn` | `--mode cdn` |
+| `--seeds <file>` | `--seeds <file>` |
+| `--output <dir>` | `--output <dir>` |
+| `--project`, `--dll`, `--url`, `--app-args`, `--no-build`, `--framework` | remain RazorWire-only for arbitrary app export |
+
 ## Development
 
 Run the tool from source while developing:
@@ -42,3 +76,9 @@ dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http:
 ```
 
 Use `--strict` for CI-like validation when an all-failed harvest should stop the preview before the host begins serving.
+
+Run the export command from source while developing:
+
+```bash
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs export --repo . --output ./dist/docs --mode cdn --strict
+```

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -47,7 +47,7 @@ appsurface docs export --repo . --output ./dist/docs --mode cdn --strict
 Options:
 
 - `--repo`, `-r`: Repository root to harvest. Defaults to the current directory.
-- `--output`, `-o`: Output directory for exported static docs. Defaults to `dist/docs`; CI should pass this explicitly.
+- `--output`, `-o`: Output directory for exported static docs. Defaults to `dist/docs`; existing files are rejected because the exporter writes a directory tree. CI should pass this explicitly.
 - `--mode`, `-m`: Export mode. `cdn` is the default and validates plus rewrites managed URLs for plain static hosts. Use `hybrid` only when the output still sits behind application-aware routing.
 - `--seeds`: Optional path to a seed-route file. This is long-only because `-r` means `--repo` in AppSurface CLI commands.
 - `--strict`: Enables `RazorDocs:Harvest:FailOnFailure=true`, which fails startup when every configured harvester fails. This is separate from `--mode cdn`, which validates the emitted static artifact and preserves `RWEXPORT00x` diagnostics.

--- a/Cli/ForgeTrust.AppSurface.Cli/packages.lock.json
+++ b/Cli/ForgeTrust.AppSurface.Cli/packages.lock.json
@@ -360,6 +360,15 @@
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
         }
       },
+      "forgetrust.razorwire.cli": {
+        "type": "Project",
+        "dependencies": {
+          "CliFx": "[2.3.6, )",
+          "ForgeTrust.AppSurface.Console": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )"
+        }
+      },
       "HtmlSanitizer": {
         "type": "CentralTransitive",
         "requested": "[9.0.892, )",

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This approach aims to:
 
 ### [CLI](./Cli/ForgeTrust.AppSurface.Cli/README.md)
 
-- [**ForgeTrust.AppSurface.Cli**](./Cli/ForgeTrust.AppSurface.Cli/README.md) – Public `appsurface` command-line tool, including the `appsurface docs` RazorDocs preview workflow.
+- [**ForgeTrust.AppSurface.Cli**](./Cli/ForgeTrust.AppSurface.Cli/README.md) – Public `appsurface` command-line tool, including `appsurface docs` preview and `appsurface docs export` static RazorDocs export workflows.
 
 ### [Dependency](./Dependency/README.md)
 

--- a/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs.Standalone/README.md
@@ -14,9 +14,10 @@ For public command-line workflows, use the AppSurface CLI as the public command 
 
 ```bash
 dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs --repo . --urls http://127.0.0.1:5189
+dotnet run --project Cli/ForgeTrust.AppSurface.Cli -- docs export --repo . --output ./dist/docs --mode cdn --strict
 ```
 
-The CLI delegates to this standalone host, so the host remains the source of truth for RazorDocs startup, static web assets, routes, and configuration binding.
+The CLI delegates to this standalone host, so the host remains the source of truth for RazorDocs startup, static web assets, routes, and configuration binding. Preview runs this host until shutdown. Export starts it in-process through `RazorDocsStandaloneHost.CreateBuilder`, binds `http://127.0.0.1:0`, crawls the resolved loopback address with RazorWire export, then stops and disposes the host.
 
 ## Entry Point
 
@@ -33,7 +34,7 @@ Do not duplicate standalone setup in test fixtures. If a scenario needs differen
 `CreateBuilder` is lower level than `RunAsync`: callers that build and start the host themselves should pass `--urls`, `--port`, or configure the web host before `Build()` instead of relying on the executable startup path's development-port fallback.
 The builder pins this standalone assembly as the host entry point identity so in-process callers, including xUnit, resolve the same static web asset manifest as the executable.
 
-The optional `configureOptions` callback is for host-shape seams that must stay on the normal AppSurface Web path. `appsurface docs` uses it to disable static web asset manifest loading for packaged tool runs because RazorDocs and RazorWire runtime assets are embedded in their assemblies. The shared AppSurface Web startup watchdog still applies through `WebOptions.StartupTimeout`, which defaults to 10 seconds and fails fast when the process stalls before Kestrel starts listening.
+The optional `configureOptions` callback is for host-shape seams that must stay on the normal AppSurface Web path. `appsurface docs` and `appsurface docs export` use it to disable static web asset manifest loading for packaged tool runs because RazorDocs and RazorWire runtime assets are embedded in their assemblies. The shared AppSurface Web startup watchdog still applies through `WebOptions.StartupTimeout`, which defaults to 10 seconds and fails fast when the process stalls before Kestrel starts listening. Export also enforces its own startup timeout because callers that build and start the host directly bypass the `RunAsync` watchdog path.
 
 ## Strict Harvest Failure
 
@@ -45,6 +46,14 @@ dotnet run --project Web/ForgeTrust.AppSurface.Docs.Standalone -- --urls http://
 ```
 
 Strict mode fails only when every configured harvester fails, times out, or cancels. Empty docs and partially degraded docs still start. The thrown `RazorDocsHarvestFailedException` uses a redacted summary suitable for CI output; raw exception details and repository paths remain in host logs for operators.
+
+For the public AppSurface CLI export path, prefer the equivalent flag:
+
+```bash
+appsurface docs export --repo . --output ./dist/docs --mode cdn --strict
+```
+
+`--strict` is the harvest fail-closed gate. `--mode cdn` is the static artifact validation gate and preserves RazorWire `RWEXPORT00x` diagnostics when managed URLs cannot become CDN-safe files.
 
 ## Local URL Behavior
 

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsViewsTests.cs
@@ -43,6 +43,7 @@ public class RazorDocsViewsTests
         Assert.Contains("data-rw-search-runtime=\"minisearch\"", layout);
         Assert.DoesNotContain("src=\"~/docs/outline-client.js\"", layout);
         Assert.Contains("window.__razorDocsConfig", layout);
+        Assert.Contains("rel=\"icon\" type=\"image/svg+xml\" href=\"@docsBrandIconUrl\"", layout);
         Assert.Contains("AssetVersioner.BuildVersionedDocsAssetUrl(DocsUrlBuilder, \"search-client.js\")", layout);
         Assert.Contains("AssetVersioner.BuildVersionedDocsAssetUrl(DocsUrlBuilder, \"minisearch.min.js\")", layout);
     }

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsWebModuleRegressionTests.cs
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/RazorDocsWebModuleRegressionTests.cs
@@ -1078,6 +1078,14 @@ public class RazorDocsWebModuleRegressionTests
                 await searchClientResponse.Content.ReadAsStringAsync(),
                 StringComparison.Ordinal);
 
+            using var brandIconResponse = await client.GetAsync($"{PackagedAssetBasePath}/appsurface-docs-icon.svg");
+            Assert.Equal(HttpStatusCode.OK, brandIconResponse.StatusCode);
+            Assert.Equal("image/svg+xml", brandIconResponse.Content.Headers.ContentType?.MediaType);
+            Assert.Contains(
+                "AppSurface layered document mark",
+                await brandIconResponse.Content.ReadAsStringAsync(),
+                StringComparison.Ordinal);
+
             using var packagedSearchCssResponse = await client.GetAsync($"{PackagedAssetBasePath}/search.css");
             Assert.Equal(HttpStatusCode.OK, packagedSearchCssResponse.StatusCode);
             Assert.Equal("text/css", packagedSearchCssResponse.Content.Headers.ContentType?.MediaType);

--- a/Web/ForgeTrust.AppSurface.Docs/ForgeTrust.AppSurface.Docs.csproj
+++ b/Web/ForgeTrust.AppSurface.Docs/ForgeTrust.AppSurface.Docs.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\css\site.gen.css" LogicalName="RazorDocsEmbeddedAssets/css/site.gen.css" />
+    <EmbeddedResource Include="wwwroot\docs\appsurface-docs-icon.svg" LogicalName="RazorDocsEmbeddedAssets/docs/appsurface-docs-icon.svg" />
     <EmbeddedResource Include="wwwroot\docs\minisearch.min.js" LogicalName="RazorDocsEmbeddedAssets/docs/minisearch.min.js" />
     <EmbeddedResource Include="wwwroot\docs\outline-client.js" LogicalName="RazorDocsEmbeddedAssets/docs/outline-client.js" />
     <EmbeddedResource Include="wwwroot\docs\search-client.js" LogicalName="RazorDocsEmbeddedAssets/docs/search-client.js" />

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -20,7 +20,7 @@ appsurface docs export --repo . --output ./dist/docs --mode cdn --strict
 
 `appsurface docs` and `appsurface docs preview` run the standalone host for local inspection. `appsurface docs export` starts that same host in-process, binds an internal `http://127.0.0.1:0` listener, resolves the actual Kestrel address, and exports through RazorWire's static export engine.
 
-Export defaults to `Production`, writes to `dist/docs` when `--output` is omitted, and seeds `/` plus the resolved docs root, `/docs` by default. Pass `--seeds <file>` for deterministic crawl roots in CI. `--seeds` has no short alias because `-r` means `--repo` for AppSurface docs commands.
+Export defaults to `Production`, writes to `dist/docs` when `--output` is omitted, rejects existing files passed to `--output`, and seeds `/` plus the resolved docs root, `/docs` by default. Pass `--seeds <file>` for deterministic crawl roots in CI. `--seeds` has no short alias because `-r` means `--repo` for AppSurface docs commands.
 
 `--strict` and `--mode cdn` check different things. `--strict` fails host startup when every configured harvester fails. `--mode cdn` validates the emitted static artifact and preserves RazorWire `RWEXPORT00x` diagnostics for missing or unrewritable managed URLs.
 

--- a/Web/ForgeTrust.AppSurface.Docs/README.md
+++ b/Web/ForgeTrust.AppSurface.Docs/README.md
@@ -8,6 +8,24 @@ Documentation site generation and hosting for AppSurface web applications.
 
 If you are evaluating RazorDocs for your own repository, start with [Use RazorDocs in your repository](./use-razordocs.md). That page explains the consumer model, host shape, authoring metadata, and adoption checklist before you drill into this package reference.
 
+## Preview and Export Commands
+
+Use the AppSurface CLI when working with this repository's RazorDocs surface:
+
+```bash
+appsurface docs --repo . --port 5189
+appsurface docs preview --repo . --port 5189
+appsurface docs export --repo . --output ./dist/docs --mode cdn --strict
+```
+
+`appsurface docs` and `appsurface docs preview` run the standalone host for local inspection. `appsurface docs export` starts that same host in-process, binds an internal `http://127.0.0.1:0` listener, resolves the actual Kestrel address, and exports through RazorWire's static export engine.
+
+Export defaults to `Production`, writes to `dist/docs` when `--output` is omitted, and seeds `/` plus the resolved docs root, `/docs` by default. Pass `--seeds <file>` for deterministic crawl roots in CI. `--seeds` has no short alias because `-r` means `--repo` for AppSurface docs commands.
+
+`--strict` and `--mode cdn` check different things. `--strict` fails host startup when every configured harvester fails. `--mode cdn` validates the emitted static artifact and preserves RazorWire `RWEXPORT00x` diagnostics for missing or unrewritable managed URLs.
+
+Use `razorwire export` for arbitrary RazorWire applications that need `--url`, `--project`, or `--dll`. Use `appsurface docs export` when AppSurface owns the RazorDocs repository host.
+
 ## What It Provides
 
 - `RazorDocsWebModule` for wiring the docs UI into an AppSurface web host

--- a/Web/ForgeTrust.AppSurface.Docs/RazorDocsWebModule.cs
+++ b/Web/ForgeTrust.AppSurface.Docs/RazorDocsWebModule.cs
@@ -248,7 +248,9 @@ public class RazorDocsWebModule : IAppSurfaceWebModule
     /// root, adds the archive surface below that route root, and serves preview-surface assets from either the live web
     /// root or the packaged Razor Class Library depending on whether published-tree mounts can shadow the stable docs root.
     /// Asset routes are built with <see cref="DocsUrlBuilder.BuildAssetUrl(string)"/> for <c>search.css</c>,
-    /// <c>minisearch.min.js</c>, <c>search-client.js</c>, and the page-local <c>outline-client.js</c>. Preview hosts can
+    /// <c>minisearch.min.js</c>, <c>search-client.js</c>, and the page-local <c>outline-client.js</c>. The packaged
+    /// AppSurface brand icon is also served from an embedded fallback so static exports that disable static-web-assets
+    /// can still validate the layout image. Preview hosts can
     /// serve those files directly from the web root; otherwise the current-surface URLs redirect through
     /// <see cref="ResolveLegacySearchAssetBasePath"/> to the packaged RazorDocs assets. Legacy asset redirects preserve
     /// only the request query string, while the redirect path itself is constrained to an app-relative URL so
@@ -283,6 +285,10 @@ public class RazorDocsWebModule : IAppSurfaceWebModule
         var docsUrlBuilder = endpoints.ServiceProvider.GetService(typeof(DocsUrlBuilder)) as DocsUrlBuilder
                              ?? new DocsUrlBuilder(docsOptions);
         MapEmbeddedAssetFallback(endpoints, RazorDocsPackagedStylesheetPath, "css/site.gen.css");
+        MapEmbeddedAssetFallback(
+            endpoints,
+            $"{RazorDocsStaticAssetBasePath}/appsurface-docs-icon.svg",
+            "docs/appsurface-docs-icon.svg");
         MapEmbeddedAssetFallback(endpoints, $"{RazorDocsStaticAssetBasePath}/search.css", "docs/search.css");
         MapEmbeddedAssetFallback(endpoints, $"{RazorDocsStaticAssetBasePath}/minisearch.min.js", "docs/minisearch.min.js");
         MapEmbeddedAssetFallback(endpoints, $"{RazorDocsStaticAssetBasePath}/search-client.js", "docs/search-client.js");

--- a/Web/ForgeTrust.AppSurface.Docs/Views/Shared/_Layout.cshtml
+++ b/Web/ForgeTrust.AppSurface.Docs/Views/Shared/_Layout.cshtml
@@ -31,6 +31,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>@ViewData["Title"] - AppSurface</title>
+    <link rel="icon" type="image/svg+xml" href="@docsBrandIconUrl" />
     <link rel="stylesheet" href="@stylesheetPath" asp-append-version="false" />
     <link rel="stylesheet" href="@docsSearchStylesheetUrl" asp-append-version="false" />
     @if (isSearchPage)

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/ExportEngineTests.cs
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/ExportEngineTests.cs
@@ -295,6 +295,68 @@ public class ExportEngineTests
     }
 
     [Fact]
+    public async Task RunAsync_Should_Use_InMemory_Seed_Routes_When_No_Seed_File_Is_Provided()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var handler = new DocsSeedHandler();
+            var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000") };
+            A.CallTo(() => _httpClientFactory.CreateClient("ExportEngine")).Returns(client);
+
+            var context = new ExportContext(
+                tempDir,
+                seedRoutesPath: null,
+                initialSeedRoutes: ["/docs"],
+                baseUrl: "http://localhost:5000");
+            await _sut.RunAsync(context);
+
+            Assert.True(File.Exists(Path.Combine(tempDir, "docs.html")));
+            Assert.Contains("/docs", handler.RequestPaths);
+            Assert.DoesNotContain("/", context.RouteOutcomes.Keys);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_Should_Fallback_To_Root_When_InMemory_Seed_Routes_Have_No_Valid_Routes()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var handler = new TestHttpMessageHandler();
+            var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000") };
+            A.CallTo(() => _httpClientFactory.CreateClient("ExportEngine")).Returns(client);
+
+            var context = new ExportContext(
+                tempDir,
+                seedRoutesPath: null,
+                initialSeedRoutes: ["mailto:test@example.com", "javascript:void(0)", ""],
+                baseUrl: "http://localhost:5000");
+            await _sut.RunAsync(context);
+
+            Assert.True(File.Exists(Path.Combine(tempDir, "index.html")));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task RunAsync_Should_Normalize_Absolute_Seed_Urls_Against_BaseUrl_PathBase()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -1496,6 +1558,21 @@ public class ExportEngineTests
 
             return path == "/app/docs"
                 ? Html("<html><body><h1>Path base docs</h1></body></html>")
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class DocsSeedHandler : HttpMessageHandler
+    {
+        public List<string> RequestPaths { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.AbsolutePath ?? "/";
+            RequestPaths.Add(path);
+
+            return path == "/docs"
+                ? Html("<html><body><h1>Docs</h1></body></html>")
                 : Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
         }
     }

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/ExportEngineTests.cs
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/ExportEngineTests.cs
@@ -219,7 +219,7 @@ public class ExportEngineTests
     [Fact]
     public async Task ExtractAssets_Should_Extract_Turbo_Frame_Dependencies_During_Run()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tempDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -246,7 +246,7 @@ public class ExportEngineTests
     [Fact]
     public async Task RunAsync_Should_Throw_When_Seed_File_Is_Missing()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tempDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDir);
         try
         {
@@ -313,7 +313,7 @@ public class ExportEngineTests
                 baseUrl: "http://localhost:5000");
             await _sut.RunAsync(context);
 
-            Assert.True(File.Exists(Path.Combine(tempDir, "docs.html")));
+            Assert.True(File.Exists(Path.Join(tempDir, "docs.html")));
             Assert.Contains("/docs", handler.RequestPaths);
             Assert.DoesNotContain("/", context.RouteOutcomes.Keys);
         }
@@ -329,7 +329,7 @@ public class ExportEngineTests
     [Fact]
     public async Task RunAsync_Should_Fallback_To_Root_When_InMemory_Seed_Routes_Have_No_Valid_Routes()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tempDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -345,7 +345,7 @@ public class ExportEngineTests
                 baseUrl: "http://localhost:5000");
             await _sut.RunAsync(context);
 
-            Assert.True(File.Exists(Path.Combine(tempDir, "index.html")));
+            Assert.True(File.Exists(Path.Join(tempDir, "index.html")));
         }
         finally
         {

--- a/Web/ForgeTrust.RazorWire.Cli/ExportContext.cs
+++ b/Web/ForgeTrust.RazorWire.Cli/ExportContext.cs
@@ -13,7 +13,21 @@ public class ExportContext
     /// <summary>
     /// Gets the optional path to a seed routes file.
     /// </summary>
+    /// <remarks>
+    /// When this path is set, file-based seeds take precedence over <see cref="InitialSeedRoutes"/> so existing CLI
+    /// callers keep their explicit seed-file behavior.
+    /// </remarks>
     public string? SeedRoutesPath { get; }
+
+    /// <summary>
+    /// Gets optional in-memory seed routes used when <see cref="SeedRoutesPath"/> is not configured.
+    /// </summary>
+    /// <remarks>
+    /// Hosts that already know their default routes can pass them directly instead of writing a temporary seed file. Values
+    /// are validated and normalized by the export engine using the same rules as file-based seeds. When no valid in-memory
+    /// seed remains, the engine falls back to the root route (<c>/</c>).
+    /// </remarks>
+    public IReadOnlyList<string> InitialSeedRoutes { get; }
 
     /// <summary>
     /// Gets the base URL of the source application being exported.
@@ -97,9 +111,39 @@ public class ExportContext
         string? seedRoutesPath,
         string baseUrl,
         ExportMode mode = ExportMode.Cdn)
+        : this(outputPath, seedRoutesPath, initialSeedRoutes: null, baseUrl, mode)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ExportContext"/> with the specified configuration and in-memory seed
+    /// routes.
+    /// </summary>
+    /// <param name="outputPath">The target directory for export.</param>
+    /// <param name="seedRoutesPath">
+    /// The path to initial seed routes, if any. When provided, this file is used instead of
+    /// <paramref name="initialSeedRoutes"/>.
+    /// </param>
+    /// <param name="initialSeedRoutes">Optional in-memory initial seed routes used when <paramref name="seedRoutesPath"/> is null or blank.</param>
+    /// <param name="baseUrl">The base URL of the site to export.</param>
+    /// <param name="mode">
+    /// The export mode. <see cref="ExportMode.Cdn"/> is the default and validates plus rewrites exporter-managed URLs for static
+    /// hosting. Use <see cref="ExportMode.Hybrid"/> when the exported output will still be served by application-aware routing.
+    /// </param>
+    /// <remarks>
+    /// This overload is for hosts that can derive seed routes directly from their own routing options. The engine applies
+    /// the same normalization and fallback rules to in-memory seeds that it applies to seed-file lines.
+    /// </remarks>
+    public ExportContext(
+        string outputPath,
+        string? seedRoutesPath,
+        IEnumerable<string>? initialSeedRoutes,
+        string baseUrl,
+        ExportMode mode = ExportMode.Cdn)
     {
         OutputPath = outputPath;
         SeedRoutesPath = seedRoutesPath;
+        InitialSeedRoutes = initialSeedRoutes?.ToArray() ?? [];
         BaseUrl = baseUrl.TrimEnd('/');
         Mode = mode;
     }

--- a/Web/ForgeTrust.RazorWire.Cli/ExportEngine.cs
+++ b/Web/ForgeTrust.RazorWire.Cli/ExportEngine.cs
@@ -301,6 +301,12 @@ public class ExportEngine
         EnqueueRoute(context, "/");
     }
 
+    /// <summary>
+    /// Validates, normalizes, and enqueues seed routes from a file or in-memory route collection.
+    /// </summary>
+    /// <param name="context">Export context whose queue receives valid normalized routes.</param>
+    /// <param name="seeds">Raw seed route values to validate.</param>
+    /// <param name="cancellationToken">Token observed between seed values.</param>
     private void QueueSeedRoutes(
         ExportContext context,
         IEnumerable<string> seeds,

--- a/Web/ForgeTrust.RazorWire.Cli/ExportEngine.cs
+++ b/Web/ForgeTrust.RazorWire.Cli/ExportEngine.cs
@@ -112,7 +112,7 @@ public class ExportEngine
     /// <param name="context">Export configuration and runtime state including base URL, output path, queue, and visited set.</param>
     /// <param name="cancellationToken">Token to observe for cooperative cancellation of the crawl and export operations.</param>
     /// <remarks>
-    /// If <see cref="ExportContext.SeedRoutesPath"/> is provided, the file is read and each line is validated and normalized to a root-relative route; invalid seeds are logged. If the seed file exists but yields no valid routes, the root path ("/") is enqueued. If no seed file is provided, the root path is enqueued. Before crawl processing begins, the engine probes AppSurface's reserved conventional 404 route and stages <c>404.html</c> when the route returns a successful HTML response. That reserved-route probe is best-effort only: failures are logged, do not abort the crawl, and do not prevent queued seed routes from being processed. Once staged, the <c>404.html</c> body participates in the same CDN validation and reference rewriting as other HTML artifacts.
+    /// If <see cref="ExportContext.SeedRoutesPath"/> is provided, the file is read and each line is validated and normalized to a root-relative route; invalid seeds are logged. If the seed file exists but yields no valid routes, the root path ("/") is enqueued. If no seed file is provided, <see cref="ExportContext.InitialSeedRoutes"/> is used when present; invalid in-memory seeds are logged and an all-invalid set also falls back to the root path. If neither source is provided, the root path is enqueued. Before crawl processing begins, the engine probes AppSurface's reserved conventional 404 route and stages <c>404.html</c> when the route returns a successful HTML response. That reserved-route probe is best-effort only: failures are logged, do not abort the crawl, and do not prevent queued seed routes from being processed. Once staged, the <c>404.html</c> body participates in the same CDN validation and reference rewriting as other HTML artifacts.
     ///
     /// Export then runs as a three-stage pipeline:
     ///
@@ -272,22 +272,7 @@ public class ExportEngine
 
             var seeds = await File.ReadAllLinesAsync(context.SeedRoutesPath, cancellationToken);
 
-            foreach (var seed in seeds)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var added = false;
-                if (TryGetNormalizedSeedRoute(seed, context, out var normalized))
-                {
-                    added = true;
-                    EnqueueRoute(context, normalized);
-                }
-
-                if (!added)
-                {
-                    _logger.LogWarning("Invalid seed route: {SeedRoute}", seed);
-                }
-            }
+            QueueSeedRoutes(context, seeds, cancellationToken);
 
             if (context.Queue.Count == 0)
             {
@@ -299,7 +284,44 @@ public class ExportEngine
             return;
         }
 
+        if (context.InitialSeedRoutes.Count > 0)
+        {
+            QueueSeedRoutes(context, context.InitialSeedRoutes, cancellationToken);
+
+            if (context.Queue.Count == 0)
+            {
+                _logger.LogWarning(
+                    "Initial seed routes were provided but no valid routes were found. Falling back to default root path.");
+                EnqueueRoute(context, "/");
+            }
+
+            return;
+        }
+
         EnqueueRoute(context, "/");
+    }
+
+    private void QueueSeedRoutes(
+        ExportContext context,
+        IEnumerable<string> seeds,
+        CancellationToken cancellationToken)
+    {
+        foreach (var seed in seeds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var added = false;
+            if (TryGetNormalizedSeedRoute(seed, context, out var normalized))
+            {
+                added = true;
+                EnqueueRoute(context, normalized);
+            }
+
+            if (!added)
+            {
+                _logger.LogWarning("Invalid seed route: {SeedRoute}", seed);
+            }
+        }
     }
 
     private async Task MaterializeTextRoutesAsync(ExportContext context, CancellationToken cancellationToken)

--- a/Web/ForgeTrust.RazorWire.Cli/README.md
+++ b/Web/ForgeTrust.RazorWire.Cli/README.md
@@ -123,12 +123,15 @@ For both `--project` and `--dll`:
 
 When the target app hosts RazorDocs:
 
+- Use `appsurface docs export --repo .` for AppSurface's own repository docs surface. That command starts the AppSurface Docs standalone host in-process, uses the same packaged static-asset fallbacks as preview, derives default seeds from RazorDocs routing, and keeps `-r` reserved for `--repo`.
 - Export the live unreleased preview surface from its configured live docs root, such as `/docs` when versioning is off, `/docs/next` when versioning is on with defaults, or `/foo/bar/next` when the host sets `RazorDocs:Routing:RouteRootPath` to `/foo/bar`.
 - Export exact published release trees as standalone static subtrees that already contain their own `index.html`, `search.html`, `search-index.json`, `search.css`, `search-client.js`, `minisearch.min.js`, section routes, and detail pages.
 - Treat those exact release trees as immutable publish artifacts. The RazorDocs runtime mounts them later under `{RouteRootPath}/v/{version}` and may also mount the recommended one at `{RouteRootPath}`.
 - The exporter recognizes custom-root RazorDocs pages by their RazorDocs client configuration or `doc-content` frame, not just by a `/docs` URL prefix. This keeps static partial generation working for mounted roots such as `/foo/bar/next`.
 - Use `--seeds` when you want deterministic seeds for docs-specific surfaces instead of relying only on crawl discovery.
 - For release publishing, set `RazorDocs__Harvest__FailOnFailure=true` in the parent environment before `razorwire export --project` or `razorwire export --dll`. The launched target app inherits that setting, fails before listening when aggregate harvest health is `Failed`, and the export command surfaces the target app's startup output. The strict exception summary is redacted, but ordinary target host logs may still contain operator diagnostics such as repository paths or raw exception messages.
+
+Keep `razorwire export` for arbitrary RazorWire apps where the CLI must launch a `--project`, launch a `--dll`, or crawl a pre-running `--url`. Use `appsurface docs export` when the AppSurface CLI owns the RazorDocs repository host and should avoid the generic child-process startup path.
 
 **Example:**
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -38,7 +38,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 ### Console and CLI polish
 
 - AppSurface console apps can now opt into a command-first output contract so public CLI help and validation flows stay quiet instead of printing Generic Host lifecycle chatter.
-- AppSurface now plans two public CLI tools: `appsurface` for repository-level AppSurface workflows, starting with `appsurface docs` for RazorDocs preview, and `razorwire` for RazorWire-specific export workflows.
+- AppSurface now plans two public CLI tools: `appsurface` for repository-level AppSurface workflows, starting with `appsurface docs` for RazorDocs preview and `appsurface docs export` for repo-owned RazorDocs static export, and `razorwire` for RazorWire-specific export workflows.
 - RazorWire CLI now uses that contract for `--help`, `export --help`, invalid option output, and missing-source validation while still preserving command-owned export progress logs.
 - RazorWire CLI now names export seed-route files with `-r|--seeds`, matching the seed terminology used throughout the exporter and docs.
 - The shared console startup seam now exposes `ConsoleOptions` and `ConsoleOutputMode`, so future public AppSurface CLIs can adopt the same behavior without forking startup logic.
@@ -124,6 +124,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorDocs generated C# API references can now render per-symbol source links for documented types, methods, properties, and enums that point at the exact source file and line, with immutable refs available when hosts want links pinned to the code version used to build the docs.
 - The primary RazorDocs Pages deployment now configures commit-pinned symbol source links, so generated C# API `Source` chips resolve to the exact file and line from the CI build revision.
 - Pull requests now run the RazorDocs CDN static export during PR validation, while Pages artifact upload and deployment remain limited to `main`, so broken managed links are caught before the public docs pipeline reaches deployment.
+- The primary RazorDocs Pages export now uses `appsurface docs export --repo .` instead of the generic `razorwire export --project` child-process path, so CI exercises the public AppSurface docs command, in-process standalone host startup, strict harvest failure, and CDN validation together.
 - RazorWire CDN export now ignores authoring-only source-navigation anchors, including repo-relative links to common source and project files and app-rendered anchors marked with `data-rw-export-ignore`.
 - RazorDocs snapshot caching is now configurable with `RazorDocs:CacheExpirationMinutes`, so development hosts can shorten reuse while production hosts can choose a longer docs and search-index cache lifetime.
 - Shared RazorDocs badges, metadata chips, provenance strips, and trust bars now live in the shared package stylesheet while `search.css` stays focused on search-specific UI.


### PR DESCRIPTION
## Summary

- Adds `appsurface docs export` while keeping `docs` and `docs preview` as local preview commands.
- Wires AppSurface docs export through an in-process RazorDocs host with default `/` and `/docs` seeds.
- Updates GitHub Pages publishing to use the AppSurface CLI export command.
- Adds packaged docs icon fallback coverage and a QA favicon fix.

Fixes #269.

## Validation

- `dotnet format ForgeTrust.AppSurface.slnx --no-restore`
- `dotnet test Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj --no-restore`
- `dotnet test Web/ForgeTrust.RazorWire.Cli.Tests/ForgeTrust.RazorWire.Cli.Tests.csproj --no-restore`
- `dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --no-restore`
- `appsurface docs export --repo . --output /private/tmp/appsurface-docs-export-qa --mode cdn --strict`
- Browser QA over preview and static export, including search and exported assets.
