### PR TITLE
feat: gate OpenAPI and Scalar docs exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - AppSurface now ships GitHub issue templates for bug reports and documentation feedback.
 - AppSurface Config now supports first-class scalar value validation on `Config<T>` and `ConfigStruct<T>` wrappers with `ConfigValueNotEmpty`, `ConfigValueRange`, `ConfigValueMinLength`, and a `ValidateValue` override for custom rules.
 - AppSurface Web CORS options now expose `AllowedHeaders` and `AllowedMethods` so applications can define explicit production preflight contracts without replacing the framework-managed policy.
+- AppSurface Web OpenAPI and Scalar modules now expose API documentation endpoints only in Development by default, with explicit `Always` and `Never` options for hosts that need production exposure or stricter local hiding.
 
 ### Changed
 
@@ -70,6 +71,7 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - AppSurface Docs authors using `featured_pages` should migrate to `featured_page_groups`; the old flat field now logs a warning and no longer renders.
 - Code that expected custom AppSurface labels from `IHostEnvironment.ApplicationName` should use `StartupContext.ApplicationName`; host environment application names now remain tied to assembly identity so ASP.NET static web assets continue to resolve.
 - Web apps with custom conventional 404 overrides should replace `NotFoundPageModel` with `BrowserStatusPageModel`. The old `ConventionalNotFoundPageMode`, `NotFoundPageMode`, `UseConventionalNotFoundPage()`, and `DisableNotFoundPage()` API names have moved to the `BrowserStatusPage*` naming surface before the first public tag.
+- Web apps that intentionally expose AppSurface-owned OpenAPI or Scalar routes outside Development should configure `AppSurfaceWebOpenApi:ExposeEndpoint=Always` and, for Scalar, `AppSurfaceWebScalar:ExposeEndpoint=Always`. Endpoint exposure does not add authentication or authorization.
 - AppSurface Docs hosts that need operational status for source-backed docs should call `DocAggregator.GetHarvestHealthAsync(...)` and branch on `DocHarvestHealthStatus` and diagnostic codes instead of scraping warning or critical log messages.
 - AppSurface Docs hosts with expensive or side-effecting harvesters can set `AppSurfaceDocs:Harvest:StartupMode` to `Disabled` or adjust `InitialRequestWaitBudgetMilliseconds`; the `Testing*DelayMilliseconds` options are intended only for local and automated observatory testing.
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ This approach aims to:
 ### [Web](./Web/README.md)
 
 - [**ForgeTrust.AppSurface.Web**](./Web/ForgeTrust.AppSurface.Web/README.md) – Bootstraps ASP.NET Core apps, lets modules register middleware and endpoints, and includes conventional browser status pages plus opt-in production 500 pages.
-- [**ForgeTrust.AppSurface.Web.OpenApi**](./Web/ForgeTrust.AppSurface.Web.OpenApi/README.md) – Optional module that adds OpenAPI generation using `AddEndpointsApiExplorer` and `WithOpenApi`.
+- [**ForgeTrust.AppSurface.Web.OpenApi**](./Web/ForgeTrust.AppSurface.Web.OpenApi/README.md) – Optional module that adds OpenAPI generation with development-only endpoint exposure by default.
 - [**ForgeTrust.RazorWire**](./Web/ForgeTrust.RazorWire/README.md) – Adds reactive Razor-based streaming, islands, and CDN-default export tooling for server-rendered web apps.
 - [**ForgeTrust.AppSurface.Docs**](./Web/ForgeTrust.AppSurface.Docs/README.md) – Reusable Razor Class Library package that serves harvested source docs with section-first landing, sidebar, search, built-in trust plus contributor-provenance details, and optional published-version archive surfaces.
 - [**ForgeTrust.AppSurface.Docs.Standalone**](./Web/ForgeTrust.AppSurface.Docs.Standalone/README.md) – Thin export host for exporting or serving AppSurface Docs as an application.
-- [**ForgeTrust.AppSurface.Web.Scalar**](./Web/ForgeTrust.AppSurface.Web.Scalar/README.md) – Optional module that serves the Scalar API reference UI and depends on the OpenAPI module.
+- [**ForgeTrust.AppSurface.Web.Scalar**](./Web/ForgeTrust.AppSurface.Web.Scalar/README.md) – Optional module that serves the Scalar API reference UI when both Scalar and OpenAPI exposure gates allow it.
 
 ### [CLI](./Cli/ForgeTrust.AppSurface.Cli/README.md)
 

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi.Tests/AppSurfaceWebOpenApiModuleTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi.Tests/AppSurfaceWebOpenApiModuleTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -23,7 +24,7 @@ public sealed class AppSurfaceWebOpenApiModuleTests
         var module = new AppSurfaceWebOpenApiModule();
         var services = new ServiceCollection();
 
-        module.ConfigureServices(CreateContext(module), services);
+        module.ConfigureServices(CreateContext(module, Environments.Development), services);
 
         using var provider = services.BuildServiceProvider();
         var options = provider.GetRequiredService<IOptionsMonitor<OpenApiOptions>>().Get("v1");
@@ -33,22 +34,127 @@ public sealed class AppSurfaceWebOpenApiModuleTests
     }
 
     [Fact]
-    public async Task ConfigureEndpoints_MapsDefaultOpenApiEndpoint()
+    public void ConfigureServices_UsesDevelopmentOnlyEndpointExposureByDefault()
     {
         var module = new AppSurfaceWebOpenApiModule();
-        var builder = WebApplication.CreateBuilder();
-        await using var app = builder.Build();
+        var services = CreateServicesWithConfiguration();
 
-        module.ConfigureEndpoints(CreateContext(module), app);
+        module.ConfigureServices(CreateContext(module, Environments.Development), services);
 
-        var routeEndpoints = ((IEndpointRouteBuilder)app)
-            .DataSources
-            .SelectMany(dataSource => dataSource.Endpoints)
-            .OfType<RouteEndpoint>();
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AppSurfaceWebOpenApiOptions>>().Value;
 
-        Assert.Contains(
-            routeEndpoints,
-            endpoint => endpoint.RoutePattern.RawText == "/openapi/{documentName}.json");
+        Assert.Equal(AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, options.ExposeEndpoint);
+    }
+
+    [Fact]
+    public void ConfigureServices_BindsEndpointExposureFromConfiguration()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var services = CreateServicesWithConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AppSurfaceWebOpenApiOptions.SectionName}:ExposeEndpoint"] = "Always"
+        });
+
+        module.ConfigureServices(CreateContext(module, Environments.Production), services);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AppSurfaceWebOpenApiOptions>>().Value;
+
+        Assert.Equal(AppSurfaceApiDocumentationEndpointExposure.Always, options.ExposeEndpoint);
+    }
+
+    [Fact]
+    public void ConfigureServices_AppliesCodeFirstEndpointExposureOverrides()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var services = CreateServicesWithConfiguration();
+
+        module.ConfigureServices(CreateContext(module, Environments.Development), services);
+        services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+            options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Never);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AppSurfaceWebOpenApiOptions>>().Value;
+
+        Assert.Equal(AppSurfaceApiDocumentationEndpointExposure.Never, options.ExposeEndpoint);
+    }
+
+    [Fact]
+    public void ConfigureServices_RejectsInvalidEndpointExposureValues()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var services = CreateServicesWithConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AppSurfaceWebOpenApiOptions.SectionName}:ExposeEndpoint"] = "99"
+        });
+
+        module.ConfigureServices(CreateContext(module, Environments.Development), services);
+
+        using var provider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService<IOptions<AppSurfaceWebOpenApiOptions>>().Value);
+
+        Assert.Contains($"{AppSurfaceWebOpenApiOptions.SectionName}:ExposeEndpoint", exception.Message);
+        Assert.Contains(nameof(AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly), exception.Message);
+        Assert.Contains(nameof(AppSurfaceApiDocumentationEndpointExposure.Always), exception.Message);
+        Assert.Contains(nameof(AppSurfaceApiDocumentationEndpointExposure.Never), exception.Message);
+    }
+
+    [Fact]
+    public void AppSurfaceApiDocumentationEndpointExposure_PreservesNumericValues()
+    {
+        Assert.Equal(0, (int)AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly);
+        Assert.Equal(1, (int)AppSurfaceApiDocumentationEndpointExposure.Always);
+        Assert.Equal(2, (int)AppSurfaceApiDocumentationEndpointExposure.Never);
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_MapsDefaultOpenApiEndpointInDevelopment()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var routePatterns = await GetMappedOpenApiRoutePatternsAsync(
+            module,
+            CreateContext(module, Environments.Development));
+
+        Assert.Contains("/openapi/{documentName}.json", routePatterns);
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_DoesNotMapDefaultOpenApiEndpointOutsideDevelopment()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var routePatterns = await GetMappedOpenApiRoutePatternsAsync(
+            module,
+            CreateContext(module, Environments.Production));
+
+        Assert.DoesNotContain("/openapi/{documentName}.json", routePatterns);
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_MapsOpenApiEndpointOutsideDevelopmentWhenExposureIsAlways()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var routePatterns = await GetMappedOpenApiRoutePatternsAsync(
+            module,
+            CreateContext(module, Environments.Production),
+            services => services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+                options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always));
+
+        Assert.Contains("/openapi/{documentName}.json", routePatterns);
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_DoesNotMapOpenApiEndpointInDevelopmentWhenExposureIsNever()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var routePatterns = await GetMappedOpenApiRoutePatternsAsync(
+            module,
+            CreateContext(module, Environments.Development),
+            services => services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+                options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Never));
+
+        Assert.DoesNotContain("/openapi/{documentName}.json", routePatterns);
     }
 
     [Fact]
@@ -62,6 +168,35 @@ public sealed class AppSurfaceWebOpenApiModuleTests
         Assert.Equal(
             "OpenApiTestApp | v1",
             document.RootElement.GetProperty("info").GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public async Task AppSurfaceWebApp_HidesOpenApiEndpointOutsideDevelopmentByDefault()
+    {
+        var module = new AppSurfaceWebOpenApiModule();
+        var startup = new TestOpenApiStartup();
+        var context = CreateContext(module, Environments.Production);
+        var builder = ((IAppSurfaceStartup)startup).CreateHostBuilder(context);
+        builder.ConfigureWebHost(webHost => webHost.UseUrls("http://127.0.0.1:0"));
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        try
+        {
+            using var client = new HttpClient
+            {
+                BaseAddress = new Uri(GetBaseAddress(host))
+            };
+
+            using var response = await client.GetAsync("/openapi/v1.json");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
     }
 
     [Fact]
@@ -117,7 +252,44 @@ public sealed class AppSurfaceWebOpenApiModuleTests
     }
 
     private static StartupContext CreateContext(AppSurfaceWebOpenApiModule module) =>
-        new([], module, "OpenApiTestApp");
+        CreateContext(module, Environments.Production);
+
+    private static StartupContext CreateContext(AppSurfaceWebOpenApiModule module, string environment) =>
+        new(["--environment", environment], module, "OpenApiTestApp");
+
+    private static ServiceCollection CreateServicesWithConfiguration(
+        Dictionary<string, string?>? configurationValues = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationValues ?? new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+
+        return services;
+    }
+
+    private static async Task<string[]> GetMappedOpenApiRoutePatternsAsync(
+        AppSurfaceWebOpenApiModule module,
+        StartupContext context,
+        Action<IServiceCollection>? configureServices = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        module.ConfigureServices(context, builder.Services);
+        configureServices?.Invoke(builder.Services);
+        await using var app = builder.Build();
+
+        module.ConfigureEndpoints(context, app);
+
+        return ((IEndpointRouteBuilder)app)
+            .DataSources
+            .SelectMany(dataSource => dataSource.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(endpoint => endpoint.RoutePattern.RawText)
+            .OfType<string>()
+            .ToArray();
+    }
 
     private static async Task<JsonDocument> GetOpenApiDocumentAsync(Action<IEndpointRouteBuilder> mapEndpoints)
     {
@@ -125,7 +297,7 @@ public sealed class AppSurfaceWebOpenApiModuleTests
         startup.WithOptions(options => options.MapEndpoints = mapEndpoints);
 
         var module = new AppSurfaceWebOpenApiModule();
-        var context = CreateContext(module);
+        var context = CreateContext(module, Environments.Development);
         var builder = ((IAppSurfaceStartup)startup).CreateHostBuilder(context);
         builder.ConfigureWebHost(webHost => webHost.UseUrls("http://127.0.0.1:0"));
 

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi.Tests/README.md
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi.Tests/README.md
@@ -5,7 +5,9 @@ This test project verifies the public behavior of `ForgeTrust.AppSurface.Web.Ope
 ## Coverage
 
 - `AppSurfaceWebOpenApiModule.ConfigureServices` registers OpenAPI document generation and endpoint API explorer services.
-- `AppSurfaceWebOpenApiModule.ConfigureEndpoints` maps the conventional `/openapi/{documentName}.json` endpoint.
+- `AppSurfaceWebOpenApiModule.ConfigureServices` binds and validates endpoint exposure options.
+- `AppSurfaceWebOpenApiModule.ConfigureEndpoints` maps the conventional `/openapi/{documentName}.json` endpoint in Development, hides it by default outside Development, and honors `Always` and `Never` overrides.
+- `AppSurfaceApiDocumentationEndpointExposure` preserves its documented numeric values.
 - Hosted integration coverage confirms generated OpenAPI documents use the `StartupContext.ApplicationName` title.
 - Hosted integration coverage confirms the default document and operation transformers remove framework-owned `ForgeTrust.AppSurface.Web` tags while preserving consumer tags.
 

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceApiDocumentationEndpointExposure.cs
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceApiDocumentationEndpointExposure.cs
@@ -1,0 +1,28 @@
+namespace ForgeTrust.AppSurface.Web.OpenApi;
+
+/// <summary>
+/// Controls when AppSurface-owned API documentation endpoints are mapped by web modules.
+/// </summary>
+/// <remarks>
+/// Use <see cref="DevelopmentOnly"/> for the safe default: local development hosts get zero-configuration API docs,
+/// while non-development hosts must opt into exposure. Use <see cref="Always"/> only when the host protects the
+/// endpoint with authentication, authorization, network controls, or another deployment boundary. This setting only
+/// controls whether AppSurface maps the endpoint; it does not add authorization by itself.
+/// </remarks>
+public enum AppSurfaceApiDocumentationEndpointExposure
+{
+    /// <summary>
+    /// Map the endpoint only when <see cref="Core.StartupContext.IsDevelopment"/> is <see langword="true"/>.
+    /// </summary>
+    DevelopmentOnly = 0,
+
+    /// <summary>
+    /// Map the endpoint in every host environment.
+    /// </summary>
+    Always = 1,
+
+    /// <summary>
+    /// Never map the endpoint, including in development.
+    /// </summary>
+    Never = 2
+}

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceApiDocumentationEndpointExposure.cs
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceApiDocumentationEndpointExposure.cs
@@ -8,11 +8,15 @@ namespace ForgeTrust.AppSurface.Web.OpenApi;
 /// while non-development hosts must opt into exposure. Use <see cref="Always"/> only when the host protects the
 /// endpoint with authentication, authorization, network controls, or another deployment boundary. This setting only
 /// controls whether AppSurface maps the endpoint; it does not add authorization by itself.
+/// Numeric values are part of the public configuration and serialization contract. Do not reorder or renumber existing
+/// members; changing these assignments can break persisted configuration, serialized payloads, and consumers. Add new
+/// modes by appending members with new explicit values.
 /// </remarks>
 public enum AppSurfaceApiDocumentationEndpointExposure
 {
     /// <summary>
-    /// Map the endpoint only when <see cref="Core.StartupContext.IsDevelopment"/> is <see langword="true"/>.
+    /// Map the endpoint only when <see cref="ForgeTrust.AppSurface.Core.StartupContext.IsDevelopment"/> is
+    /// <see langword="true"/>.
     /// </summary>
     DevelopmentOnly = 0,
 

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceWebOpenApiModule.cs
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceWebOpenApiModule.cs
@@ -95,13 +95,8 @@ public class AppSurfaceWebOpenApiModule : IAppSurfaceWebModule
         AppSurfaceApiDocumentationEndpointExposure exposure,
         StartupContext context)
     {
-        return exposure switch
-        {
-            AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly => context.IsDevelopment,
-            AppSurfaceApiDocumentationEndpointExposure.Always => true,
-            AppSurfaceApiDocumentationEndpointExposure.Never => false,
-            _ => false
-        };
+        return exposure == AppSurfaceApiDocumentationEndpointExposure.Always
+            || (exposure == AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly && context.IsDevelopment);
     }
 
     /// <summary>

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceWebOpenApiModule.cs
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceWebOpenApiModule.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace ForgeTrust.AppSurface.Web.OpenApi;
 
@@ -12,12 +13,14 @@ namespace ForgeTrust.AppSurface.Web.OpenApi;
 /// <remarks>
 /// Use <see cref="AppSurfaceWebOpenApiModule"/> when AppSurface should own the default OpenAPI service and endpoint
 /// wiring for an app. The module registers ASP.NET Core OpenAPI generation, endpoint API exploration, document and
-/// operation transformers, and maps the OpenAPI endpoint during endpoint configuration. The default document title is
+/// operation transformers, and maps the OpenAPI endpoint during endpoint configuration when
+/// <see cref="AppSurfaceWebOpenApiOptions.ExposeEndpoint"/> allows the active environment. The default document title is
 /// <c>{ApplicationName} | v1</c>, and the built-in transformers remove the framework implementation tag
 /// <c>ForgeTrust.AppSurface.Web</c> while preserving other tags. Register a custom module or add additional OpenAPI
 /// options when an application needs multiple documents, custom versioning, authentication metadata, or different tag
 /// policies. Pitfall: transformer tag collections may be null and this module must run before consumers expect the
-/// <c>MapOpenApi</c> endpoint to be mapped.
+/// <c>MapOpenApi</c> endpoint to be mapped. The production opt-in setting maps the endpoint only; hosts must still
+/// protect exposed OpenAPI documents with authorization, private networking, or another deployment boundary.
 /// </remarks>
 public class AppSurfaceWebOpenApiModule : IAppSurfaceWebModule
 {
@@ -34,6 +37,12 @@ public class AppSurfaceWebOpenApiModule : IAppSurfaceWebModule
     /// <param name="services">The service collection receiving OpenAPI and endpoint exploration registrations.</param>
     public virtual void ConfigureServices(StartupContext context, IServiceCollection services)
     {
+        services.AddOptions<AppSurfaceWebOpenApiOptions>()
+            .BindConfiguration(AppSurfaceWebOpenApiOptions.SectionName)
+            .Validate(
+                options => Enum.IsDefined(options.ExposeEndpoint),
+                $"{AppSurfaceWebOpenApiOptions.SectionName}:ExposeEndpoint must be one of DevelopmentOnly, Always, or Never.");
+
         services.AddOpenApi(options =>
         {
             options.AddDocumentTransformer((d, _, _) =>
@@ -67,13 +76,32 @@ public class AppSurfaceWebOpenApiModule : IAppSurfaceWebModule
     }
 
     /// <summary>
-    /// Maps the OpenAPI document endpoint.
+    /// Maps the OpenAPI document endpoint when <see cref="AppSurfaceWebOpenApiOptions.ExposeEndpoint"/> allows it.
     /// </summary>
     /// <param name="context">The startup context.</param>
     /// <param name="endpoints">The endpoint route builder.</param>
     public virtual void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
     {
+        var options = endpoints.ServiceProvider.GetRequiredService<IOptions<AppSurfaceWebOpenApiOptions>>().Value;
+        if (!AllowsEndpointExposure(options.ExposeEndpoint, context))
+        {
+            return;
+        }
+
         endpoints.MapOpenApi();
+    }
+
+    private static bool AllowsEndpointExposure(
+        AppSurfaceApiDocumentationEndpointExposure exposure,
+        StartupContext context)
+    {
+        return exposure switch
+        {
+            AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly => context.IsDevelopment,
+            AppSurfaceApiDocumentationEndpointExposure.Always => true,
+            AppSurfaceApiDocumentationEndpointExposure.Never => false,
+            _ => false
+        };
     }
 
     /// <summary>

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceWebOpenApiOptions.cs
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi/AppSurfaceWebOpenApiOptions.cs
@@ -1,0 +1,25 @@
+namespace ForgeTrust.AppSurface.Web.OpenApi;
+
+/// <summary>
+/// Configures AppSurface's OpenAPI endpoint mapping behavior.
+/// </summary>
+/// <remarks>
+/// The default <see cref="ExposeEndpoint"/> value keeps the generated OpenAPI document available during development
+/// while avoiding accidental production metadata exposure. Set <see cref="ExposeEndpoint"/> to
+/// <see cref="AppSurfaceApiDocumentationEndpointExposure.Always"/> only when the endpoint is intentionally available
+/// outside development and is protected by host-owned controls such as authorization, private networking, or a reverse
+/// proxy policy.
+/// </remarks>
+public sealed class AppSurfaceWebOpenApiOptions
+{
+    /// <summary>
+    /// Gets the configuration section used for AppSurface OpenAPI options.
+    /// </summary>
+    public const string SectionName = "AppSurfaceWebOpenApi";
+
+    /// <summary>
+    /// Gets or sets when the generated OpenAPI document endpoint should be mapped.
+    /// </summary>
+    public AppSurfaceApiDocumentationEndpointExposure ExposeEndpoint { get; set; } =
+        AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly;
+}

--- a/Web/ForgeTrust.AppSurface.Web.OpenApi/README.md
+++ b/Web/ForgeTrust.AppSurface.Web.OpenApi/README.md
@@ -7,7 +7,7 @@ This package provides a modular integration for OpenAPI (Swagger) document gener
 The `AppSurfaceWebOpenApiModule` simplifies the configuration of OpenAPI by:
 - Registering the necessary services via `AddOpenApi`.
 - Configuring the `EndpointsApiExplorer`.
-- Automatically mapping the OpenAPI documentation endpoints.
+- Mapping the OpenAPI documentation endpoint when endpoint exposure options allow it.
 - Providing default document and operation transformers to clean up and brand the generated documentation based on the `StartupContext`.
 
 ## Release Guidance
@@ -33,7 +33,39 @@ public class MyModule : IAppSurfaceWebModule
 ## Features
 
 - **Document Transformation**: Automatically updates the API title and tags based on the application name defined in the `StartupContext`.
-- **Automatic Endpoint Mapping**: Calls `endpoints.MapOpenApi()` for you during the endpoint configuration phase.
+- **Controlled Endpoint Mapping**: Calls `endpoints.MapOpenApi()` during endpoint configuration only when `AppSurfaceWebOpenApiOptions.ExposeEndpoint` allows the active environment.
+- **Production-Safe Default**: Maps `/openapi/{documentName}.json` in Development and hides it in non-development environments unless the host opts in.
+
+## Endpoint Exposure
+
+`AppSurfaceWebOpenApiOptions` binds from the `AppSurfaceWebOpenApi` configuration section.
+
+```json
+{
+  "AppSurfaceWebOpenApi": {
+    "ExposeEndpoint": "DevelopmentOnly"
+  }
+}
+```
+
+`ExposeEndpoint` uses `AppSurfaceApiDocumentationEndpointExposure`:
+
+- `DevelopmentOnly` (`0`): maps the OpenAPI endpoint only when `StartupContext.IsDevelopment` is `true`. This is the default.
+- `Always` (`1`): maps the endpoint in every environment.
+- `Never` (`2`): never maps the endpoint, including in Development.
+
+Use `Always` only when the host intentionally exposes API metadata and protects it with host-owned controls such as authorization, private networking, or a reverse proxy policy. AppSurface only decides whether to map the endpoint; it does not add authentication or authorization.
+
+Code-first configuration is also supported:
+
+```csharp
+services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+{
+    options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always;
+});
+```
+
+Invalid enum values fail options validation at startup when the options are read.
 
 ---
 [📂 Back to Web List](../README.md) | [🏠 Back to Root](../../README.md)

--- a/Web/ForgeTrust.AppSurface.Web.Scalar.Tests/AppSurfaceWebScalarModuleTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar.Tests/AppSurfaceWebScalarModuleTests.cs
@@ -8,8 +8,10 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace ForgeTrust.AppSurface.Web.Scalar.Tests;
 
@@ -27,29 +29,157 @@ public sealed class AppSurfaceWebScalarModuleTests
     }
 
     [Fact]
-    public async Task ConfigureEndpoints_MapsDefaultScalarApiReferenceEndpoint()
+    public void ConfigureServices_UsesDevelopmentOnlyEndpointExposureByDefault()
     {
         var module = new AppSurfaceWebScalarModule();
-        var builder = WebApplication.CreateBuilder();
-        await using var app = builder.Build();
+        var services = CreateServicesWithConfiguration();
 
-        module.ConfigureEndpoints(CreateContext(module), app);
+        module.ConfigureServices(CreateContext(module, Environments.Development), services);
 
-        var routeEndpoints = ((IEndpointRouteBuilder)app)
-            .DataSources
-            .SelectMany(dataSource => dataSource.Endpoints)
-            .OfType<RouteEndpoint>();
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AppSurfaceWebScalarOptions>>().Value;
 
-        Assert.Contains(
-            routeEndpoints,
-            endpoint => endpoint.RoutePattern.RawText?.StartsWith("/scalar", StringComparison.Ordinal) == true);
+        Assert.Equal(AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, options.ExposeEndpoint);
+    }
+
+    [Fact]
+    public void ConfigureServices_BindsEndpointExposureFromConfiguration()
+    {
+        var module = new AppSurfaceWebScalarModule();
+        var services = CreateServicesWithConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AppSurfaceWebScalarOptions.SectionName}:ExposeEndpoint"] = "Always"
+        });
+
+        module.ConfigureServices(CreateContext(module, Environments.Production), services);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AppSurfaceWebScalarOptions>>().Value;
+
+        Assert.Equal(AppSurfaceApiDocumentationEndpointExposure.Always, options.ExposeEndpoint);
+    }
+
+    [Fact]
+    public void ConfigureServices_AppliesCodeFirstEndpointExposureOverrides()
+    {
+        var module = new AppSurfaceWebScalarModule();
+        var services = CreateServicesWithConfiguration();
+
+        module.ConfigureServices(CreateContext(module, Environments.Development), services);
+        services.Configure<AppSurfaceWebScalarOptions>(options =>
+            options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Never);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AppSurfaceWebScalarOptions>>().Value;
+
+        Assert.Equal(AppSurfaceApiDocumentationEndpointExposure.Never, options.ExposeEndpoint);
+    }
+
+    [Fact]
+    public void ConfigureServices_RejectsInvalidEndpointExposureValues()
+    {
+        var module = new AppSurfaceWebScalarModule();
+        var services = CreateServicesWithConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AppSurfaceWebScalarOptions.SectionName}:ExposeEndpoint"] = "99"
+        });
+
+        module.ConfigureServices(CreateContext(module, Environments.Development), services);
+
+        using var provider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService<IOptions<AppSurfaceWebScalarOptions>>().Value);
+
+        Assert.Contains($"{AppSurfaceWebScalarOptions.SectionName}:ExposeEndpoint", exception.Message);
+        Assert.Contains(nameof(AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly), exception.Message);
+        Assert.Contains(nameof(AppSurfaceApiDocumentationEndpointExposure.Always), exception.Message);
+        Assert.Contains(nameof(AppSurfaceApiDocumentationEndpointExposure.Never), exception.Message);
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_MapsDefaultScalarApiReferenceEndpointInDevelopment()
+    {
+        var routePatterns = await GetMappedDocumentationRoutePatternsAsync(
+            CreateContext(new AppSurfaceWebScalarModule(), Environments.Development));
+
+        Assert.Contains(routePatterns, pattern => pattern.StartsWith("/scalar", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_DoesNotMapDefaultScalarApiReferenceEndpointOutsideDevelopment()
+    {
+        var routePatterns = await GetMappedDocumentationRoutePatternsAsync(
+            CreateContext(new AppSurfaceWebScalarModule(), Environments.Production));
+
+        Assert.DoesNotContain(routePatterns, pattern => pattern.StartsWith("/scalar", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_MapsScalarOutsideDevelopmentWhenScalarAndOpenApiExposureAreAlways()
+    {
+        var routePatterns = await GetMappedDocumentationRoutePatternsAsync(
+            CreateContext(new AppSurfaceWebScalarModule(), Environments.Production),
+            services =>
+            {
+                services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+                    options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always);
+                services.Configure<AppSurfaceWebScalarOptions>(options =>
+                    options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always);
+            });
+
+        Assert.Contains("/openapi/{documentName}.json", routePatterns);
+        Assert.Contains(routePatterns, pattern => pattern.StartsWith("/scalar", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, AppSurfaceApiDocumentationEndpointExposure.Always, false, false)]
+    [InlineData(AppSurfaceApiDocumentationEndpointExposure.Always, AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, true, false)]
+    [InlineData(AppSurfaceApiDocumentationEndpointExposure.Never, AppSurfaceApiDocumentationEndpointExposure.Always, false, false)]
+    [InlineData(AppSurfaceApiDocumentationEndpointExposure.Always, AppSurfaceApiDocumentationEndpointExposure.Never, true, false)]
+    public async Task ConfigureEndpoints_RequiresScalarAndOpenApiExposureOutsideDevelopment(
+        AppSurfaceApiDocumentationEndpointExposure openApiExposure,
+        AppSurfaceApiDocumentationEndpointExposure scalarExposure,
+        bool expectedOpenApiMapped,
+        bool expectedScalarMapped)
+    {
+        var routePatterns = await GetMappedDocumentationRoutePatternsAsync(
+            CreateContext(new AppSurfaceWebScalarModule(), Environments.Production),
+            services =>
+            {
+                services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+                    options.ExposeEndpoint = openApiExposure);
+                services.Configure<AppSurfaceWebScalarOptions>(options =>
+                    options.ExposeEndpoint = scalarExposure);
+            });
+
+        Assert.Equal(expectedOpenApiMapped, routePatterns.Contains("/openapi/{documentName}.json"));
+        Assert.Equal(
+            expectedScalarMapped,
+            routePatterns.Any(pattern => pattern.StartsWith("/scalar", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task ConfigureEndpoints_DoesNotMapOpenApiEndpointItself()
+    {
+        var routePatterns = await GetMappedScalarOnlyRoutePatternsAsync(
+            CreateContext(new AppSurfaceWebScalarModule(), Environments.Production),
+            services =>
+            {
+                services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+                    options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always);
+                services.Configure<AppSurfaceWebScalarOptions>(options =>
+                    options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always);
+            });
+
+        Assert.DoesNotContain("/openapi/{documentName}.json", routePatterns);
+        Assert.Contains(routePatterns, pattern => pattern.StartsWith("/scalar", StringComparison.Ordinal));
     }
 
     [Fact]
     public async Task NoOpLifecycleMethods_AreSafeToCallWithNormalInputs()
     {
         var module = new AppSurfaceWebScalarModule();
-        var context = CreateContext(module);
+        var context = CreateContext(module, Environments.Development);
         var services = new ServiceCollection();
         var hostBuilder = Host.CreateDefaultBuilder();
         var appBuilder = WebApplication.CreateBuilder();
@@ -81,7 +211,7 @@ public sealed class AppSurfaceWebScalarModuleTests
             };
         });
 
-        var context = CreateContext(module);
+        var context = CreateContext(module, Environments.Development);
         var builder = ((IAppSurfaceStartup)startup).CreateHostBuilder(context);
         builder.ConfigureWebHost(webHost => webHost.UseUrls("http://127.0.0.1:0"));
 
@@ -119,8 +249,99 @@ public sealed class AppSurfaceWebScalarModuleTests
         }
     }
 
+    [Fact]
+    public async Task AppSurfaceWebApp_HidesScalarAndOpenApiEndpointsOutsideDevelopmentByDefault()
+    {
+        var module = new AppSurfaceWebScalarModule();
+        var startup = new TestScalarStartup();
+        var context = CreateContext(module, Environments.Production);
+        var builder = ((IAppSurfaceStartup)startup).CreateHostBuilder(context);
+        builder.ConfigureWebHost(webHost => webHost.UseUrls("http://127.0.0.1:0"));
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        try
+        {
+            using var client = new HttpClient
+            {
+                BaseAddress = new Uri(GetBaseAddress(host))
+            };
+
+            using var openApiResponse = await client.GetAsync("/openapi/v1.json");
+            using var scalarResponse = await client.GetAsync("/scalar/");
+
+            Assert.Equal(HttpStatusCode.NotFound, openApiResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, scalarResponse.StatusCode);
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+
     private static StartupContext CreateContext(AppSurfaceWebScalarModule module) =>
-        new([], module, "ScalarTestApp");
+        CreateContext(module, Environments.Production);
+
+    private static StartupContext CreateContext(AppSurfaceWebScalarModule module, string environment) =>
+        new(["--environment", environment], module, "ScalarTestApp");
+
+    private static ServiceCollection CreateServicesWithConfiguration(
+        Dictionary<string, string?>? configurationValues = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationValues ?? new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+
+        return services;
+    }
+
+    private static async Task<string[]> GetMappedDocumentationRoutePatternsAsync(
+        StartupContext context,
+        Action<IServiceCollection>? configureServices = null)
+    {
+        var openApiModule = new AppSurfaceWebOpenApiModule();
+        var scalarModule = new AppSurfaceWebScalarModule();
+        var builder = WebApplication.CreateBuilder();
+        openApiModule.ConfigureServices(context, builder.Services);
+        scalarModule.ConfigureServices(context, builder.Services);
+        configureServices?.Invoke(builder.Services);
+        await using var app = builder.Build();
+
+        openApiModule.ConfigureEndpoints(context, app);
+        scalarModule.ConfigureEndpoints(context, app);
+
+        return GetRoutePatterns(app);
+    }
+
+    private static async Task<string[]> GetMappedScalarOnlyRoutePatternsAsync(
+        StartupContext context,
+        Action<IServiceCollection>? configureServices = null)
+    {
+        var openApiModule = new AppSurfaceWebOpenApiModule();
+        var scalarModule = new AppSurfaceWebScalarModule();
+        var builder = WebApplication.CreateBuilder();
+        openApiModule.ConfigureServices(context, builder.Services);
+        scalarModule.ConfigureServices(context, builder.Services);
+        configureServices?.Invoke(builder.Services);
+        await using var app = builder.Build();
+
+        scalarModule.ConfigureEndpoints(context, app);
+
+        return GetRoutePatterns(app);
+    }
+
+    private static string[] GetRoutePatterns(IEndpointRouteBuilder endpoints) =>
+        endpoints
+            .DataSources
+            .SelectMany(dataSource => dataSource.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(endpoint => endpoint.RoutePattern.RawText)
+            .OfType<string>()
+            .ToArray();
 
     private static string GetBaseAddress(IHost host)
     {

--- a/Web/ForgeTrust.AppSurface.Web.Scalar.Tests/AppSurfaceWebScalarModuleTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar.Tests/AppSurfaceWebScalarModuleTests.cs
@@ -132,18 +132,23 @@ public sealed class AppSurfaceWebScalarModuleTests
     }
 
     [Theory]
-    [InlineData(AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, AppSurfaceApiDocumentationEndpointExposure.Always, false, false)]
-    [InlineData(AppSurfaceApiDocumentationEndpointExposure.Always, AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, true, false)]
-    [InlineData(AppSurfaceApiDocumentationEndpointExposure.Never, AppSurfaceApiDocumentationEndpointExposure.Always, false, false)]
-    [InlineData(AppSurfaceApiDocumentationEndpointExposure.Always, AppSurfaceApiDocumentationEndpointExposure.Never, true, false)]
-    public async Task ConfigureEndpoints_RequiresScalarAndOpenApiExposureOutsideDevelopment(
+    [InlineData("Development", AppSurfaceApiDocumentationEndpointExposure.Always, AppSurfaceApiDocumentationEndpointExposure.Never, true, false)]
+    [InlineData("Development", AppSurfaceApiDocumentationEndpointExposure.Never, AppSurfaceApiDocumentationEndpointExposure.Always, false, false)]
+    [InlineData("Development", AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, AppSurfaceApiDocumentationEndpointExposure.Never, true, false)]
+    [InlineData("Development", AppSurfaceApiDocumentationEndpointExposure.Never, AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, false, false)]
+    [InlineData("Production", AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, AppSurfaceApiDocumentationEndpointExposure.Always, false, false)]
+    [InlineData("Production", AppSurfaceApiDocumentationEndpointExposure.Always, AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly, true, false)]
+    [InlineData("Production", AppSurfaceApiDocumentationEndpointExposure.Never, AppSurfaceApiDocumentationEndpointExposure.Always, false, false)]
+    [InlineData("Production", AppSurfaceApiDocumentationEndpointExposure.Always, AppSurfaceApiDocumentationEndpointExposure.Never, true, false)]
+    public async Task ConfigureEndpoints_RequiresScalarAndOpenApiExposureInCurrentEnvironment(
+        string environment,
         AppSurfaceApiDocumentationEndpointExposure openApiExposure,
         AppSurfaceApiDocumentationEndpointExposure scalarExposure,
         bool expectedOpenApiMapped,
         bool expectedScalarMapped)
     {
         var routePatterns = await GetMappedDocumentationRoutePatternsAsync(
-            CreateContext(new AppSurfaceWebScalarModule(), Environments.Production),
+            CreateContext(new AppSurfaceWebScalarModule(), environment),
             services =>
             {
                 services.Configure<AppSurfaceWebOpenApiOptions>(options =>

--- a/Web/ForgeTrust.AppSurface.Web.Scalar/AppSurfaceWebScalarModule.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar/AppSurfaceWebScalarModule.cs
@@ -64,13 +64,8 @@ public class AppSurfaceWebScalarModule : IAppSurfaceWebModule
         AppSurfaceApiDocumentationEndpointExposure exposure,
         StartupContext context)
     {
-        return exposure switch
-        {
-            AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly => context.IsDevelopment,
-            AppSurfaceApiDocumentationEndpointExposure.Always => true,
-            AppSurfaceApiDocumentationEndpointExposure.Never => false,
-            _ => false
-        };
+        return exposure == AppSurfaceApiDocumentationEndpointExposure.Always
+            || (exposure == AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly && context.IsDevelopment);
     }
 
     /// <summary>

--- a/Web/ForgeTrust.AppSurface.Web.Scalar/AppSurfaceWebScalarModule.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar/AppSurfaceWebScalarModule.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
 
 namespace ForgeTrust.AppSurface.Web.Scalar;
@@ -11,15 +12,25 @@ namespace ForgeTrust.AppSurface.Web.Scalar;
 /// <summary>
 /// A web module that integrates Scalar API reference documentation into the application.
 /// </summary>
+/// <remarks>
+/// The Scalar UI is available in development by default and hidden in non-development environments unless both Scalar
+/// and the AppSurface-owned OpenAPI document are explicitly exposed. Exposing Scalar does not add authentication or
+/// authorization; production hosts must protect the route separately when it is reachable by untrusted users.
+/// </remarks>
 public class AppSurfaceWebScalarModule : IAppSurfaceWebModule
 {
     /// <summary>
-    /// Configures services needed for Scalar; currently no implementation is required.
+    /// Configures services needed for Scalar, including endpoint exposure options.
     /// </summary>
     /// <param name="context">The startup context.</param>
     /// <param name="services">The service collection.</param>
     public void ConfigureServices(StartupContext context, IServiceCollection services)
     {
+        services.AddOptions<AppSurfaceWebScalarOptions>()
+            .BindConfiguration(AppSurfaceWebScalarOptions.SectionName)
+            .Validate(
+                options => Enum.IsDefined(options.ExposeEndpoint),
+                $"{AppSurfaceWebScalarOptions.SectionName}:ExposeEndpoint must be one of DevelopmentOnly, Always, or Never.");
     }
 
     /// <summary>
@@ -32,13 +43,34 @@ public class AppSurfaceWebScalarModule : IAppSurfaceWebModule
     }
 
     /// <summary>
-    /// Maps the Scalar API reference endpoint.
+    /// Maps the Scalar API reference endpoint when Scalar and OpenAPI exposure options both allow it.
     /// </summary>
     /// <param name="context">The startup context.</param>
     /// <param name="endpoints">The endpoint route builder.</param>
     public void ConfigureEndpoints(StartupContext context, IEndpointRouteBuilder endpoints)
     {
+        var scalarOptions = endpoints.ServiceProvider.GetRequiredService<IOptions<AppSurfaceWebScalarOptions>>().Value;
+        var openApiOptions = endpoints.ServiceProvider.GetRequiredService<IOptions<AppSurfaceWebOpenApiOptions>>().Value;
+        if (!AllowsEndpointExposure(scalarOptions.ExposeEndpoint, context)
+            || !AllowsEndpointExposure(openApiOptions.ExposeEndpoint, context))
+        {
+            return;
+        }
+
         endpoints.MapScalarApiReference();
+    }
+
+    private static bool AllowsEndpointExposure(
+        AppSurfaceApiDocumentationEndpointExposure exposure,
+        StartupContext context)
+    {
+        return exposure switch
+        {
+            AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly => context.IsDevelopment,
+            AppSurfaceApiDocumentationEndpointExposure.Always => true,
+            AppSurfaceApiDocumentationEndpointExposure.Never => false,
+            _ => false
+        };
     }
 
     /// <summary>

--- a/Web/ForgeTrust.AppSurface.Web.Scalar/AppSurfaceWebScalarOptions.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar/AppSurfaceWebScalarOptions.cs
@@ -1,0 +1,25 @@
+using ForgeTrust.AppSurface.Web.OpenApi;
+
+namespace ForgeTrust.AppSurface.Web.Scalar;
+
+/// <summary>
+/// Configures AppSurface's Scalar API reference endpoint mapping behavior.
+/// </summary>
+/// <remarks>
+/// Scalar depends on the AppSurface-owned OpenAPI document in the default integration. The Scalar UI is mapped only
+/// when this option allows Scalar exposure and <see cref="AppSurfaceWebOpenApiOptions.ExposeEndpoint"/> also allows the
+/// backing OpenAPI endpoint in the same environment. This option does not add authentication or authorization.
+/// </remarks>
+public sealed class AppSurfaceWebScalarOptions
+{
+    /// <summary>
+    /// Gets the configuration section used for AppSurface Scalar options.
+    /// </summary>
+    public const string SectionName = "AppSurfaceWebScalar";
+
+    /// <summary>
+    /// Gets or sets when the Scalar API reference endpoint should be mapped.
+    /// </summary>
+    public AppSurfaceApiDocumentationEndpointExposure ExposeEndpoint { get; set; } =
+        AppSurfaceApiDocumentationEndpointExposure.DevelopmentOnly;
+}

--- a/Web/ForgeTrust.AppSurface.Web.Scalar/README.md
+++ b/Web/ForgeTrust.AppSurface.Web.Scalar/README.md
@@ -4,7 +4,7 @@ This package integrates the [Scalar](https://scalar.com/) API Reference UI into 
 
 ## Overview
 
-The `AppSurfaceWebScalarModule` provides a modern, interactive API documentation interface. It depends on `ForgeTrust.AppSurface.Web.OpenApi` and automatically configures everything needed to serve the Scalar UI.
+The `AppSurfaceWebScalarModule` provides a modern, interactive API documentation interface. It depends on `ForgeTrust.AppSurface.Web.OpenApi` and maps the Scalar UI when Scalar exposure options and the AppSurface-owned OpenAPI endpoint exposure both allow the active environment.
 
 ## Release Guidance
 
@@ -29,8 +29,60 @@ public class MyModule : IAppSurfaceWebModule
 ## Features
 
 - **Built-in Dependency**: Automatically registers the `AppSurfaceWebOpenApiModule`.
-- **Automatic UI Mapping**: Maps the Scalar API reference endpoint using `MapScalarApiReference()`.
-- **Zero Config**: Works out of the box with the default AppSurface startup pipeline.
+- **Controlled UI Mapping**: Maps the Scalar API reference endpoint using `MapScalarApiReference()` only when exposure options allow it.
+- **OpenAPI-Aware Gate**: Requires the AppSurface-owned OpenAPI endpoint to be exposed in the same environment. Scalar never calls `MapOpenApi()` itself.
+- **Production-Safe Default**: Maps Scalar in Development and hides it in non-development environments unless the host opts in.
+
+## Endpoint Exposure
+
+`AppSurfaceWebScalarOptions` binds from the `AppSurfaceWebScalar` configuration section.
+
+```json
+{
+  "AppSurfaceWebScalar": {
+    "ExposeEndpoint": "DevelopmentOnly"
+  }
+}
+```
+
+`ExposeEndpoint` uses `AppSurfaceApiDocumentationEndpointExposure` from `ForgeTrust.AppSurface.Web.OpenApi`:
+
+- `DevelopmentOnly` (`0`): maps Scalar only when `StartupContext.IsDevelopment` is `true`. This is the default.
+- `Always` (`1`): allows Scalar in every environment, subject to OpenAPI exposure also being allowed.
+- `Never` (`2`): never maps Scalar, including in Development.
+
+For production exposure, opt into both Scalar and OpenAPI:
+
+```json
+{
+  "AppSurfaceWebOpenApi": {
+    "ExposeEndpoint": "Always"
+  },
+  "AppSurfaceWebScalar": {
+    "ExposeEndpoint": "Always"
+  }
+}
+```
+
+If Scalar is `Always` but OpenAPI remains `DevelopmentOnly` in Production, neither the Scalar UI nor the AppSurface-owned OpenAPI endpoint is available through the default module composition. If OpenAPI is `Always` but Scalar is `DevelopmentOnly`, the OpenAPI document is available and Scalar stays hidden.
+
+Use `Always` only when the host intentionally exposes API documentation and protects it with host-owned controls such as authorization, private networking, or a reverse proxy policy. AppSurface only decides whether to map endpoints; it does not add authentication or authorization.
+
+Code-first configuration is also supported:
+
+```csharp
+services.Configure<AppSurfaceWebOpenApiOptions>(options =>
+{
+    options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always;
+});
+
+services.Configure<AppSurfaceWebScalarOptions>(options =>
+{
+    options.ExposeEndpoint = AppSurfaceApiDocumentationEndpointExposure.Always;
+});
+```
+
+Invalid enum values fail options validation at startup when the options are read.
 
 ---
 [📂 Back to Web List](../README.md) | [🏠 Back to Root](../../README.md)

--- a/Web/README.md
+++ b/Web/README.md
@@ -7,11 +7,11 @@ Need install guidance first? Start with the [AppSurface v0.1 package chooser](..
 ## Contents
 
 - [**ForgeTrust.AppSurface.Web**](./ForgeTrust.AppSurface.Web/README.md) – The core web bootstrapping library, including conventional browser status pages and opt-in production 500 pages.
-- [**ForgeTrust.AppSurface.Web.OpenApi**](./ForgeTrust.AppSurface.Web.OpenApi/README.md) – Modular OpenAPI generation.
+- [**ForgeTrust.AppSurface.Web.OpenApi**](./ForgeTrust.AppSurface.Web.OpenApi/README.md) – Modular OpenAPI generation with development-only endpoint exposure by default.
 - [**ForgeTrust.AppSurface.Docs**](./ForgeTrust.AppSurface.Docs/README.md) – Reusable docs package for harvesting and serving repository documentation.
 - [**ForgeTrust.AppSurface.Docs.Standalone**](./ForgeTrust.AppSurface.Docs.Standalone/README.md) – AppSurface host for exporting and serving AppSurface Docs.
 - [**ForgeTrust.RazorWire**](./ForgeTrust.RazorWire/README.md) – Reactive web components, real-time streaming, CDN-default static export, and convention-based failed form UX.
-- [**ForgeTrust.AppSurface.Web.Scalar**](./ForgeTrust.AppSurface.Web.Scalar/README.md) – Scalar API Reference UI integration.
+- [**ForgeTrust.AppSurface.Web.Scalar**](./ForgeTrust.AppSurface.Web.Scalar/README.md) – Scalar API Reference UI integration gated by Scalar and OpenAPI endpoint exposure.
 - `ForgeTrust.AppSurface.Web.Tests` – Test suite for web components.
 
 ## JavaScript workspace

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -56,6 +56,7 @@ AppSurface is putting the release contract in place before `v0.1.0`. This slice 
 - RazorWire CLI users who still want extensionless, server-routed export output should pass `--mode hybrid`. The default `cdn` mode is for plain static hosts and CDNs, not S3-specific infrastructure.
 - PackageIndex now has a real `--help`/`-h` surface that exits successfully, describes its commands and options, and reports unknown commands before printing usage.
 - AppSurface docs preview now defaults to the Development host environment when no `--environment` is supplied, so local `appsurface docs` runs with no configured endpoint use the deterministic per-workspace localhost port instead of falling through to Kestrel's port `5000` default.
+- AppSurface-owned OpenAPI and Scalar endpoints now use production exposure gates. OpenAPI and Scalar remain zero-configuration in Development, but non-development hosts must opt in with `AppSurfaceWebOpenApi:ExposeEndpoint=Always` and, for Scalar, `AppSurfaceWebScalar:ExposeEndpoint=Always`. Scalar also requires the AppSurface-owned OpenAPI endpoint to be exposed and never maps OpenAPI on its own.
 
 ### Core diagnostics
 
@@ -203,6 +204,7 @@ There is no tagged migration guide yet because AppSurface has not cut `v0.1.0`. 
 - AppSurface Docs authors should migrate flat `featured_pages` metadata to `featured_page_groups`. The old field is ignored and logs a warning; each group needs at least `label` or `intent`, plus a `pages` list containing the existing `question`, `path`, `supporting_copy`, and `order` entries.
 - Code that previously read `IHostEnvironment.ApplicationName` to recover a custom AppSurface display label should read `StartupContext.ApplicationName` instead. `IHostEnvironment.ApplicationName` now stays aligned with the host entry-assembly identity used for static web asset discovery unless `StartupContext.OverrideEntryPointAssembly` explicitly selects a different manifest identity. `StartupContext.EntryPointAssembly` still defaults to the root module assembly for command/controller/component discovery, so existing cross-assembly scanning behavior remains stable.
 - Web apps with custom conventional 404 views should change `@model ForgeTrust.AppSurface.Web.NotFoundPageModel` to `@model ForgeTrust.AppSurface.Web.BrowserStatusPageModel`. The old 404-only options API names have moved to `BrowserStatusPage*` names before `v0.1.0`; conventional production `500` exception pages now ship as the opt-in fix for issue #224.
+- Web apps that intentionally exposed AppSurface-owned OpenAPI or Scalar routes outside Development should set `AppSurfaceWebOpenApi:ExposeEndpoint=Always` and, when using Scalar, `AppSurfaceWebScalar:ExposeEndpoint=Always`. The new setting only controls endpoint mapping; apps still need host-owned authorization, private networking, or reverse-proxy protection for public environments.
 
 ## Proof artifacts
 


### PR DESCRIPTION
## Summary
- add public OpenAPI/Scalar endpoint exposure options with development-only defaults
- gate OpenAPI mapping by environment/config and gate Scalar on both Scalar and AppSurface-owned OpenAPI exposure
- document production opt-in behavior and host-owned protection responsibilities

Fixes #376

## QA
- /qa browser pass against examples/web-app: development defaults expose OpenAPI/Scalar, production defaults hide both, production Always exposes both, mismatch configs behave as expected
- dotnet test Web/ForgeTrust.AppSurface.Web.OpenApi.Tests/ForgeTrust.AppSurface.Web.OpenApi.Tests.csproj --no-restore
- dotnet test Web/ForgeTrust.AppSurface.Web.Scalar.Tests/ForgeTrust.AppSurface.Web.Scalar.Tests.csproj --no-restore