### PR TITLE
fix: harden RazorWire stream cleanup

### DIFF
--- a/Web/ForgeTrust.RazorWire.Tests/InMemoryRazorWireStreamHubTests.cs
+++ b/Web/ForgeTrust.RazorWire.Tests/InMemoryRazorWireStreamHubTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Channels;
 using ForgeTrust.RazorWire.Streams;
 
 namespace ForgeTrust.RazorWire.Tests;
@@ -43,6 +44,73 @@ public class InMemoryRazorWireStreamHubTests
     }
 
     [Fact]
+    public void Unsubscribe_RemovesEmptyLiveChannelState_ForManyUniqueChannels()
+    {
+        // Arrange
+        var hub = new InMemoryRazorWireStreamHub();
+
+        // Act
+        for (var index = 0; index < 300; index++)
+        {
+            var channel = $"orders-{index}";
+            var reader = hub.Subscribe(channel);
+            hub.Unsubscribe(channel, reader);
+        }
+
+        // Assert
+        var diagnostics = hub.GetDiagnostics();
+        Assert.Equal(0, diagnostics.LiveChannelCount);
+        Assert.Equal(0, diagnostics.LiveSubscriberCount);
+        Assert.Equal(0, diagnostics.SubscriptionCount);
+    }
+
+    [Fact]
+    public async Task Unsubscribe_WithWrongChannel_RemovesRecordedSubscription()
+    {
+        // Arrange
+        var hub = new InMemoryRazorWireStreamHub();
+        var reader = hub.Subscribe("orders");
+
+        // Act
+        hub.Unsubscribe("not-orders", reader);
+        await hub.PublishAsync("orders", "ignored");
+
+        // Assert
+        var waitTask = reader.WaitToReadAsync().AsTask();
+        var completed = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(1)));
+        Assert.Same(waitTask, completed);
+        Assert.False(await waitTask);
+
+        var diagnostics = hub.GetDiagnostics();
+        Assert.Equal(0, diagnostics.LiveChannelCount);
+        Assert.Equal(0, diagnostics.LiveSubscriberCount);
+        Assert.Equal(0, diagnostics.SubscriptionCount);
+    }
+
+    [Fact]
+    public async Task PublishAsync_PrunesClosedWriterAndRemovesEmptyLiveChannel()
+    {
+        // Arrange
+        var hub = new InMemoryRazorWireStreamHub();
+        var reader = hub.Subscribe("orders");
+        Assert.True(hub.TryCompleteSubscriberWriterForTesting(reader));
+
+        // Act
+        await hub.PublishAsync("orders", "ignored");
+
+        // Assert
+        var waitTask = reader.WaitToReadAsync().AsTask();
+        var completed = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(1)));
+        Assert.Same(waitTask, completed);
+        Assert.False(await waitTask);
+
+        var diagnostics = hub.GetDiagnostics();
+        Assert.Equal(0, diagnostics.LiveChannelCount);
+        Assert.Equal(0, diagnostics.LiveSubscriberCount);
+        Assert.Equal(0, diagnostics.SubscriptionCount);
+    }
+
+    [Fact]
     public async Task PublishAsync_WithNoSubscribers_CompletesWithoutErrors()
     {
         // Arrange
@@ -83,6 +151,28 @@ public class InMemoryRazorWireStreamHubTests
     }
 
     [Fact]
+    public void Subscribe_WithReplayAcrossUniqueEmptyChannels_DoesNotRetainReplayState()
+    {
+        // Arrange
+        var hub = new InMemoryRazorWireStreamHub();
+
+        // Act
+        for (var index = 0; index < 300; index++)
+        {
+            var channel = $"orders-{index}";
+            var reader = hub.Subscribe(channel, new RazorWireStreamSubscribeOptions { Replay = true });
+            hub.Unsubscribe(channel, reader);
+        }
+
+        // Assert
+        var diagnostics = hub.GetDiagnostics();
+        Assert.Equal(0, diagnostics.LiveChannelCount);
+        Assert.Equal(0, diagnostics.LiveSubscriberCount);
+        Assert.Equal(0, diagnostics.SubscriptionCount);
+        Assert.Equal(0, diagnostics.ReplayChannelCount);
+    }
+
+    [Fact]
     public async Task PublishAsync_WithReplay_PrunesOldInactiveReplayChannels()
     {
         var hub = new InMemoryRazorWireStreamHub();
@@ -101,5 +191,168 @@ public class InMemoryRazorWireStreamHubTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         Assert.Equal("live", await prunedReader.ReadAsync(cts.Token));
         Assert.Equal("retained-259", await retainedReader.ReadAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithReplay_PrunesInactiveChannels_WhenOldestChannelsAreActive()
+    {
+        var hub = new InMemoryRazorWireStreamHub();
+        var activeReaders = new List<ChannelReader<string>>();
+        for (var index = 0; index < 20; index++)
+        {
+            await hub.PublishAsync(
+                $"orders-{index}",
+                $"retained-{index}",
+                new RazorWireStreamPublishOptions { Replay = true });
+            activeReaders.Add(hub.Subscribe($"orders-{index}", new RazorWireStreamSubscribeOptions { Replay = true }));
+        }
+
+        for (var index = 20; index < 270; index++)
+        {
+            await hub.PublishAsync(
+                $"orders-{index}",
+                $"retained-{index}",
+                new RazorWireStreamPublishOptions { Replay = true });
+        }
+
+        var diagnostics = hub.GetDiagnostics();
+        Assert.Equal(256, diagnostics.ReplayChannelCount);
+
+        var activeReplayReader = hub.Subscribe("orders-0", new RazorWireStreamSubscribeOptions { Replay = true });
+        var inactivePrunedReader = hub.Subscribe("orders-20", new RazorWireStreamSubscribeOptions { Replay = true });
+        await hub.PublishAsync("orders-20", "live");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        Assert.Equal("retained-0", await activeReplayReader.ReadAsync(cts.Token));
+        Assert.Equal("live", await inactivePrunedReader.ReadAsync(cts.Token));
+
+        foreach (var activeReader in activeReaders)
+        {
+            hub.Unsubscribe("orders", activeReader);
+        }
+
+        hub.Unsubscribe("orders-0", activeReplayReader);
+        hub.Unsubscribe("orders-20", inactivePrunedReader);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithReplay_DoesNotRemoveCandidateRepublishedDuringPrune()
+    {
+        var hub = new InMemoryRazorWireStreamHub();
+        await hub.PublishAsync("orders-0", "old", new RazorWireStreamPublishOptions { Replay = true });
+
+        var republished = 0;
+        hub.BeforeReplayPruneCandidateForTesting = channel =>
+        {
+            if (channel == "orders-0" && Interlocked.Exchange(ref republished, 1) == 0)
+            {
+                hub.PublishAsync("orders-0", "new", new RazorWireStreamPublishOptions { Replay = true })
+                    .AsTask()
+                    .GetAwaiter()
+                    .GetResult();
+            }
+        };
+
+        for (var index = 1; index <= 256; index++)
+        {
+            await hub.PublishAsync(
+                $"orders-{index}",
+                $"retained-{index}",
+                new RazorWireStreamPublishOptions { Replay = true });
+        }
+
+        hub.BeforeReplayPruneCandidateForTesting = null;
+
+        var replayReader = hub.Subscribe("orders-0", new RazorWireStreamSubscribeOptions { Replay = true });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        Assert.Equal("old", await replayReader.ReadAsync(cts.Token));
+        Assert.Equal("new", await replayReader.ReadAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithReplay_DoesNotPruneActiveReplayChannel()
+    {
+        var hub = new InMemoryRazorWireStreamHub();
+        await hub.PublishAsync("orders-0", "retained-0", new RazorWireStreamPublishOptions { Replay = true });
+        var activeReader = hub.Subscribe("orders-0", new RazorWireStreamSubscribeOptions { Replay = true });
+
+        using var activeCts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        Assert.Equal("retained-0", await activeReader.ReadAsync(activeCts.Token));
+
+        for (var index = 1; index < 260; index++)
+        {
+            await hub.PublishAsync(
+                $"orders-{index}",
+                $"retained-{index}",
+                new RazorWireStreamPublishOptions { Replay = true });
+        }
+
+        var lateReader = hub.Subscribe("orders-0", new RazorWireStreamSubscribeOptions { Replay = true });
+
+        using var lateCts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        Assert.Equal("retained-0", await lateReader.ReadAsync(lateCts.Token));
+
+        hub.Unsubscribe("orders-0", activeReader);
+        hub.Unsubscribe("orders-0", lateReader);
+    }
+
+    [Fact]
+    public async Task Unsubscribe_DoesNotClearReplayBuffer()
+    {
+        var hub = new InMemoryRazorWireStreamHub();
+        await hub.PublishAsync("orders", "retained", new RazorWireStreamPublishOptions { Replay = true });
+        var liveReader = hub.Subscribe("orders");
+
+        hub.Unsubscribe("orders", liveReader);
+
+        var diagnostics = hub.GetDiagnostics();
+        Assert.Equal(0, diagnostics.LiveChannelCount);
+        Assert.Equal(1, diagnostics.ReplayChannelCount);
+
+        var replayReader = hub.Subscribe("orders", new RazorWireStreamSubscribeOptions { Replay = true });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        Assert.Equal("retained", await replayReader.ReadAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task Subscribe_DuringLiveChannelRetirement_DoesNotOrphanNewSubscriber()
+    {
+        var hub = new InMemoryRazorWireStreamHub();
+        using var retired = new ManualResetEventSlim();
+        using var releaseCleanup = new ManualResetEventSlim();
+        var hookCalls = 0;
+        hub.AfterLiveChannelRetiredForTesting = () =>
+        {
+            if (Interlocked.Increment(ref hookCalls) != 1)
+            {
+                return;
+            }
+
+            retired.Set();
+            Assert.True(releaseCleanup.Wait(TimeSpan.FromSeconds(5)));
+        };
+
+        var firstReader = hub.Subscribe("orders");
+        var unsubscribeTask = Task.Run(() => hub.Unsubscribe("orders", firstReader));
+        Assert.True(retired.Wait(TimeSpan.FromSeconds(5)));
+
+        var secondReader = hub.Subscribe("orders");
+        releaseCleanup.Set();
+        await unsubscribeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        hub.AfterLiveChannelRetiredForTesting = null;
+
+        await hub.PublishAsync("orders", "live");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        Assert.Equal("live", await secondReader.ReadAsync(cts.Token));
+
+        hub.Unsubscribe("orders", secondReader);
+
+        var diagnostics = hub.GetDiagnostics();
+        Assert.Equal(0, diagnostics.LiveChannelCount);
+        Assert.Equal(0, diagnostics.LiveSubscriberCount);
+        Assert.Equal(0, diagnostics.SubscriptionCount);
     }
 }

--- a/Web/ForgeTrust.RazorWire/README.md
+++ b/Web/ForgeTrust.RazorWire/README.md
@@ -158,7 +158,8 @@ services.AddRazorWire(options =>
 });
 ```
 
-Stream subscriptions are denied by default. Choose `AllowAll` only for public/demo streams:
+Stream subscriptions are denied by default. Choose `AllowAll` only for public/demo streams. Public channels should use
+validated, intentionally namespaced channel names so arbitrary client input cannot fan out into unlimited channel names:
 
 ```csharp
 services.AddRazorWire(options =>
@@ -204,6 +205,8 @@ RazorWire can push Turbo Stream updates to one or more clients over Server-Sent 
 
 RazorWire can also send a narrow same-origin visit command with `Visit(...)`. Visit streams are one-shot navigation commands, not replayable state. Use them for active subscribers only, and keep normal links or retained state available when late subscribers or no-JavaScript users need to continue.
 
+The in-memory stream hub keeps live subscriber tracking separate from opt-in replay retention. Empty live channel tracking is released after the last subscriber disconnects or publish-time cleanup prunes stale writers. Retained replay buffers are not deleted by live disconnects; they stay bounded by the replay retention policy.
+
 ### Form Enhancement
 
 Standard HTML forms can return targeted stream updates instead of full reloads or redirect-first flows. The counter example above is the smallest version of that story: submit a normal MVC form, return RazorWire updates, and change only the DOM you care about.
@@ -239,7 +242,7 @@ RazorWire is designed for a fast feedback loop during development:
 - `Subscribe(channel)` receives only live messages published after subscription.
 - `Subscribe(channel, new RazorWireStreamSubscribeOptions { Replay = true })` receives retained replay messages first, then continues with live messages.
 
-Replay is opt-in and intentionally small. The in-memory hub keeps a bounded per-channel buffer and drops the oldest retained fragments first. Use replay for idempotent state snapshots, progress indicators, and other "latest known UI" streams where a late subscriber should catch up. Do not use replay for one-time commands, sensitive personal data, secrets, or unbounded event logs.
+Replay is opt-in and intentionally small. The in-memory hub keeps up to 25 retained fragments per replay channel and prunes inactive replay channels when more than 256 replay channels are retained, dropping the oldest retained fragments and inactive replay channels first. Replay subscriptions to channels with no retained messages do not allocate durable per-channel replay metadata. Use replay for idempotent state snapshots, progress indicators, and other "latest known UI" streams where a late subscriber should catch up. Do not use replay for one-time commands, sensitive personal data, secrets, or unbounded event logs.
 
 ### `IRazorWireChannelAuthorizer`
 
@@ -313,8 +316,8 @@ Subscribes the page to a RazorWire stream channel.
 
 - `channel`: required channel name.
 - `permanent`: keeps the stream source alive across Turbo visits.
-- Stream endpoints deny subscriptions by default; configure `RazorWireStreamAuthorizationMode.AllowAll` for public/demo channels or provide a custom `IRazorWireChannelAuthorizer`.
-- `replay`: when `true`, appends `?replay=1` to the stream endpoint so the page receives retained channel messages before live updates.
+- Stream endpoints deny subscriptions by default; configure `RazorWireStreamAuthorizationMode.AllowAll` only for public/demo channels or provide a custom `IRazorWireChannelAuthorizer`. Public/demo channels should validate or namespace channel names instead of accepting arbitrary user-supplied channel identifiers.
+- `replay`: when `true`, appends `?replay=1` to the stream endpoint so the page receives retained channel messages before live updates. The in-memory hub retains at most 25 messages per replay channel and prunes inactive replay channels when more than 256 replay channels are retained.
 
 ```html
 <rw:stream-source id="rw-stream-reactivity" channel="reactivity" permanent="true"></rw:stream-source>

--- a/Web/ForgeTrust.RazorWire/Streams/IRazorWireStreamHub.cs
+++ b/Web/ForgeTrust.RazorWire/Streams/IRazorWireStreamHub.cs
@@ -5,6 +5,11 @@ namespace ForgeTrust.RazorWire.Streams;
 /// <summary>
 /// Defines the contract for a message hub that supports pub/sub operations over named channels.
 /// </summary>
+/// <remarks>
+/// Implementations may keep live subscriber state and replay retention state separately. Live subscriptions should be
+/// released when readers disconnect, while opt-in replay buffers may outlive live subscribers until the implementation's
+/// bounded retention policy prunes them.
+/// </remarks>
 public interface IRazorWireStreamHub
 {
     /// <summary>
@@ -56,7 +61,8 @@ public interface IRazorWireStreamHub
     /// </returns>
     /// <remarks>
     /// Pitfall: <see cref="RazorWireStreamSubscribeOptions.Replay"/> is an opt-in contract between caller and hub
-    /// implementation; the interface fallback remains live-only for backward compatibility.
+    /// implementation; the interface fallback remains live-only for backward compatibility. Replay should be reserved for
+    /// idempotent retained state, not one-shot commands or sensitive payloads.
     /// </remarks>
     ChannelReader<string> Subscribe(string channel, RazorWireStreamSubscribeOptions? options)
     {
@@ -66,7 +72,11 @@ public interface IRazorWireStreamHub
     /// <summary>
     /// Unsubscribes the specified reader from the named channel so it no longer receives messages from that channel.
     /// </summary>
-    /// <param name="channel">The name of the channel to unsubscribe from.</param>
+    /// <param name="channel">
+    /// The name of the channel to unsubscribe from. Normal callers should pass the same channel used for subscription.
+    /// Endpoint cleanup paths usually have that value available; passing a different value can be surprising on
+    /// implementations that do not keep their own subscription ownership map.
+    /// </param>
     /// <param name="reader">The ChannelReader&lt;string&gt; instance to detach from the channel.</param>
     void Unsubscribe(string channel, ChannelReader<string> reader);
 }

--- a/Web/ForgeTrust.RazorWire/Streams/InMemoryRazorWireStreamHub.cs
+++ b/Web/ForgeTrust.RazorWire/Streams/InMemoryRazorWireStreamHub.cs
@@ -25,6 +25,8 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
     private readonly ConcurrentDictionary<string, Queue<string>> _replayMessages = new();
     private readonly object[] _replayLocks = CreateReplayLocks();
     private readonly ConcurrentDictionary<string, ReplayTouch> _replayTouched = new();
+    private readonly SortedSet<ReplayTouchEntry> _replayTouchesByAge = [];
+    private readonly object _replayPruneGate = new();
     private long _replayTouchSequence;
 
     /// <summary>
@@ -220,9 +222,7 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
             messages.Dequeue();
         }
 
-        _replayTouched[channel] = new ReplayTouch(
-            DateTimeOffset.UtcNow,
-            Interlocked.Increment(ref _replayTouchSequence));
+        TrackReplayTouch(channel);
     }
 
     private IReadOnlyList<string> GetReplayMessagesLocked(string channel)
@@ -242,17 +242,14 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
             return;
         }
 
-        foreach (var candidate in _replayTouched
-            .OrderBy(item => item.Value.TouchedUtc)
-            .ThenBy(item => item.Value.Sequence)
-            .ToArray())
+        foreach (var candidate in SnapshotReplayPruneCandidates())
         {
             if (_replayMessages.Count <= MaxReplayChannels)
             {
                 return;
             }
 
-            var channel = candidate.Key;
+            var channel = candidate.Channel;
             BeforeReplayPruneCandidateForTesting?.Invoke(channel);
 
             var gate = GetReplayLock(channel);
@@ -263,18 +260,70 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
                     return;
                 }
 
-                if (!_replayTouched.TryGetValue(channel, out var currentTouch) || currentTouch != candidate.Value)
+                if (!IsCurrentReplayTouch(channel, candidate.Touch))
                 {
                     continue;
                 }
 
-                if (!_replayMessages.ContainsKey(channel) || HasLiveSubscribers(channel))
+                if (!_replayMessages.ContainsKey(channel))
+                {
+                    RemoveReplayTouch(channel, candidate.Touch);
+                    continue;
+                }
+
+                if (HasLiveSubscribers(channel))
                 {
                     continue;
                 }
 
                 _replayMessages.TryRemove(channel, out _);
+                RemoveReplayTouch(channel, candidate.Touch);
+            }
+        }
+    }
+
+    private void TrackReplayTouch(string channel)
+    {
+        var touch = new ReplayTouch(
+            DateTimeOffset.UtcNow,
+            Interlocked.Increment(ref _replayTouchSequence));
+
+        lock (_replayPruneGate)
+        {
+            if (_replayTouched.TryGetValue(channel, out var previousTouch))
+            {
+                _replayTouchesByAge.Remove(new ReplayTouchEntry(channel, previousTouch));
+            }
+
+            _replayTouched[channel] = touch;
+            _replayTouchesByAge.Add(new ReplayTouchEntry(channel, touch));
+        }
+    }
+
+    private ReplayTouchEntry[] SnapshotReplayPruneCandidates()
+    {
+        lock (_replayPruneGate)
+        {
+            return [.. _replayTouchesByAge];
+        }
+    }
+
+    private bool IsCurrentReplayTouch(string channel, ReplayTouch touch)
+    {
+        lock (_replayPruneGate)
+        {
+            return _replayTouched.TryGetValue(channel, out var currentTouch) && currentTouch == touch;
+        }
+    }
+
+    private void RemoveReplayTouch(string channel, ReplayTouch touch)
+    {
+        lock (_replayPruneGate)
+        {
+            if (_replayTouched.TryGetValue(channel, out var currentTouch) && currentTouch == touch)
+            {
                 _replayTouched.TryRemove(channel, out _);
+                _replayTouchesByAge.Remove(new ReplayTouchEntry(channel, touch));
             }
         }
     }
@@ -431,4 +480,24 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
         LiveChannelState State);
 
     private readonly record struct ReplayTouch(DateTimeOffset TouchedUtc, long Sequence);
+
+    private readonly record struct ReplayTouchEntry(string Channel, ReplayTouch Touch) : IComparable<ReplayTouchEntry>
+    {
+        public int CompareTo(ReplayTouchEntry other)
+        {
+            var touchedComparison = Touch.TouchedUtc.CompareTo(other.Touch.TouchedUtc);
+            if (touchedComparison != 0)
+            {
+                return touchedComparison;
+            }
+
+            var sequenceComparison = Touch.Sequence.CompareTo(other.Touch.Sequence);
+            if (sequenceComparison != 0)
+            {
+                return sequenceComparison;
+            }
+
+            return StringComparer.Ordinal.Compare(Channel, other.Channel);
+        }
+    }
 }

--- a/Web/ForgeTrust.RazorWire/Streams/InMemoryRazorWireStreamHub.cs
+++ b/Web/ForgeTrust.RazorWire/Streams/InMemoryRazorWireStreamHub.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Channels;
 
 namespace ForgeTrust.RazorWire.Streams;
@@ -147,12 +148,13 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
             return;
         }
 
-        foreach (var subscriber in state.SnapshotWriters())
+        var failedSubscribers = state
+            .SnapshotWriters()
+            .Where(subscriber => !subscriber.TryWrite(message));
+
+        foreach (var subscriber in failedSubscribers)
         {
-            if (!subscriber.TryWrite(message))
-            {
-                RemoveClosedSubscriber(channel, state, subscriber);
-            }
+            RemoveClosedSubscriber(channel, state, subscriber);
         }
     }
 

--- a/Web/ForgeTrust.RazorWire/Streams/InMemoryRazorWireStreamHub.cs
+++ b/Web/ForgeTrust.RazorWire/Streams/InMemoryRazorWireStreamHub.cs
@@ -6,18 +6,43 @@ namespace ForgeTrust.RazorWire.Streams;
 /// <summary>
 /// Provides an in-memory implementation of <see cref="IRazorWireStreamHub"/> using <see cref="Channel{T}"/> for message distribution.
 /// </summary>
+/// <remarks>
+/// Live subscriber state is tracked separately from replay state. Empty live channels are removed after the last
+/// subscriber disconnects or after publish-time pruning finds stale writers, while replay buffers remain available until
+/// the bounded replay retention policy removes them. The hub keeps up to 25 retained messages per replay channel and
+/// prunes inactive replay channels when more than 256 replay channels are retained.
+/// </remarks>
 public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
 {
     private const int ReplayCapacity = 25;
     private const int MaxReplayChannels = 256;
+    private const int ReplayLockStripeCount = 64;
 
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<ChannelWriter<string>, byte>> _channels = new();
-    private readonly ConcurrentDictionary<ChannelReader<string>, ChannelWriter<string>> _readerToWriter = new();
-    private readonly ConcurrentDictionary<ChannelWriter<string>, ChannelReader<string>> _writerToReader = new();
+    private readonly ConcurrentDictionary<string, LiveChannelState> _channels = new();
+    private readonly ConcurrentDictionary<ChannelReader<string>, LiveSubscription> _subscriptionsByReader = new();
+    private readonly ConcurrentDictionary<ChannelWriter<string>, LiveSubscription> _subscriptionsByWriter = new();
     private readonly ConcurrentDictionary<string, Queue<string>> _replayMessages = new();
-    private readonly ConcurrentDictionary<string, object> _replayLocks = new();
+    private readonly object[] _replayLocks = CreateReplayLocks();
     private readonly ConcurrentDictionary<string, ReplayTouch> _replayTouched = new();
     private long _replayTouchSequence;
+
+    /// <summary>
+    /// Gets or sets an internal test hook that runs after an empty live channel state is retired and before it is removed from the live channel map.
+    /// </summary>
+    /// <remarks>
+    /// Production code leaves this unset. Regression tests use it to force subscribe/cleanup interleavings that would
+    /// otherwise depend on timing.
+    /// </remarks>
+    internal Action? AfterLiveChannelRetiredForTesting { get; set; }
+
+    /// <summary>
+    /// Gets or sets an internal test hook that runs before a replay prune candidate takes its channel stripe lock.
+    /// </summary>
+    /// <remarks>
+    /// Production code leaves this unset. Regression tests use it to force publish/prune interleavings that would
+    /// otherwise depend on timing.
+    /// </remarks>
+    internal Action<string>? BeforeReplayPruneCandidateForTesting { get; set; }
 
     /// <summary>
     /// Publishes a message to all subscribers of the specified channel. Any subscribers that are closed or unable to accept the message are removed during the process.
@@ -37,7 +62,7 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
         {
             if (options?.Replay == true)
             {
-                var gate = _replayLocks.GetOrAdd(channel, _ => new object());
+                var gate = GetReplayLock(channel);
                 lock (gate)
                 {
                     AddReplayMessageLocked(channel, message);
@@ -76,75 +101,112 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
         var subscriber = Channel.CreateBounded<string>(
             new BoundedChannelOptions(100) { FullMode = BoundedChannelFullMode.DropOldest });
 
-        _readerToWriter.TryAdd(subscriber.Reader, subscriber.Writer);
-        _writerToReader.TryAdd(subscriber.Writer, subscriber.Reader);
-
         if (options?.Replay == true)
         {
-            var gate = _replayLocks.GetOrAdd(channel, _ => new object());
+            var gate = GetReplayLock(channel);
             lock (gate)
             {
-                var subscribers = _channels.GetOrAdd(
-                    channel,
-                    _ => new ConcurrentDictionary<ChannelWriter<string>, byte>());
                 foreach (var message in GetReplayMessagesLocked(channel))
                 {
                     subscriber.Writer.TryWrite(message);
                 }
 
-                subscribers.TryAdd(subscriber.Writer, 0);
+                AddLiveSubscriber(channel, subscriber.Reader, subscriber.Writer);
             }
 
             return subscriber.Reader;
         }
 
-        var liveSubscribers = _channels.GetOrAdd(channel, _ => new ConcurrentDictionary<ChannelWriter<string>, byte>());
-        liveSubscribers.TryAdd(subscriber.Writer, 0);
+        AddLiveSubscriber(channel, subscriber.Reader, subscriber.Writer);
         return subscriber.Reader;
     }
 
     /// <summary>
     /// Unregisters a subscriber from the specified channel and completes its associated writer.
     /// </summary>
-    /// <param name="channel">The name of the channel to remove the subscriber from.</param>
+    /// <param name="channel">
+    /// The channel name supplied by the caller. The in-memory hub removes the reader from its recorded channel so endpoint
+    /// cleanup remains correct even if this value is stale, but application code should still pass the same channel used
+    /// for subscription for clarity and compatibility with other implementations.
+    /// </param>
     /// <param name="reader">The subscriber's <see cref="ChannelReader{String}"/>; its paired writer will be completed and removed from channel tracking.</param>
     public void Unsubscribe(string channel, ChannelReader<string> reader)
     {
-        if (_readerToWriter.TryRemove(reader, out var writer))
+        if (_subscriptionsByReader.TryRemove(reader, out var subscription))
         {
-            _writerToReader.TryRemove(writer, out _);
-            writer.TryComplete();
-            if (_channels.TryGetValue(channel, out var subscribers))
-            {
-                subscribers.TryRemove(writer, out _);
-            }
+            _subscriptionsByWriter.TryRemove(subscription.Writer, out _);
+            subscription.Writer.TryComplete();
+            RemoveSubscriberFromLiveState(subscription);
         }
     }
 
     private void PublishLiveMessage(string channel, string message)
     {
-        if (!_channels.TryGetValue(channel, out var subscribersDict))
+        if (!_channels.TryGetValue(channel, out var state))
         {
             return;
         }
 
-        var subscribers = subscribersDict.Keys.ToList();
-        var closedSubscribers = subscribers.Where(subscriber => !subscriber.TryWrite(message)).ToList();
-
-        // Cleanup closed subscribers
-        foreach (var closed in closedSubscribers)
+        foreach (var subscriber in state.SnapshotWriters())
         {
-            // Explicitly attempt to complete to trigger any underlying cleanup logic
-            closed.TryComplete();
-
-            subscribersDict.TryRemove(closed, out _);
-
-            // Also remove the bidirectional mappings to prevent leaks
-            if (_writerToReader.TryRemove(closed, out var reader))
+            if (!subscriber.TryWrite(message))
             {
-                _readerToWriter.TryRemove(reader, out _);
+                RemoveClosedSubscriber(channel, state, subscriber);
             }
         }
+    }
+
+    private void AddLiveSubscriber(string channel, ChannelReader<string> reader, ChannelWriter<string> writer)
+    {
+        while (true)
+        {
+            var state = _channels.GetOrAdd(channel, _ => new LiveChannelState());
+            if (!state.TryAdd(writer))
+            {
+                TryRemoveLiveChannel(channel, state);
+                continue;
+            }
+
+            var subscription = new LiveSubscription(channel, reader, writer, state);
+            _subscriptionsByReader[reader] = subscription;
+            _subscriptionsByWriter[writer] = subscription;
+            return;
+        }
+    }
+
+    private void RemoveClosedSubscriber(string fallbackChannel, LiveChannelState fallbackState, ChannelWriter<string> writer)
+    {
+        writer.TryComplete();
+        if (_subscriptionsByWriter.TryRemove(writer, out var subscription))
+        {
+            _subscriptionsByReader.TryRemove(subscription.Reader, out _);
+            RemoveSubscriberFromLiveState(subscription);
+            return;
+        }
+
+        fallbackState.Remove(writer);
+        RemoveLiveChannelIfEmpty(fallbackChannel, fallbackState);
+    }
+
+    private void RemoveSubscriberFromLiveState(LiveSubscription subscription)
+    {
+        subscription.State.Remove(subscription.Writer);
+        RemoveLiveChannelIfEmpty(subscription.ChannelName, subscription.State);
+    }
+
+    private void RemoveLiveChannelIfEmpty(string channel, LiveChannelState state)
+    {
+        if (state.TryRetireIfEmpty())
+        {
+            AfterLiveChannelRetiredForTesting?.Invoke();
+            TryRemoveLiveChannel(channel, state);
+        }
+    }
+
+    private bool TryRemoveLiveChannel(string channel, LiveChannelState state)
+    {
+        return ((ICollection<KeyValuePair<string, LiveChannelState>>)_channels)
+            .Remove(new KeyValuePair<string, LiveChannelState>(channel, state));
     }
 
     private void AddReplayMessageLocked(string channel, string message)
@@ -178,22 +240,193 @@ public class InMemoryRazorWireStreamHub : IRazorWireStreamHub
             return;
         }
 
-        foreach (var channel in _replayTouched
+        foreach (var candidate in _replayTouched
             .OrderBy(item => item.Value.TouchedUtc)
             .ThenBy(item => item.Value.Sequence)
-            .Select(item => item.Key)
-            .Take(_replayMessages.Count - MaxReplayChannels))
+            .ToArray())
         {
-            if (_channels.TryGetValue(channel, out var subscribers) && !subscribers.IsEmpty)
+            if (_replayMessages.Count <= MaxReplayChannels)
             {
-                continue;
+                return;
             }
 
-            _replayMessages.TryRemove(channel, out _);
-            _replayLocks.TryRemove(channel, out _);
-            _replayTouched.TryRemove(channel, out _);
+            var channel = candidate.Key;
+            BeforeReplayPruneCandidateForTesting?.Invoke(channel);
+
+            var gate = GetReplayLock(channel);
+            lock (gate)
+            {
+                if (_replayMessages.Count <= MaxReplayChannels)
+                {
+                    return;
+                }
+
+                if (!_replayTouched.TryGetValue(channel, out var currentTouch) || currentTouch != candidate.Value)
+                {
+                    continue;
+                }
+
+                if (!_replayMessages.ContainsKey(channel) || HasLiveSubscribers(channel))
+                {
+                    continue;
+                }
+
+                _replayMessages.TryRemove(channel, out _);
+                _replayTouched.TryRemove(channel, out _);
+            }
         }
     }
+
+    private bool HasLiveSubscribers(string channel)
+    {
+        return _channels.TryGetValue(channel, out var state) && state.HasSubscribers;
+    }
+
+    private object GetReplayLock(string channel)
+    {
+        var index = unchecked((uint)StringComparer.Ordinal.GetHashCode(channel) % (uint)_replayLocks.Length);
+        return _replayLocks[index];
+    }
+
+    private static object[] CreateReplayLocks()
+    {
+        var locks = new object[ReplayLockStripeCount];
+        for (var index = 0; index < locks.Length; index++)
+        {
+            locks[index] = new object();
+        }
+
+        return locks;
+    }
+
+    /// <summary>
+    /// Gets internal stream state counts used by regression tests to verify cleanup behavior.
+    /// </summary>
+    /// <returns>A snapshot of live and replay tracking counts.</returns>
+    internal InMemoryRazorWireStreamHubDiagnostics GetDiagnostics()
+    {
+        var liveSubscriberCount = 0;
+        foreach (var state in _channels.Values)
+        {
+            liveSubscriberCount += state.Count;
+        }
+
+        return new InMemoryRazorWireStreamHubDiagnostics(
+            _channels.Count,
+            liveSubscriberCount,
+            _subscriptionsByReader.Count,
+            _replayMessages.Count);
+    }
+
+    /// <summary>
+    /// Completes the writer for an active subscription without removing the subscription maps.
+    /// </summary>
+    /// <param name="reader">The reader whose paired writer should be completed.</param>
+    /// <returns><see langword="true"/> when the reader belongs to an active subscription; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This internal test seam simulates a writer closed by channel infrastructure so publish-time pruning can be verified
+    /// through the same cleanup path that handles stale live subscribers.
+    /// </remarks>
+    internal bool TryCompleteSubscriberWriterForTesting(ChannelReader<string> reader)
+    {
+        if (!_subscriptionsByReader.TryGetValue(reader, out var subscription))
+        {
+            return false;
+        }
+
+        return subscription.Writer.TryComplete();
+    }
+
+    /// <summary>
+    /// Represents a snapshot of internal stream tracking counts used by the RazorWire test suite.
+    /// </summary>
+    /// <param name="LiveChannelCount">The number of live channel state entries currently retained.</param>
+    /// <param name="LiveSubscriberCount">The number of active live subscriber writers currently retained.</param>
+    /// <param name="SubscriptionCount">The number of reader-owned subscription records currently retained.</param>
+    /// <param name="ReplayChannelCount">The number of channels with retained replay messages.</param>
+    internal readonly record struct InMemoryRazorWireStreamHubDiagnostics(
+        int LiveChannelCount,
+        int LiveSubscriberCount,
+        int SubscriptionCount,
+        int ReplayChannelCount);
+
+    private sealed class LiveChannelState
+    {
+        private readonly object _gate = new();
+        private readonly HashSet<ChannelWriter<string>> _writers = [];
+        private bool _retired;
+
+        public int Count
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _writers.Count;
+                }
+            }
+        }
+
+        public bool HasSubscribers
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _writers.Count > 0;
+                }
+            }
+        }
+
+        public bool TryAdd(ChannelWriter<string> writer)
+        {
+            lock (_gate)
+            {
+                if (_retired)
+                {
+                    return false;
+                }
+
+                return _writers.Add(writer);
+            }
+        }
+
+        public bool Remove(ChannelWriter<string> writer)
+        {
+            lock (_gate)
+            {
+                return _writers.Remove(writer);
+            }
+        }
+
+        public IReadOnlyList<ChannelWriter<string>> SnapshotWriters()
+        {
+            lock (_gate)
+            {
+                return [.. _writers];
+            }
+        }
+
+        public bool TryRetireIfEmpty()
+        {
+            lock (_gate)
+            {
+                if (_writers.Count > 0)
+                {
+                    return false;
+                }
+
+                _retired = true;
+                return true;
+            }
+        }
+    }
+
+    private readonly record struct LiveSubscription(
+        string ChannelName,
+        ChannelReader<string> Reader,
+        ChannelWriter<string> Writer,
+        LiveChannelState State);
 
     private readonly record struct ReplayTouch(DateTimeOffset TouchedUtc, long Sequence);
 }

--- a/Web/ForgeTrust.RazorWire/Streams/RazorWireStreamOptions.cs
+++ b/Web/ForgeTrust.RazorWire/Streams/RazorWireStreamOptions.cs
@@ -6,11 +6,14 @@ namespace ForgeTrust.RazorWire.Streams;
 /// <remarks>
 /// Replay is disabled by default so existing channels remain live-only. Enable <see cref="Replay"/> only for
 /// idempotent state snapshots or bounded progress events that are safe for late subscribers to receive after publish.
+/// The in-memory hub retains at most 25 messages per replay channel and prunes inactive replay channels when more than
+/// 256 replay channels are retained.
 /// </remarks>
 public sealed record RazorWireStreamPublishOptions
 {
     /// <summary>
     /// Gets a value indicating whether this message should be retained in the bounded replay buffer for its channel.
+    /// Retained messages survive live subscriber disconnects until normal replay pruning removes them.
     /// </summary>
     public bool Replay { get; init; }
 }
@@ -21,12 +24,14 @@ public sealed record RazorWireStreamPublishOptions
 /// <remarks>
 /// Replay is opt-in per subscription. A replaying subscriber first receives the channel's retained messages, then receives
 /// live messages like any other subscriber. The in-memory hub bounds replay storage and drops the oldest retained messages
-/// when the channel exceeds its replay capacity.
+/// when the channel exceeds its replay capacity of 25 messages, and prunes inactive replay channels when more than 256
+/// replay channels are retained.
 /// </remarks>
 public sealed record RazorWireStreamSubscribeOptions
 {
     /// <summary>
-    /// Gets a value indicating whether retained channel messages should be delivered before live messages.
+    /// Gets a value indicating whether retained channel messages should be delivered before live messages. A replay
+    /// subscription to a channel with no retained messages does not create a durable replay buffer.
     /// </summary>
     public bool Replay { get; init; }
 }

--- a/examples/razorwire-mvc/README.md
+++ b/examples/razorwire-mvc/README.md
@@ -113,6 +113,8 @@ The sample also demonstrates live multi-client updates.
 
 RazorWire stream subscriptions are denied by default. This sample explicitly sets `RazorWireOptions.Streams.AuthorizationMode = RazorWireStreamAuthorizationMode.AllowAll` in `RazorWireExampleModule.ConfigureServices` because the `reactivity` channel is a public demo channel. Production apps should register `IRazorWireChannelAuthorizer` when channels depend on the current user, tenant, or workflow state.
 
+When you intentionally expose public/demo streams, keep channel names validated and namespaced instead of accepting arbitrary request values. Live subscriber tracking is released after disconnect, and replay buffers are bounded to 25 messages per channel while inactive replay channels are pruned after the in-memory hub retains more than 256 replay channels, but public endpoints should still avoid unbounded channel cardinality from user input.
+
 ### Registration and Message Publishing
 
 The reactivity page includes two additional form flows:

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -26,6 +26,10 @@ Post-RC1 work is now collected here as deltas from the current release candidate
 
 - RazorWire CLI process execution now follows an explicit reliability contract for one-shot commands and launched target apps. No action is expected: command names, flags, defaults, and export semantics are unchanged. Target-app failures that were previously hidden behind startup or readiness timeouts may now surface earlier with captured output and recovery guidance.
 
+### RazorWire streams
+
+- RazorWire's in-memory stream hub now releases empty live channel tracking after the last subscriber disconnects or publish-time cleanup prunes stale writers. Replay buffers remain separate from live subscriber state, keep 25 retained messages per channel, prune inactive replay channels after more than 256 replay channels are retained, and are not deleted just because the last live subscriber disconnects.
+
 ### Web host development defaults
 
 - Tailwind build execution now uses a compiled MSBuild task with stable `ASTW###` diagnostics, structured CLI arguments, bounded output capture, cancellation support, and a packed-package smoke test that proves task and dependency loading from a real nupkg consumer.
@@ -37,6 +41,7 @@ Post-RC1 work is now collected here as deltas from the current release candidate
 ## Migration watch
 
 - Existing RazorWire CLI users do not need command or flag changes for the process-execution migration. The main behavior difference is that target-app failures may now appear earlier with captured output instead of being hidden behind startup or readiness timeouts.
+- RazorWire stream consumers do not need application code changes for the live-channel cleanup update. Public or demo stream endpoints should still validate or namespace channel names before opting into `AllowAll`; active connection cardinality limits are tracked separately from this cleanup work.
 - Tailwind package consumers do not need source changes for the compiled MSBuild task. Maintainers should keep the packed-package smoke path green when changing task dependencies or diagnostics.
 - AppSurface Docs JavaScript harvest consumers can keep explicit `@namespace` and `@module` tags when they need a stable API family name; otherwise the new fallback grouping may split same-stem files by path instead of merging them.
 - Operators may see more conservative redaction in config audit reports as the secret-fragment list expands. Treat that as the intended default, and use explicit sensitivity options only to document package-owned keys.


### PR DESCRIPTION
## Summary

- Replaces RazorWire stream live-channel tracking with retired, gated live state so empty channels are removed without orphaning concurrent subscribers.
- Tracks subscriptions by returned reader so unsubscribe removes the recorded channel even when the caller supplies a stale channel string.
- Bounds replay coordination with fixed stripe locks and protects replay prune/removal with per-channel locking and touch rechecks.
- Documents live state vs replay state, replay capacity, replay channel pruning, and public/demo channel naming guidance.

## Test Coverage

All new RazorWire stream cleanup and replay paths have regression coverage.

Covered paths:
- many unique live channels subscribe/unsubscribe back to zero live state
- wrong-channel unsubscribe removes the recorded subscription
- stale completed writers are pruned during publish and empty live channels are removed
- replay subscriptions across unique empty channels do not retain replay buffers
- active replay channels are not pruned while subscribed
- replay survives live disconnect until normal replay pruning removes it
- deterministic live-channel retirement/subscribe interleaving keeps the new subscriber reachable
- replay pruning keeps walking when oldest channels are active
- replay prune does not delete a channel republished during prune

## Pre-Landing Review

No blocking issues found after review pass. Earlier replay-prune race and active-oldest pruning issues were fixed before this PR was opened.

## Design Review

No frontend UI files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: harden RazorWire stream hub cleanup and replay metadata behavior for #436.
Delivered: stream hub cleanup/replay coordination fixes, targeted tests, XML docs, package/example docs, and unreleased notes.

## Plan Completion

All requested implementation, docs, release-note, and regression-test items were addressed. No public API shape change was introduced.

## Verification Results

- `dotnet test Web/ForgeTrust.RazorWire.Tests/ForgeTrust.RazorWire.Tests.csproj --no-restore` passed: 207 tests
- `dotnet build --no-restore` passed: 0 warnings, 0 errors
- `git diff --cached --check` passed before commit

## TODOS

No TODO items completed in this PR.

## Documentation

Updated:
- `Web/ForgeTrust.RazorWire/README.md`
- `examples/razorwire-mvc/README.md`
- XML comments on the stream hub/options contracts
- `releases/unreleased.md`

## Test plan

- [x] RazorWire unit tests pass
- [x] Solution build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)