### PR TITLE
refactor(core): migrate process utils to CliWrap

### DIFF
--- a/Aspire/ForgeTrust.AppSurface.Aspire.Tests/packages.lock.json
+++ b/Aspire/ForgeTrust.AppSurface.Aspire.Tests/packages.lock.json
@@ -577,19 +577,20 @@
         "type": "Project",
         "dependencies": {
           "Aspire.Hosting": "[9.4.2, )",
-          "ForgeTrust.AppSurface.Console": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Console": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.console": {
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -630,6 +631,12 @@
         "requested": "[2.3.6, )",
         "resolved": "2.3.6",
         "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "KubernetesClient": {
         "type": "CentralTransitive",

--- a/Aspire/ForgeTrust.AppSurface.Aspire/packages.lock.json
+++ b/Aspire/ForgeTrust.AppSurface.Aspire/packages.lock.json
@@ -484,12 +484,13 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -499,6 +500,12 @@
         "requested": "[2.3.6, )",
         "resolved": "2.3.6",
         "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "KubernetesClient": {
         "type": "CentralTransitive",

--- a/Caching/ForgeTrust.AppSurface.Caching.Tests/packages.lock.json
+++ b/Caching/ForgeTrust.AppSurface.Caching.Tests/packages.lock.json
@@ -375,16 +375,23 @@
       "forgetrust.appsurface.caching": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Caching.Memory": "[9.0.6, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",

--- a/Caching/ForgeTrust.AppSurface.Caching/packages.lock.json
+++ b/Caching/ForgeTrust.AppSurface.Caching/packages.lock.json
@@ -259,9 +259,16 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/packages.lock.json
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/packages.lock.json
@@ -417,6 +417,7 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -485,6 +486,12 @@
         "requested": "[2.3.6, )",
         "resolved": "2.3.6",
         "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "HtmlSanitizer": {
         "type": "CentralTransitive",

--- a/Cli/ForgeTrust.AppSurface.Cli/packages.lock.json
+++ b/Cli/ForgeTrust.AppSurface.Cli/packages.lock.json
@@ -297,6 +297,7 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -359,6 +360,12 @@
           "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "HtmlSanitizer": {
         "type": "CentralTransitive",

--- a/Config/ForgeTrust.AppSurface.Config.Tests/packages.lock.json
+++ b/Config/ForgeTrust.AppSurface.Config.Tests/packages.lock.json
@@ -367,16 +367,23 @@
       "forgetrust.appsurface.config": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Options": "[9.0.6, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/Config/ForgeTrust.AppSurface.Config/packages.lock.json
+++ b/Config/ForgeTrust.AppSurface.Config/packages.lock.json
@@ -248,9 +248,16 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/Console/ForgeTrust.AppSurface.Console.Tests/packages.lock.json
+++ b/Console/ForgeTrust.AppSurface.Console.Tests/packages.lock.json
@@ -357,12 +357,13 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -372,6 +373,12 @@
         "requested": "[2.3.6, )",
         "resolved": "2.3.6",
         "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/Console/ForgeTrust.AppSurface.Console/packages.lock.json
+++ b/Console/ForgeTrust.AppSurface.Console/packages.lock.json
@@ -244,9 +244,16 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/Dependency/ForgeTrust.AppSurface.Dependency.Autofac.Tests/packages.lock.json
+++ b/Dependency/ForgeTrust.AppSurface.Dependency.Autofac.Tests/packages.lock.json
@@ -373,6 +373,7 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -382,7 +383,7 @@
         "dependencies": {
           "Autofac": "[8.0.0, )",
           "Autofac.Extensions.DependencyInjection": "[9.0.0, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "Autofac.Extensions.DependencyInjection": {
@@ -394,6 +395,12 @@
           "Autofac": "8.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/Dependency/ForgeTrust.AppSurface.Dependency.Autofac/packages.lock.json
+++ b/Dependency/ForgeTrust.AppSurface.Dependency.Autofac/packages.lock.json
@@ -254,9 +254,16 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/ForgeTrust.AppSurface.Core.Tests/ProcessUtilsTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/ProcessUtilsTests.cs
@@ -314,11 +314,8 @@ public class ProcessUtilsTests
     public async Task ExecuteProcessAsync_UsesConfiguredWorkingDirectory()
     {
         var logger = new ListLogger();
-        var tempDirectoryName = $"appsurface-process-utils-{Guid.NewGuid():N}";
-        var tempDirectory = Path.Combine(
-            Directory.GetCurrentDirectory(),
-            Path.GetFileName(tempDirectoryName));
-        Directory.CreateDirectory(tempDirectory);
+        var tempDirectory = Directory.CreateDirectory(
+            Path.Join(Directory.GetCurrentDirectory(), $"appsurface-process-utils-{Guid.NewGuid():N}")).FullName;
         var (fileName, args) = CreateShellCommand("cd", "pwd");
 
         try

--- a/ForgeTrust.AppSurface.Core.Tests/ProcessUtilsTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/ProcessUtilsTests.cs
@@ -314,9 +314,10 @@ public class ProcessUtilsTests
     public async Task ExecuteProcessAsync_UsesConfiguredWorkingDirectory()
     {
         var logger = new ListLogger();
+        var tempDirectoryName = $"appsurface-process-utils-{Guid.NewGuid():N}";
         var tempDirectory = Path.Combine(
             Directory.GetCurrentDirectory(),
-            $"appsurface-process-utils-{Guid.NewGuid():N}");
+            Path.GetFileName(tempDirectoryName));
         Directory.CreateDirectory(tempDirectory);
         var (fileName, args) = CreateShellCommand("cd", "pwd");
 

--- a/ForgeTrust.AppSurface.Core.Tests/ProcessUtilsTests.cs
+++ b/ForgeTrust.AppSurface.Core.Tests/ProcessUtilsTests.cs
@@ -311,6 +311,65 @@ public class ProcessUtilsTests
     }
 
     [Fact]
+    public async Task ExecuteProcessAsync_UsesConfiguredWorkingDirectory()
+    {
+        var logger = new ListLogger();
+        var tempDirectory = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            $"appsurface-process-utils-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        var (fileName, args) = CreateShellCommand("cd", "pwd");
+
+        try
+        {
+            var result = await ProcessUtils.ExecuteProcessAsync(
+                fileName,
+                args,
+                tempDirectory,
+                logger,
+                CancellationToken.None);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(
+                NormalizePathForComparison(tempDirectory),
+                NormalizePathForComparison(result.Stdout.Trim()));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteProcessAsync_InheritsParentEnvironmentVariables()
+    {
+        var logger = new ListLogger();
+        var variableName = $"APPSURFACE_PROCESS_UTILS_{Guid.NewGuid():N}";
+        const string expectedValue = "inherited-from-parent";
+        Environment.SetEnvironmentVariable(variableName, expectedValue);
+        var (fileName, args) = CreateShellCommand(
+            $"echo %{variableName}%",
+            $"printf '%s' \"${variableName}\"");
+
+        try
+        {
+            var result = await ProcessUtils.ExecuteProcessAsync(
+                fileName,
+                args,
+                Directory.GetCurrentDirectory(),
+                logger,
+                CancellationToken.None);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(expectedValue, result.Stdout.Trim());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, null);
+        }
+    }
+
+    [Fact]
     public async Task ExecuteProcessAsync_PropagatesStreamingFailures_WhenLoggerThrows()
     {
         var logger = new ThrowingLogger(LogLevel.Information);
@@ -368,62 +427,6 @@ public class ProcessUtilsTests
                 && entry.Message.Contains(fileName, StringComparison.Ordinal));
     }
 
-    [Fact]
-    public async Task ExecuteProcessAsync_LogsAndThrows_WhenProcessStartReturnsFalse()
-    {
-        var logger = new ListLogger();
-        const string fileName = "synthetic-process";
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            ProcessUtils.ExecuteProcessAsync(
-                fileName,
-                [],
-                Directory.GetCurrentDirectory(),
-                logger,
-                CancellationToken.None,
-                streamOutput: false,
-                stderrLogLevelSelector: null,
-                hooks: new ProcessUtils.ProcessExecutionHooks
-                {
-                    StartProcessOverride = _ => false
-                }));
-
-        Assert.Equal($"Failed to start process: {fileName}", exception.Message);
-        Assert.Contains(
-            logger.Messages,
-            entry => entry.LogLevel == LogLevel.Error
-                && entry.Message.Contains(fileName, StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task ExecuteProcessAsync_LogsDebug_WhenCleanupKillThrows()
-    {
-        var logger = new ListLogger();
-        var (fileName, args) = CreateShellCommand(
-            "(echo steady) & exit /b 0",
-            "printf 'steady\\n'");
-
-        var result = await ProcessUtils.ExecuteProcessAsync(
-            fileName,
-            args,
-            Directory.GetCurrentDirectory(),
-            logger,
-            CancellationToken.None,
-            streamOutput: false,
-            stderrLogLevelSelector: null,
-            hooks: new ProcessUtils.ProcessExecutionHooks
-            {
-                HasExitedOverride = _ => false,
-                KillProcessOverride = _ => throw new InvalidOperationException("kill failure")
-            });
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Contains(
-            logger.Messages,
-            entry => entry.LogLevel == LogLevel.Debug
-                && entry.Exception?.Message == "kill failure");
-    }
-
     private static (string FileName, IReadOnlyList<string> Args) CreateShellCommand(string windowsScript, string unixScript)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -432,6 +435,14 @@ public class ProcessUtilsTests
         }
 
         return ("/bin/sh", ["-c", unixScript]);
+    }
+
+    private static string NormalizePathForComparison(string path)
+    {
+        var fullPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? fullPath.ToUpperInvariant()
+            : fullPath;
     }
 
     private static string GetPlatformMultilineOutput(params string[] lines)

--- a/ForgeTrust.AppSurface.Core.Tests/packages.lock.json
+++ b/ForgeTrust.AppSurface.Core.Tests/packages.lock.json
@@ -350,9 +350,16 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj
+++ b/ForgeTrust.AppSurface.Core/ForgeTrust.AppSurface.Core.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CliWrap"/>
     <PackageReference Include="Microsoft.Extensions.Hosting"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
   </ItemGroup>

--- a/ForgeTrust.AppSurface.Core/ProcessUtils.cs
+++ b/ForgeTrust.AppSurface.Core/ProcessUtils.cs
@@ -1,5 +1,7 @@
-using System.Diagnostics;
+using System.ComponentModel;
 using System.Text;
+using CliWrap;
+using CliWrap.Exceptions;
 using Microsoft.Extensions.Logging;
 
 namespace ForgeTrust.AppSurface.Core;
@@ -37,33 +39,6 @@ public record CommandResult(int ExitCode, string Stdout, string Stderr);
 /// </summary>
 public static class ProcessUtils
 {
-    /// <summary>
-    /// Test hooks that allow deterministic verification of process lifecycle edge cases.
-    /// </summary>
-    /// <remarks>
-    /// Use these hooks only from tests that need to simulate rare runtime conditions such as
-    /// <see cref="Process.Start()"/> returning <see langword="false"/> or process termination throwing during cleanup.
-    /// Production code should continue to use the public <see cref="ExecuteProcessAsync(string, IReadOnlyList{string}, string, ILogger, CancellationToken, bool, Func{string, LogLevel}?)"/>
-    /// overload, which executes real process operations without overrides.
-    /// </remarks>
-    internal sealed record ProcessExecutionHooks
-    {
-        /// <summary>
-        /// Gets or sets an optional process-start override.
-        /// </summary>
-        internal Func<Process, bool>? StartProcessOverride { get; init; }
-
-        /// <summary>
-        /// Gets or sets an optional process-state override for <see cref="Process.HasExited"/>.
-        /// </summary>
-        internal Func<Process, bool>? HasExitedOverride { get; init; }
-
-        /// <summary>
-        /// Gets or sets an optional process-kill override used during cleanup.
-        /// </summary>
-        internal Action<Process>? KillProcessOverride { get; init; }
-    }
-
     /// <summary>
     /// Executes a process asynchronously and captures its output.
     /// </summary>
@@ -106,127 +81,75 @@ public static class ProcessUtils
         bool streamOutput = false,
         Func<string, LogLevel>? stderrLogLevelSelector = null)
     {
-        return await ExecuteProcessAsync(
-            fileName,
-            args,
-            workingDirectory,
-            logger,
-            cancellationToken,
-            streamOutput,
-            stderrLogLevelSelector,
-            hooks: null);
-    }
+        string stdout = string.Empty;
+        string stderr = string.Empty;
 
-    /// <summary>
-    /// Executes a process asynchronously with optional lifecycle hooks for deterministic testing.
-    /// </summary>
-    /// <param name="fileName">The path to the executable file to launch.</param>
-    /// <param name="args">The ordered list of command-line arguments to pass to the process.</param>
-    /// <param name="workingDirectory">The working directory used when starting the process.</param>
-    /// <param name="logger">The logger that receives streamed output when <paramref name="streamOutput"/> is enabled.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <param name="streamOutput">
-    /// If <see langword="true" />, standard output and standard error are logged in real time and also
-    /// captured in the returned <see cref="CommandResult" />.
-    /// </param>
-    /// <param name="stderrLogLevelSelector">
-    /// Optional selector that can remap the log level used for each standard error line when
-    /// <paramref name="streamOutput"/> is enabled.
-    /// </param>
-    /// <param name="hooks">
-    /// Optional lifecycle hooks used by tests to simulate rare process runtime behaviors that are otherwise difficult
-    /// to reproduce deterministically.
-    /// </param>
-    /// <returns>A <see cref="CommandResult"/> containing the process exit code and captured standard output/error.</returns>
-    internal static async Task<CommandResult> ExecuteProcessAsync(
-        string fileName,
-        IReadOnlyList<string> args,
-        string workingDirectory,
-        ILogger logger,
-        CancellationToken cancellationToken,
-        bool streamOutput,
-        Func<string, LogLevel>? stderrLogLevelSelector,
-        ProcessExecutionHooks? hooks)
-    {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = fileName,
-            WorkingDirectory = workingDirectory,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
+        var command = Cli.Wrap(fileName)
+            .WithArguments(args)
+            .WithWorkingDirectory(workingDirectory)
+            .WithValidation(CommandResultValidation.None)
+            .WithStandardOutputPipe(PipeTarget.Create(async (stream, targetCancellationToken) =>
+            {
+                stdout = await CaptureOutputAsync(
+                    stream,
+                    logger,
+                    LogLevel.Information,
+                    fileName,
+                    targetCancellationToken,
+                    streamOutput);
+            }))
+            .WithStandardErrorPipe(PipeTarget.Create(async (stream, targetCancellationToken) =>
+            {
+                stderr = await CaptureOutputAsync(
+                    stream,
+                    logger,
+                    LogLevel.Error,
+                    fileName,
+                    targetCancellationToken,
+                    streamOutput,
+                    stderrLogLevelSelector);
+            }));
 
-        foreach (var arg in args)
-        {
-            startInfo.ArgumentList.Add(arg);
-        }
-
-        using var process = new Process();
-        process.StartInfo = startInfo;
-        var started = false;
-        Task<string>? stdoutTask = null;
-        Task<string>? stderrTask = null;
-        var outputObserved = false;
         try
         {
-            try
-            {
-                if (!StartProcess(process, hooks))
-                {
-                    var exception = new InvalidOperationException($"Failed to start process: {fileName}");
-                    logger.LogError(exception, "Failed to start process {FileName}", fileName);
-                    throw exception;
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to start process {FileName}", fileName);
-                throw new InvalidOperationException($"Failed to start process: {fileName}", ex);
-            }
-
-            started = true;
-
-            if (streamOutput)
-            {
-                stdoutTask = StreamToLoggerAsync(process.StandardOutput, logger, LogLevel.Information, fileName, cancellationToken);
-                stderrTask = StreamToLoggerAsync(process.StandardError, logger, LogLevel.Error, fileName, cancellationToken, stderrLogLevelSelector);
-            }
-            else
-            {
-                stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-                stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-            }
-
-            await WaitForExitOrStreamingFailureAsync(process, streamOutput, stdoutTask, stderrTask, cancellationToken);
-
-            var stdout = await GetResultAsync(stdoutTask);
-            var stderr = await GetResultAsync(stderrTask);
-            outputObserved = true;
-
-            return new CommandResult(process.ExitCode, stdout, stderr);
+            var result = await command.ExecuteAsync(cancellationToken);
+            return new CommandResult(result.ExitCode, stdout, stderr);
         }
-        finally
+        catch (OperationCanceledException)
         {
-            TryKillProcess(process, started, logger, hooks);
-
-            if (!outputObserved)
-            {
-                // Ensure tasks are observed if an exception occurred before the normal result path.
-                await ObserveTaskAsync(stdoutTask, "stdout", fileName, logger);
-                await ObserveTaskAsync(stderrTask, "stderr", fileName, logger);
-            }
+            throw;
+        }
+        catch (CliWrapException ex)
+        {
+            logger.LogError(ex, "Failed to start process {FileName}", fileName);
+            throw new InvalidOperationException($"Failed to start process: {fileName}", ex);
+        }
+        catch (Win32Exception ex)
+        {
+            logger.LogError(ex, "Failed to start process {FileName}", fileName);
+            throw new InvalidOperationException($"Failed to start process: {fileName}", ex);
         }
     }
 
-    private static bool StartProcess(Process process, ProcessExecutionHooks? hooks)
+    private static async Task<string> CaptureOutputAsync(
+        Stream stream,
+        ILogger logger,
+        LogLevel logLevel,
+        string fileName,
+        CancellationToken cancellationToken,
+        bool streamOutput,
+        Func<string, LogLevel>? levelSelector = null)
     {
-        return hooks?.StartProcessOverride?.Invoke(process) ?? process.Start();
+        using var reader = new StreamReader(
+            stream,
+            Console.OutputEncoding,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 1024,
+            leaveOpen: true);
+
+        return streamOutput
+            ? await StreamToLoggerAsync(reader, logger, logLevel, fileName, cancellationToken, levelSelector)
+            : await reader.ReadToEndAsync(cancellationToken);
     }
 
     /// <summary>
@@ -326,109 +249,6 @@ public static class ProcessUtils
         else
         {
             logger.Log(effectiveLevel, "{FileName}: {Output}", fileName, line);
-        }
-    }
-
-    private static void TryKillProcess(Process process, bool started, ILogger logger, ProcessExecutionHooks? hooks)
-    {
-        if (!started) return;
-        try
-        {
-            if (!(hooks?.HasExitedOverride?.Invoke(process) ?? process.HasExited))
-            {
-                if (hooks?.KillProcessOverride is { } killProcessOverride)
-                {
-                    killProcessOverride(process);
-                }
-                else
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "Failed to kill process {ProcessId}", process.Id);
-        }
-    }
-
-    private static async Task WaitForExitOrStreamingFailureAsync(
-        Process process,
-        bool streamOutput,
-        Task<string>? stdoutTask,
-        Task<string>? stderrTask,
-        CancellationToken cancellationToken)
-    {
-        var waitForExitTask = process.WaitForExitAsync(cancellationToken);
-
-        if (!streamOutput)
-        {
-            await waitForExitTask;
-            return;
-        }
-
-        var pendingTasks = new List<Task>(2);
-        if (stdoutTask != null)
-        {
-            pendingTasks.Add(stdoutTask);
-        }
-
-        if (stderrTask != null)
-        {
-            pendingTasks.Add(stderrTask);
-        }
-
-        while (!waitForExitTask.IsCompleted && pendingTasks.Count > 0)
-        {
-            var waitCandidates = new Task[pendingTasks.Count + 1];
-            waitCandidates[0] = waitForExitTask;
-            pendingTasks.CopyTo(waitCandidates, 1);
-
-            var completedTask = await Task.WhenAny(waitCandidates);
-            if (completedTask == waitForExitTask)
-            {
-                break;
-            }
-
-            if (completedTask.IsFaulted || completedTask.IsCanceled)
-            {
-                await completedTask;
-            }
-
-            pendingTasks.Remove(completedTask);
-        }
-
-        await waitForExitTask;
-    }
-
-    /// <summary>
-    /// Gets the result of a task if it is a Task&lt;string&gt;.
-    /// </summary>
-    /// <param name="task">The task to observe.</param>
-    /// <returns>The string result if available, otherwise an empty string.</returns>
-    private static async Task<string> GetResultAsync(Task<string>? task)
-    {
-        if (task == null) return string.Empty;
-        return await task;
-    }
-
-    /// <summary>
-    /// Observes a task during cleanup and logs any exceptions without surfacing them.
-    /// </summary>
-    /// <param name="task">The task to observe.</param>
-    /// <param name="streamName">The name of the stream (e.g., "stdout").</param>
-    /// <param name="fileName">The file name of the process being executed.</param>
-    /// <param name="logger">The logger for debugging.</param>
-    private static async Task ObserveTaskAsync(Task<string>? task, string streamName, string fileName, ILogger logger)
-    {
-        if (task == null) return;
-        try
-        {
-            await task;
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "Failed to complete reading {StreamName} for {FileName}", streamName, fileName);
         }
     }
 }

--- a/ForgeTrust.AppSurface.Core/ProcessUtils.cs
+++ b/ForgeTrust.AppSurface.Core/ProcessUtils.cs
@@ -119,12 +119,7 @@ public static class ProcessUtils
         {
             throw;
         }
-        catch (CliWrapException ex)
-        {
-            logger.LogError(ex, "Failed to start process {FileName}", fileName);
-            throw new InvalidOperationException($"Failed to start process: {fileName}", ex);
-        }
-        catch (Win32Exception ex)
+        catch (Exception ex) when (ex is CliWrapException or Win32Exception)
         {
             logger.LogError(ex, "Failed to start process {FileName}", fileName);
             throw new InvalidOperationException($"Failed to start process: {fileName}", ex);

--- a/ForgeTrust.AppSurface.Core/README.md
+++ b/ForgeTrust.AppSurface.Core/README.md
@@ -16,7 +16,7 @@ The Core library is designed to be lightweight and implementation-agnostic. It p
 - **`ConsoleOutputMode`**: Shared core enum that lets console-oriented packages describe whether command output should remain host-centric or command-first.
 - **`AppSurfaceStartup`**: The base class that orchestrates the host building and service registration process.
 - **`AppSurfaceStartup.RegisterDependencies`**: A protected seam for specialized startup types that need the module graph prepared before they build the Generic Host.
-- **`ProcessUtils`**: The AppSurface-owned process execution surface for framework code that needs captured stdout, captured stderr, non-throwing non-zero exit codes, cancellation-aware execution, and optional line-by-line logging.
+- **`ProcessUtils`**: The AppSurface-owned process execution surface for framework code that needs to capture stdout and stderr, non-throwing non-zero exit codes, cancellation-aware execution, and optional line-by-line logging.
 
 ## Application labels and host identity
 

--- a/ForgeTrust.AppSurface.Core/README.md
+++ b/ForgeTrust.AppSurface.Core/README.md
@@ -16,6 +16,7 @@ The Core library is designed to be lightweight and implementation-agnostic. It p
 - **`ConsoleOutputMode`**: Shared core enum that lets console-oriented packages describe whether command output should remain host-centric or command-first.
 - **`AppSurfaceStartup`**: The base class that orchestrates the host building and service registration process.
 - **`AppSurfaceStartup.RegisterDependencies`**: A protected seam for specialized startup types that need the module graph prepared before they build the Generic Host.
+- **`ProcessUtils`**: The AppSurface-owned process execution surface for framework code that needs captured stdout, captured stderr, non-throwing non-zero exit codes, cancellation-aware execution, and optional line-by-line logging.
 
 ## Application labels and host identity
 
@@ -61,6 +62,30 @@ Pitfalls:
 - Do not create a static `LoggerFactory` inside a utility. That couples Core to a console/logging policy the host did not choose.
 - Do not throw only because a fallback warning was logged. Keep the documented return behavior unless the input contract itself is invalid.
 - Do not swallow cleanup failures silently when a logger is available. Log them at `Debug` when they are intentionally suppressed to preserve the primary exception or cancellation path.
+
+## Process execution utilities
+
+`ProcessUtils.ExecuteProcessAsync(...)` runs an external command through CliWrap and returns a `CommandResult` containing `ExitCode`, `Stdout`, and `Stderr`. It is not a general replacement for CliWrap; it is the opinionated AppSurface process boundary for framework features that need consistent command result semantics.
+
+Use `ProcessUtils` when AppSurface framework code needs this shared process policy:
+
+- arguments are passed as an ordered `IReadOnlyList<string>` and are escaped by CliWrap rather than concatenated into a shell command;
+- `workingDirectory` is applied to the launched process;
+- parent environment variables are inherited by default;
+- stdout and stderr are captured separately;
+- non-zero exit codes are returned in `CommandResult.ExitCode` instead of throwing;
+- startup failures and cancellation still surface as exceptions;
+- `streamOutput: true` logs completed stdout lines at `Information` and completed stderr lines at `Error` unless `stderrLogLevelSelector` remaps a specific stderr line.
+
+Use CliWrap directly for application code or package code that needs command-specific composition, such as custom environment variable overrides, stdin piping, process pipelines, credentials, resource policies, timeouts that are not modeled as cancellation tokens, or event-stream handling. When the same advanced behavior becomes a repeated AppSurface framework concern, add it deliberately to `ProcessUtils` instead of reimplementing it at each call site.
+
+Pitfalls:
+
+- `Stdout` and `Stderr` are separate buffers, not a merged chronological transcript. If exact cross-stream ordering matters, use CliWrap directly and preserve the event stream yourself.
+- `streamOutput: true` still captures the full text for both streams. It is for real-time logging, not for reducing memory usage on unbounded output.
+- Cancellation is the timeout mechanism for this wrapper. Pass a `CancellationToken` from a `CancellationTokenSource` with the timeout policy you want.
+- Logger and `stderrLogLevelSelector` exceptions are not swallowed. A caller should treat those failures as execution failures because the returned output may be incomplete.
+- Keep `ProcessUtils` focused on AppSurface framework policy. Do not add one-off knobs that only one consumer needs; use CliWrap directly at that call site.
 
 ## Usage
 

--- a/ForgeTrust.AppSurface.Core/packages.lock.json
+++ b/ForgeTrust.AppSurface.Core/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
+      },
       "Microsoft.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[9.0.6, )",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This approach aims to:
 
 ### [Core](./ForgeTrust.AppSurface.Core/README.md)
 
-- [**ForgeTrust.AppSurface.Core**](./ForgeTrust.AppSurface.Core/README.md) – Core abstractions for defining modules and starting an application via `AppSurfaceStartup` and `StartupContext`.
+- [**ForgeTrust.AppSurface.Core**](./ForgeTrust.AppSurface.Core/README.md) – Core abstractions for defining modules, starting an application via `AppSurfaceStartup` and `StartupContext`, and running AppSurface-owned process workflows through a CliWrap-backed policy surface.
 
 ### [Console](./Console/README.md)
 

--- a/Web/ForgeTrust.AppSurface.Docs.Standalone/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Docs.Standalone/packages.lock.json
@@ -36,24 +36,21 @@
       "forgetrust.appsurface.caching": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
-      },
-      "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "CliWrap": "[3.10.1, )"
         }
       },
       "forgetrust.appsurface.docs": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Caching": "[1.0.0, )",
-          "ForgeTrust.RazorWire": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Caching": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )",
           "HtmlSanitizer": "[9.0.892, )",
           "Markdig": "[0.44.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
@@ -62,22 +59,21 @@
           "YamlDotNet": "[17.0.1, )"
         }
       },
-      "forgetrust.razorwire": {
+      "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
@@ -94,6 +90,19 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "HtmlSanitizer": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.AppSurface.Docs.Tests/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Docs.Tests/packages.lock.json
@@ -429,6 +429,7 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -485,6 +486,12 @@
           "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Markdig": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.AppSurface.Docs/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Docs/packages.lock.json
@@ -86,34 +86,30 @@
       "forgetrust.appsurface.caching": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
-        }
-      },
-      "forgetrust.razorwire": {
-        "type": "Project",
-        "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
@@ -130,6 +126,19 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi.Tests/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi.Tests/packages.lock.json
@@ -120,20 +120,29 @@
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.openapi": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.OpenApi": "[9.0.8, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi/packages.lock.json
@@ -252,6 +252,7 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -259,8 +260,14 @@
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.AppSurface.Web.Scalar.Tests/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar.Tests/packages.lock.json
@@ -120,27 +120,36 @@
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.openapi": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.OpenApi": "[9.0.8, )"
         }
       },
       "forgetrust.appsurface.web.scalar": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web.OpenApi": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web.OpenApi": "[0.1.0, )",
           "Scalar.AspNetCore": "[2.6.8, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.AppSurface.Web.Scalar/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar/packages.lock.json
@@ -249,6 +249,7 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -256,15 +257,21 @@
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.openapi": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.OpenApi": "[9.0.8, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/packages.lock.json
@@ -129,17 +129,20 @@
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
@@ -156,6 +159,12 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       }
     }
   }

--- a/Web/ForgeTrust.AppSurface.Web.Tailwind/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.Tailwind/packages.lock.json
@@ -3,7 +3,10 @@
   "dependencies": {
     "net10.0": {
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
         "type": "Project"
@@ -19,6 +22,12 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       }
     }
   }

--- a/Web/ForgeTrust.AppSurface.Web.Tests.SharedErrorPagesFixture/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.Tests.SharedErrorPagesFixture/packages.lock.json
@@ -3,13 +3,22 @@
   "dependencies": {
     "net10.0": {
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       }
     }
   }

--- a/Web/ForgeTrust.AppSurface.Web.Tests/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/packages.lock.json
@@ -115,20 +115,29 @@
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tests.sharederrorpagesfixture": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       }
     }
   }

--- a/Web/ForgeTrust.AppSurface.Web/packages.lock.json
+++ b/Web/ForgeTrust.AppSurface.Web/packages.lock.json
@@ -3,7 +3,16 @@
   "dependencies": {
     "net10.0": {
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       }
     }
   }

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/packages.lock.json
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/packages.lock.json
@@ -387,12 +387,13 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -400,13 +401,13 @@
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.razorwire": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
         }
       },
@@ -414,9 +415,9 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Console": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "ForgeTrust.RazorWire": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Console": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )"
         }
       },
       "CliFx": {
@@ -424,6 +425,12 @@
         "requested": "[2.3.6, )",
         "resolved": "2.3.6",
         "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.RazorWire.Cli/packages.lock.json
+++ b/Web/ForgeTrust.RazorWire.Cli/packages.lock.json
@@ -258,12 +258,13 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -271,15 +272,21 @@
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.razorwire": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.RazorWire.IntegrationTests/packages.lock.json
+++ b/Web/ForgeTrust.RazorWire.IntegrationTests/packages.lock.json
@@ -427,29 +427,24 @@
       "forgetrust.appsurface.caching": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Caching.Memory": "[9.0.6, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
-        }
-      },
-      "forgetrust.appsurface.web": {
-        "type": "Project",
-        "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
         }
       },
       "forgetrust.appsurface.docs": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Caching": "[1.0.0, )",
-          "ForgeTrust.RazorWire": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Caching": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind": "[0.1.0, )",
+          "ForgeTrust.RazorWire": "[0.1.0, )",
           "HtmlSanitizer": "[9.0.892, )",
           "Markdig": "[0.44.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )",
@@ -461,25 +456,24 @@
       "forgetrust.appsurface.docs.standalone": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Docs": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Docs": "[0.1.0, )"
         }
       },
-      "forgetrust.razorwire": {
+      "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
@@ -496,6 +490,19 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "HtmlSanitizer": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.RazorWire.Tests/packages.lock.json
+++ b/Web/ForgeTrust.RazorWire.Tests/packages.lock.json
@@ -380,6 +380,7 @@
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -387,15 +388,21 @@
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.razorwire": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "CentralTransitive",

--- a/Web/ForgeTrust.RazorWire/packages.lock.json
+++ b/Web/ForgeTrust.RazorWire/packages.lock.json
@@ -27,13 +27,22 @@
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "CentralTransitive",

--- a/benchmarks/AppSurfaceBenchmarks/packages.lock.json
+++ b/benchmarks/AppSurfaceBenchmarks/packages.lock.json
@@ -770,32 +770,35 @@
         "type": "Project"
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.openapi": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.OpenApi": "[9.0.8, )"
         }
       },
       "forgetrust.appsurface.web.scalar": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web.OpenApi": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web.OpenApi": "[0.1.0, )",
           "Scalar.AspNetCore": "[2.6.8, )"
         }
       },
       "manydependencyinjectioncontrollers": {
         "type": "Project",
         "dependencies": {
-          "DependencyInjectionControllers": "[1.0.0, )"
+          "DependencyInjectionControllers": "[0.1.0, )"
         }
       },
       "simpleapicontroller": {
@@ -804,8 +807,14 @@
       "webappexample": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web.Scalar": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Web.Scalar": "[0.1.0, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "CentralTransitive",

--- a/examples/config-validation/packages.lock.json
+++ b/examples/config-validation/packages.lock.json
@@ -238,16 +238,23 @@
       "forgetrust.appsurface.config": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Options": "[9.0.6, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/examples/console-app/packages.lock.json
+++ b/examples/console-app/packages.lock.json
@@ -238,7 +238,7 @@
       "forgetrust.appsurface.config": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
           "Microsoft.Extensions.Options": "[9.0.6, )"
         }
       },
@@ -246,12 +246,13 @@
         "type": "Project",
         "dependencies": {
           "CliFx": "[2.3.6, )",
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.core": {
         "type": "Project",
         "dependencies": {
+          "CliWrap": "[3.10.1, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "Microsoft.Extensions.Logging.Console": "[9.0.6, )"
         }
@@ -261,6 +262,12 @@
         "requested": "[2.3.6, )",
         "resolved": "2.3.6",
         "contentHash": "7Q6rbhCxpEoAtPrcBm4sJ4QlDeY+0Dp4in0oXAxrJJ/4L1LV/YkDQSqfUMwK56GbnpUo4fIrpOxoxM+ta44B1g=="
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/examples/razorwire-mvc/packages.lock.json
+++ b/examples/razorwire-mvc/packages.lock.json
@@ -16,30 +16,26 @@
         }
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
-        }
-      },
-      "forgetrust.razorwire": {
-        "type": "Project",
-        "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
-          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[1.0.0, )",
-          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.linux-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-arm64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.osx-x64": "[0.1.0, )",
+          "ForgeTrust.AppSurface.Web.Tailwind.Runtime.win-x64": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.tailwind.runtime.linux-arm64": {
@@ -56,6 +52,19 @@
       },
       "forgetrust.appsurface.web.tailwind.runtime.win-x64": {
         "type": "Project"
+      },
+      "forgetrust.razorwire": {
+        "type": "Project",
+        "dependencies": {
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
+          "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation": "[10.0.2, )"
+        }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "CentralTransitive",

--- a/examples/web-app/packages.lock.json
+++ b/examples/web-app/packages.lock.json
@@ -8,27 +8,36 @@
         "contentHash": "Le+kehlmrlQfuDFUt1zZ2dVwrhFQtKREdKBo+rexOwaCoYP0/qpgT9tLxCsZjsgR5Itk1UKPcbgO+FyaNid/bA=="
       },
       "forgetrust.appsurface.core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "CliWrap": "[3.10.1, )"
+        }
       },
       "forgetrust.appsurface.web": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Core": "[1.0.0, )"
+          "ForgeTrust.AppSurface.Core": "[0.1.0, )"
         }
       },
       "forgetrust.appsurface.web.openapi": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web": "[0.1.0, )",
           "Microsoft.AspNetCore.OpenApi": "[9.0.8, )"
         }
       },
       "forgetrust.appsurface.web.scalar": {
         "type": "Project",
         "dependencies": {
-          "ForgeTrust.AppSurface.Web.OpenApi": "[1.0.0, )",
+          "ForgeTrust.AppSurface.Web.OpenApi": "[0.1.0, )",
           "Scalar.AspNetCore": "[2.6.8, )"
         }
+      },
+      "CliWrap": {
+        "type": "CentralTransitive",
+        "requested": "[3.10.1, )",
+        "resolved": "3.10.1",
+        "contentHash": "C+WzXwzpQsJVNqvuh19ZO/bw/vR43L+DC/CmvK+PATUBkail2AWYE6an17dOGgWaVGzF9sU28YwRwfNfkPrQdg=="
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -54,6 +54,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 ### Core diagnostics
 
 - Core static utilities now use explicit `ILogger` overloads and source-generated `[LoggerMessage]` definitions for host-owned diagnostics. `PathUtils.FindRepositoryRoot` can warn when discovery falls back from a missing path, and parallel enumerable cleanup paths now log suppressed cleanup failures at `Debug` when a caller supplies a logger.
+- `ProcessUtils` now runs through CliWrap while keeping the existing AppSurface process contract for captured output, streaming logs, cancellation, and non-throwing non-zero exit codes.
 
 ### Dependency maintenance
 


### PR DESCRIPTION
## Summary
- Migrate ProcessUtils process execution internals from System.Diagnostics.Process to CliWrap while preserving the public API.
- Keep ProcessUtils positioned as the AppSurface process policy surface for advanced behavior, with documentation on when to use it versus CliWrap directly.
- Add regression coverage for working directory and inherited environment behavior, and update package lock files for the new Core dependency edge.

## Validation
- dotnet format ForgeTrust.AppSurface.Core.Tests/ForgeTrust.AppSurface.Core.Tests.csproj
- dotnet test ForgeTrust.AppSurface.Core.Tests/ForgeTrust.AppSurface.Core.Tests.csproj
- dotnet test Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/ForgeTrust.AppSurface.Web.Tailwind.Tests.csproj
- dotnet test Web/ForgeTrust.AppSurface.Docs.Tests/ForgeTrust.AppSurface.Docs.Tests.csproj --filter FullyQualifiedName~DocAggregatorTests
- dotnet build
- git diff --check

Fixes #271