### PR TITLE
fix: omit config audit collection display values

### DIFF
--- a/Config/ForgeTrust.AppSurface.Config.Tests/ConfigAuditReporterTests.cs
+++ b/Config/ForgeTrust.AppSurface.Config.Tests/ConfigAuditReporterTests.cs
@@ -126,6 +126,26 @@ public class ConfigAuditReporterTests
         public CyclicOptions? Self { get; set; }
     }
 
+    private sealed class ServiceSecretOptions
+    {
+        public string Name { get; set; } = "billing";
+
+        public string Password { get; set; } = "password-from-collection";
+
+        public string Token { get; set; } = "token-from-collection";
+
+        public string Secret { get; set; } = "secret-from-collection";
+
+        public string ApiKey { get; set; } = "api-key-from-collection";
+
+        public NestedSecretOptions Nested { get; set; } = new();
+    }
+
+    private sealed class NestedSecretOptions
+    {
+        public string Secret { get; set; } = "nested-secret-from-collection";
+    }
+
     [Fact]
     public void GetReport_WithContractFixture_ReportsStatesSourcesPatchesAndRedaction()
     {
@@ -326,6 +346,71 @@ public class ConfigAuditReporterTests
 
         Assert.True(redacted.IsRedacted);
         Assert.Equal("[redacted]", redacted.DisplayValue);
+    }
+
+    [Fact]
+    public void Redactor_OmitsNonSensitiveCollections()
+    {
+        var redactor = new ConfigAuditRedactor();
+
+        var formatted = redactor.FormatValue("Values", new[] { "one", "two", "three" }, []);
+
+        Assert.Null(formatted.DisplayValue);
+        Assert.False(formatted.IsRedacted);
+    }
+
+    [Fact]
+    public void Redactor_RedactsCollectionsWhenSourceMetadataIsSensitive()
+    {
+        var redactor = new ConfigAuditRedactor();
+
+        var redacted = redactor.FormatValue(
+            "Values",
+            new[] { "one", "two", "three" },
+            [
+                new ConfigAuditSourceRecord
+                {
+                    Kind = ConfigAuditSourceKind.Provider,
+                    ProviderName = "SecretProvider",
+                    ConfigPath = "Values",
+                    AppliedToPath = "Values",
+                    Role = ConfigAuditSourceRole.Base,
+                    Sensitivity = ConfigAuditSensitivity.Sensitive
+                }
+            ]);
+
+        Assert.True(redacted.IsRedacted);
+        Assert.Equal("[redacted]", redacted.DisplayValue);
+    }
+
+    [Fact]
+    public void GetReport_OmitsCollectionDisplayValuesWithoutLeakingNestedSecrets()
+    {
+        var environment = A.Fake<IEnvironmentProvider>();
+        A.CallTo(() => environment.GetEnvironmentVariable(A<string>._, A<string?>._)).Returns(null);
+        var services = CreateServices("/missing", environment);
+        services.AddSingleton<IConfigProvider>(
+            new DictionaryConfigProvider(
+                new Dictionary<string, object?>
+                {
+                    ["Services"] = new List<ServiceSecretOptions>
+                    {
+                        new()
+                    }
+                }));
+        services.AddConfigAuditKey<List<ServiceSecretOptions>>("Services");
+
+        var provider = services.BuildServiceProvider();
+        var report = provider.GetRequiredService<IConfigAuditReporter>().GetReport("Production");
+
+        var entry = AssertEntry(report, "Services", ConfigAuditEntryState.Resolved, null);
+        Assert.False(entry.IsRedacted);
+        var rendered = provider.GetRequiredService<ConfigAuditTextRenderer>().Render(report);
+        Assert.DoesNotContain("password-from-collection", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("token-from-collection", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-from-collection", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("api-key-from-collection", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("nested-secret-from-collection", rendered, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -577,7 +662,7 @@ public class ConfigAuditReporterTests
     }
 
     [Fact]
-    public void Redactor_FallsBackWhenEnumerableCannotSerialize()
+    public void Redactor_OmitsEnumerablesThatWouldHaveFailedSerialization()
     {
         var redactor = new ConfigAuditRedactor();
 
@@ -586,13 +671,13 @@ public class ConfigAuditReporterTests
         var invalidOperation = redactor.FormatValue("Values", new InvalidOperationEnumerable(), []);
         var throwingToString = redactor.FormatValue("Values", new ThrowingToStringEnumerable(), []);
 
-        Assert.Equal(nameof(ThrowingEnumerable), formatted.DisplayValue);
+        Assert.Null(formatted.DisplayValue);
         Assert.False(formatted.IsRedacted);
-        Assert.Equal(nameof(JsonExceptionEnumerable), json.DisplayValue);
+        Assert.Null(json.DisplayValue);
         Assert.False(json.IsRedacted);
-        Assert.Equal(nameof(InvalidOperationEnumerable), invalidOperation.DisplayValue);
+        Assert.Null(invalidOperation.DisplayValue);
         Assert.False(invalidOperation.IsRedacted);
-        Assert.Equal(nameof(ThrowingToStringEnumerable), throwingToString.DisplayValue);
+        Assert.Null(throwingToString.DisplayValue);
         Assert.False(throwingToString.IsRedacted);
     }
 

--- a/Config/ForgeTrust.AppSurface.Config/ConfigAuditModels.cs
+++ b/Config/ForgeTrust.AppSurface.Config/ConfigAuditModels.cs
@@ -77,8 +77,9 @@ public sealed class ConfigAuditProvider
 /// <remarks>
 /// <see cref="State"/> summarizes the entry as a whole. Object entries can contain <see cref="Children"/> with more
 /// specific provenance, including nested <see cref="ConfigAuditEntryState.PartiallyResolved"/> states when descendants
-/// are patched. <see cref="DisplayValue"/> is already redacted and can be <see langword="null"/> for complex values;
-/// callers should inspect children instead of assuming a full object dump is available.
+/// are patched. <see cref="DisplayValue"/> is already redacted and can be <see langword="null"/> for complex values,
+/// including collections whose elements are not dumped into parent display strings. Callers should inspect source
+/// records and available children instead of assuming a full object dump is available.
 /// </remarks>
 public sealed class ConfigAuditEntry
 {
@@ -98,7 +99,8 @@ public sealed class ConfigAuditEntry
     public required ConfigAuditEntryState State { get; init; }
 
     /// <summary>
-    /// Gets the display-safe value. Sensitive values are already redacted.
+    /// Gets the display-safe value. Sensitive values are already redacted, and collection parent values may be omitted
+    /// so nested element data cannot leak through a serialized dump.
     /// </summary>
     public string? DisplayValue { get; init; }
 

--- a/Config/ForgeTrust.AppSurface.Config/ConfigAuditRedactor.cs
+++ b/Config/ForgeTrust.AppSurface.Config/ConfigAuditRedactor.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Globalization;
-using System.Text.Json;
 
 namespace ForgeTrust.AppSurface.Config;
 
@@ -9,9 +8,10 @@ namespace ForgeTrust.AppSurface.Config;
 /// </summary>
 /// <remarks>
 /// Matching is fragment based and case-insensitive across keys, config paths, applied paths, and environment variable
-/// names. Sensitive values are replaced with a fixed placeholder before rendering. Non-sensitive complex objects may
-/// produce a <see langword="null"/> display value so callers can rely on child entries instead of an unsafe dump.
-/// Formatting failures are swallowed intentionally to keep audit generation best-effort.
+/// names. Sensitive values are replaced with a fixed placeholder before rendering. Non-sensitive complex values,
+/// including collections, may produce a <see langword="null"/> display value so callers can rely on source records and
+/// supported child entries instead of an unsafe dump. Formatting failures are swallowed intentionally to keep audit
+/// generation best-effort.
 /// </remarks>
 internal sealed class ConfigAuditRedactor
 {
@@ -94,24 +94,9 @@ internal sealed class ConfigAuditRedactor
             return s;
         }
 
-        if (value is IEnumerable && value.GetType() != typeof(string))
+        if (value is IEnumerable)
         {
-            try
-            {
-                return JsonSerializer.Serialize(value);
-            }
-            catch (NotSupportedException)
-            {
-                return SafeToString(value);
-            }
-            catch (JsonException)
-            {
-                return SafeToString(value);
-            }
-            catch (InvalidOperationException)
-            {
-                return SafeToString(value);
-            }
+            return null;
         }
 
         if (!ConfigScalarTypes.IsScalar(value.GetType()))

--- a/Config/ForgeTrust.AppSurface.Config/README.md
+++ b/Config/ForgeTrust.AppSurface.Config/README.md
@@ -114,9 +114,16 @@ Redaction is deliberately conservative. It does not expose string lengths, sensi
 nested values. Source metadata remains visible unless a provider marks the source metadata itself as sensitive. This
 keeps reports safe to paste into support issues while still showing where a value came from.
 
+Collection parent values are omitted instead of serialized when the collection key and source metadata are not
+sensitive. This avoids leaking nested element fields such as `Password`, `Token`, `Secret`, or `ApiKey` through a raw
+JSON dump. Use source records, diagnostics, and object child entries that the reporter already exposes to inspect
+structure; collection element traversal is intentionally outside the first audit surface.
+
 ### Audit Pitfalls
 
 - Audit reports cover AppSurface-known entries, not every raw process environment variable or every unused file key.
+- Collection display values are intentionally omitted rather than summarized or serialized; register more specific
+  keys when element-level audit visibility is required.
 - Provider-discovered raw key enumeration is intentionally separate from the first audit surface.
 - File origins include file path and config path. Line and column origins are not part of the first report.
 - Validation diagnostics name keys and rules; they do not include attempted secret values.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -73,6 +73,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 
 - Strongly typed config wrappers now validate resolved object values with DataAnnotations during startup, including defaults, and report operator-friendly `ConfigurationValidationException` failures without echoing attempted values.
 - Configuration audits can now produce a source-aware report for discovered wrappers and explicitly registered keys, showing provider order, file and environment provenance, defaults, validation diagnostics, and redacted display-safe values.
+- Configuration audits now omit non-sensitive collection parent display values instead of serializing collection contents, preventing nested fields such as passwords, tokens, secrets, and API keys from leaking through raw collection dumps while preserving redaction for sensitive keys and source metadata.
 - Nested config validation can now opt into Microsoft Options `[ValidateObjectMembers]` and `[ValidateEnumeratedItems]` markers while AppSurface owns traversal, path formatting, and cycle protection.
 - Scalar config wrappers can now validate resolved primitive values directly with `ConfigValueNotEmpty`, `ConfigValueRange`, and `ConfigValueMinLength` attributes, while wrapper-specific scalar rules can override `ValidateValue`.
 - Config wrappers can now opt into required resolved presence with `ConfigKeyRequired`, so startup fails when no provider value and no default are available while defaults and supplied zero values still count as present.


### PR DESCRIPTION
## Summary
- Omit non-sensitive collection parent display values from config audit reports instead of serializing collection contents
- Keep sensitive key/source collection values redacted as [redacted]
- Document the collection omission contract in XML docs and the Config README
- Add regression coverage for benign collections, source-sensitive collections, and rendered audit text not leaking nested collection secrets

Fixes #374.

Follow-up filed for explicit collection traversal: #379.

## Verification
- dotnet test Config/ForgeTrust.AppSurface.Config.Tests/ForgeTrust.AppSurface.Config.Tests.csproj --no-restore (192 passed)
- dotnet format Config/ForgeTrust.AppSurface.Config/ForgeTrust.AppSurface.Config.csproj --verify-no-changes --no-restore
- dotnet format Config/ForgeTrust.AppSurface.Config.Tests/ForgeTrust.AppSurface.Config.Tests.csproj --verify-no-changes --no-restore
- git diff --check
- /qa diff-aware browser smoke against Docs standalone at http://127.0.0.1:6197/docs: no console errors, no issues found

## Notes
- ./scripts/coverage-solution.sh was attempted and reached a merged coverage summary, but one RazorWire integration coverage run failed because coverlet hit a locked ForgeTrust.AppSurface.Caching.pdb. Config coverage in that merged report was 97.91% line / 93.65% branch.