### PR TITLE
fix: secure RazorWire stream text rendering

### DIFF
--- a/Web/ForgeTrust.RazorWire.Tests/InMemoryRazorWireStreamHubTests.cs
+++ b/Web/ForgeTrust.RazorWire.Tests/InMemoryRazorWireStreamHubTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using ForgeTrust.RazorWire.Bridge;
 using ForgeTrust.RazorWire.Streams;
 
 namespace ForgeTrust.RazorWire.Tests;
@@ -135,6 +136,28 @@ public class InMemoryRazorWireStreamHubTests
         Assert.Equal("first", await reader.ReadAsync(cts.Token));
         Assert.Equal("second", await reader.ReadAsync(cts.Token));
         Assert.Equal("third", await reader.ReadAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithBuilderOutput_DeliversEncodedStreamThroughLiveAndReplay()
+    {
+        var hub = new InMemoryRazorWireStreamHub();
+        var liveReader = hub.Subscribe("orders");
+        var stream = new RazorWireStreamBuilder()
+            .Update("<target&name>", "<script>alert(1)</script>")
+            .Build();
+
+        await hub.PublishAsync("orders", stream, new RazorWireStreamPublishOptions { Replay = true });
+        var replayReader = hub.Subscribe("orders", new RazorWireStreamSubscribeOptions { Replay = true });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        var liveMessage = await liveReader.ReadAsync(cts.Token);
+        var replayMessage = await replayReader.ReadAsync(cts.Token);
+
+        Assert.Equal(liveMessage, replayMessage);
+        Assert.Contains("target=\"&lt;target&amp;name&gt;\"", liveMessage);
+        Assert.Contains("<template>&lt;script&gt;alert(1)&lt;/script&gt;</template>", liveMessage);
+        Assert.DoesNotContain("<script>alert(1)</script>", liveMessage);
     }
 
     [Fact]

--- a/Web/ForgeTrust.RazorWire.Tests/RazorWireStreamBuilderTests.cs
+++ b/Web/ForgeTrust.RazorWire.Tests/RazorWireStreamBuilderTests.cs
@@ -16,7 +16,7 @@ namespace ForgeTrust.RazorWire.Tests;
 public class RazorWireStreamBuilderTests
 {
     [Fact]
-    public void Append_RendersCorrectMarkup()
+    public void Append_EncodesPlainTextContent()
     {
         // Arrange
         var builder = new RazorWireStreamBuilder();
@@ -27,7 +27,101 @@ public class RazorWireStreamBuilderTests
         // Assert
         Assert.Contains("action=\"append\"", result);
         Assert.Contains("target=\"target-id\"", result);
-        Assert.Contains("<template><div>content</div></template>", result);
+        Assert.Contains("<template>&lt;div&gt;content&lt;/div&gt;</template>", result);
+        Assert.DoesNotContain("<template><div>content</div></template>", result);
+    }
+
+    [Theory]
+    [InlineData("append")]
+    [InlineData("prepend")]
+    [InlineData("replace")]
+    [InlineData("update")]
+    public void TextActions_EncodePlainTextContent(string action)
+    {
+        // Arrange
+        var builder = new RazorWireStreamBuilder();
+
+        // Act
+        var result = QueueTextAction(builder, action, "target-id", "<strong>A&B</strong>").Build();
+
+        // Assert
+        Assert.Contains($"action=\"{action}\"", result);
+        Assert.Contains("<template>&lt;strong&gt;A&amp;B&lt;/strong&gt;</template>", result);
+        Assert.DoesNotContain("<strong>A&B</strong>", result);
+    }
+
+    [Theory]
+    [InlineData("append")]
+    [InlineData("prepend")]
+    [InlineData("replace")]
+    [InlineData("update")]
+    public void HtmlActions_PreserveTrustedHtmlContent(string action)
+    {
+        // Arrange
+        var builder = new RazorWireStreamBuilder();
+
+        // Act
+        var result = QueueHtmlAction(builder, action, "target-id", "<strong>A&B</strong>").Build();
+
+        // Assert
+        Assert.Contains($"action=\"{action}\"", result);
+        Assert.Contains("<template><strong>A&B</strong></template>", result);
+        Assert.DoesNotContain("&lt;strong&gt;A&amp;B&lt;/strong&gt;", result);
+    }
+
+    [Theory]
+    [InlineData("append")]
+    [InlineData("prepend")]
+    [InlineData("replace")]
+    [InlineData("update")]
+    public void TextActions_WithNullContent_RenderEmptyTemplate(string action)
+    {
+        // Arrange
+        var builder = new RazorWireStreamBuilder();
+
+        // Act
+        var result = QueueTextAction(builder, action, "target-id", null).Build();
+
+        // Assert
+        Assert.Contains($"action=\"{action}\"", result);
+        Assert.Contains("<template></template>", result);
+    }
+
+    [Theory]
+    [InlineData("append")]
+    [InlineData("prepend")]
+    [InlineData("replace")]
+    [InlineData("update")]
+    public void HtmlActions_WithNullContent_RenderEmptyTemplate(string action)
+    {
+        // Arrange
+        var builder = new RazorWireStreamBuilder();
+
+        // Act
+        var result = QueueHtmlAction(builder, action, "target-id", null).Build();
+
+        // Assert
+        Assert.Contains($"action=\"{action}\"", result);
+        Assert.Contains("<template></template>", result);
+    }
+
+    [Fact]
+    public void Build_WithMixedTextAndTrustedHtmlActions_PreservesQueueOrderAndTrustModes()
+    {
+        // Arrange
+        var builder = new RazorWireStreamBuilder();
+
+        // Act
+        var result = builder
+            .Append("list", "<li>text</li>")
+            .UpdateHtml("status", "<p>trusted</p>")
+            .Build();
+
+        // Assert
+        var textIndex = result.IndexOf("<template>&lt;li&gt;text&lt;/li&gt;</template>", StringComparison.Ordinal);
+        var htmlIndex = result.IndexOf("<template><p>trusted</p></template>", StringComparison.Ordinal);
+        Assert.True(textIndex >= 0);
+        Assert.True(htmlIndex > textIndex);
     }
 
     [Fact]
@@ -153,7 +247,7 @@ public class RazorWireStreamBuilderTests
         // Assert
         Assert.Contains("action=\"append\"", result);
         Assert.Contains("target=\"list\"", result);
-        Assert.Contains("<template><li>one</li></template>", result);
+        Assert.Contains("<template>&lt;li&gt;one&lt;/li&gt;</template>", result);
         Assert.Contains("action=\"remove\"", result);
         Assert.Contains("target=\"obsolete\"", result);
     }
@@ -178,6 +272,7 @@ public class RazorWireStreamBuilderTests
         Assert.True(visitIndex > updateIndex);
         Assert.Contains("url=\"/docs/next\"", result);
         Assert.Contains("visit-action=\"replace\"", result);
+        Assert.Contains("<template>&lt;p&gt;done&lt;/p&gt;</template>", result);
     }
 
     [Fact]
@@ -442,6 +537,38 @@ public class RazorWireStreamBuilderTests
         Assert.DoesNotContain("data-rw-form-error-list", rendered);
         Assert.DoesNotContain("Name is required", rendered);
         Assert.Contains("There are 2 more validation errors.", rendered);
+    }
+
+    private static RazorWireStreamBuilder QueueTextAction(
+        RazorWireStreamBuilder builder,
+        string action,
+        string target,
+        string? content)
+    {
+        return action switch
+        {
+            "append" => builder.Append(target, content),
+            "prepend" => builder.Prepend(target, content),
+            "replace" => builder.Replace(target, content),
+            "update" => builder.Update(target, content),
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unsupported test action.")
+        };
+    }
+
+    private static RazorWireStreamBuilder QueueHtmlAction(
+        RazorWireStreamBuilder builder,
+        string action,
+        string target,
+        string? trustedHtml)
+    {
+        return action switch
+        {
+            "append" => builder.AppendHtml(target, trustedHtml),
+            "prepend" => builder.PrependHtml(target, trustedHtml),
+            "replace" => builder.ReplaceHtml(target, trustedHtml),
+            "update" => builder.UpdateHtml(target, trustedHtml),
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unsupported test action.")
+        };
     }
 
     private static ViewContext CreateViewContext()

--- a/Web/ForgeTrust.RazorWire.Tests/RazorWireStreamResultTests.cs
+++ b/Web/ForgeTrust.RazorWire.Tests/RazorWireStreamResultTests.cs
@@ -32,6 +32,21 @@ public class RazorWireStreamResultTests
     }
 
     [Fact]
+    public async Task ExecuteResultAsync_WithNullRawHtml_WritesEmptyBodyAndSetsTurboContentType()
+    {
+        // Arrange
+        using var actionContext = CreateActionContext();
+        var result = new RazorWireStreamResult(rawContent: null);
+
+        // Act
+        await result.ExecuteResultAsync(actionContext.ActionContext);
+
+        // Assert
+        Assert.Equal("text/vnd.turbo-stream.html", actionContext.ActionContext.HttpContext.Response.ContentType);
+        Assert.Equal(string.Empty, await RazorWireTestContext.ReadBodyAsync(actionContext.ActionContext.HttpContext.Response));
+    }
+
+    [Fact]
     public async Task ExecuteResultAsync_WithController_ReusesControllerViewDataAndTempData()
     {
         // Arrange

--- a/Web/ForgeTrust.RazorWire/Bridge/RazorWireStreamBuilder.cs
+++ b/Web/ForgeTrust.RazorWire/Bridge/RazorWireStreamBuilder.cs
@@ -23,14 +23,38 @@ public class RazorWireStreamBuilder
     }
 
     /// <summary>
-    /// Queues an append action that inserts the provided HTML into the specified target element.
+    /// Queues an append action that inserts HTML-encoded text into the specified target element.
     /// </summary>
-    /// <param name="target">The target DOM selector or element identifier to which the HTML will be appended.</param>
-    /// <param name="templateHtml">The HTML fragment to append inside the target's template.</param>
+    /// <remarks>
+    /// This method treats <paramref name="content"/> as plain text and HTML-encodes it before writing it to the stream
+    /// template. Use <see cref="AppendHtml(string,string?)"/> only when the caller already owns a trusted HTML fragment
+    /// and has encoded any user-supplied values inside it.
+    /// </remarks>
+    /// <param name="target">The target DOM selector or element identifier to which the encoded text will be appended.</param>
+    /// <param name="content">Plain-text content to append inside the target's template; <c>null</c> renders as empty text.</param>
     /// <returns>The same <see cref="RazorWireStreamBuilder"/> instance to allow fluent chaining.</returns>
-    public RazorWireStreamBuilder Append(string target, string templateHtml)
+    public RazorWireStreamBuilder Append(string target, string? content)
     {
-        _actions.Add(new RawHtmlStreamAction("append", target, templateHtml));
+        _actions.Add(new TemplateStreamAction("append", target, content, TemplateContentKind.PlainText));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Queues an append action that inserts a trusted HTML fragment into the specified target element without encoding or sanitizing it.
+    /// </summary>
+    /// <remarks>
+    /// This is the raw-markup escape hatch for server-authored fragments. RazorWire does not encode or sanitize
+    /// <paramref name="trustedHtml"/>; callers must ensure the fragment is trusted and that any user-supplied values have
+    /// already been HTML-encoded. Prefer <see cref="Append(string,string?)"/> for text and
+    /// <see cref="AppendPartial(string,string,object?)"/> or <see cref="AppendComponent{T}(string,object?)"/> for Razor-rendered markup.
+    /// </remarks>
+    /// <param name="target">The target DOM selector or element identifier to which the trusted HTML will be appended.</param>
+    /// <param name="trustedHtml">Trusted HTML to append inside the target's template; <c>null</c> renders as an empty fragment.</param>
+    /// <returns>The same <see cref="RazorWireStreamBuilder"/> instance to allow fluent chaining.</returns>
+    public RazorWireStreamBuilder AppendHtml(string target, string? trustedHtml)
+    {
+        _actions.Add(new TemplateStreamAction("append", target, trustedHtml, TemplateContentKind.TrustedHtml));
 
         return this;
     }
@@ -50,14 +74,36 @@ public class RazorWireStreamBuilder
     }
 
     /// <summary>
-    /// Queues a raw HTML prepend action targeting the specified DOM element.
+    /// Queues a prepend action that inserts HTML-encoded text into the specified target element.
     /// </summary>
     /// <param name="target">The DOM target selector or identifier to receive the content.</param>
-    /// <param name="templateHtml">The HTML content to insert before the target element's existing content.</param>
+    /// <param name="content">Plain-text content to insert before the target element's existing content; <c>null</c> renders as empty text.</param>
     /// <returns>The builder instance for fluent chaining.</returns>
-    public RazorWireStreamBuilder Prepend(string target, string templateHtml)
+    /// <remarks>
+    /// RazorWire HTML-encodes <paramref name="content"/> before placing it in the stream template. Use
+    /// <see cref="PrependHtml(string,string?)"/> only for trusted, already-safe HTML fragments.
+    /// </remarks>
+    public RazorWireStreamBuilder Prepend(string target, string? content)
     {
-        _actions.Add(new RawHtmlStreamAction("prepend", target, templateHtml));
+        _actions.Add(new TemplateStreamAction("prepend", target, content, TemplateContentKind.PlainText));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Queues a prepend action that inserts a trusted HTML fragment without encoding or sanitizing it.
+    /// </summary>
+    /// <remarks>
+    /// RazorWire writes <paramref name="trustedHtml"/> directly into the stream template. Use this only for
+    /// server-authored trusted markup; encode user values before composing the fragment. Prefer
+    /// <see cref="Prepend(string,string?)"/> for text and partial or component helpers for Razor-rendered markup.
+    /// </remarks>
+    /// <param name="target">The DOM target selector or identifier to receive the trusted HTML.</param>
+    /// <param name="trustedHtml">Trusted HTML content to insert before the target element's existing content; <c>null</c> renders as an empty fragment.</param>
+    /// <returns>The builder instance for fluent chaining.</returns>
+    public RazorWireStreamBuilder PrependHtml(string target, string? trustedHtml)
+    {
+        _actions.Add(new TemplateStreamAction("prepend", target, trustedHtml, TemplateContentKind.TrustedHtml));
 
         return this;
     }
@@ -77,14 +123,36 @@ public class RazorWireStreamBuilder
     }
 
     /// <summary>
-    /// Queues a raw HTML replace action targeting the specified DOM element.
+    /// Queues a replace action that inserts HTML-encoded text into the specified target element.
     /// </summary>
     /// <param name="target">The DOM element selector or identifier to target.</param>
-    /// <param name="templateHtml">The HTML content used to replace the target's contents.</param>
+    /// <param name="content">Plain-text content used to replace the target's contents; <c>null</c> renders as empty text.</param>
     /// <returns>The current RazorWireStreamBuilder instance.</returns>
-    public RazorWireStreamBuilder Replace(string target, string templateHtml)
+    /// <remarks>
+    /// RazorWire HTML-encodes <paramref name="content"/> before placing it in the stream template. Use
+    /// <see cref="ReplaceHtml(string,string?)"/> only for trusted HTML fragments.
+    /// </remarks>
+    public RazorWireStreamBuilder Replace(string target, string? content)
     {
-        _actions.Add(new RawHtmlStreamAction("replace", target, templateHtml));
+        _actions.Add(new TemplateStreamAction("replace", target, content, TemplateContentKind.PlainText));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Queues a replace action that inserts a trusted HTML fragment without encoding or sanitizing it.
+    /// </summary>
+    /// <remarks>
+    /// RazorWire writes <paramref name="trustedHtml"/> directly into the stream template. Use this only for
+    /// server-authored trusted markup; encode user values before composing the fragment. Prefer
+    /// <see cref="Replace(string,string?)"/> for text and partial or component helpers for Razor-rendered markup.
+    /// </remarks>
+    /// <param name="target">The DOM element selector or identifier to target.</param>
+    /// <param name="trustedHtml">Trusted HTML content used to replace the target's contents; <c>null</c> renders as an empty fragment.</param>
+    /// <returns>The current RazorWireStreamBuilder instance.</returns>
+    public RazorWireStreamBuilder ReplaceHtml(string target, string? trustedHtml)
+    {
+        _actions.Add(new TemplateStreamAction("replace", target, trustedHtml, TemplateContentKind.TrustedHtml));
 
         return this;
     }
@@ -104,14 +172,36 @@ public class RazorWireStreamBuilder
     }
 
     /// <summary>
-    /// Queues a raw HTML "update" turbo-stream action for the specified DOM target using the provided HTML template.
+    /// Queues an update action that inserts HTML-encoded text into the specified target element.
     /// </summary>
     /// <param name="target">The DOM target selector or identifier to apply the update to.</param>
-    /// <param name="templateHtml">The HTML fragment to use as the action's template.</param>
+    /// <param name="content">Plain-text content to use as the action's template; <c>null</c> renders as empty text.</param>
     /// <returns>The same RazorWireStreamBuilder instance for fluent chaining.</returns>
-    public RazorWireStreamBuilder Update(string target, string templateHtml)
+    /// <remarks>
+    /// RazorWire HTML-encodes <paramref name="content"/> before placing it in the stream template. Use
+    /// <see cref="UpdateHtml(string,string?)"/> only for trusted HTML fragments.
+    /// </remarks>
+    public RazorWireStreamBuilder Update(string target, string? content)
     {
-        _actions.Add(new RawHtmlStreamAction("update", target, templateHtml));
+        _actions.Add(new TemplateStreamAction("update", target, content, TemplateContentKind.PlainText));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Queues an update action that inserts a trusted HTML fragment without encoding or sanitizing it.
+    /// </summary>
+    /// <remarks>
+    /// RazorWire writes <paramref name="trustedHtml"/> directly into the stream template. Use this only for
+    /// server-authored trusted markup; encode user values before composing the fragment. Prefer
+    /// <see cref="Update(string,string?)"/> for text and partial or component helpers for Razor-rendered markup.
+    /// </remarks>
+    /// <param name="target">The DOM target selector or identifier to apply the update to.</param>
+    /// <param name="trustedHtml">Trusted HTML fragment to use as the action's template; <c>null</c> renders as an empty fragment.</param>
+    /// <returns>The same RazorWireStreamBuilder instance for fluent chaining.</returns>
+    public RazorWireStreamBuilder UpdateHtml(string target, string? trustedHtml)
+    {
+        _actions.Add(new TemplateStreamAction("update", target, trustedHtml, TemplateContentKind.TrustedHtml));
 
         return this;
     }
@@ -248,7 +338,7 @@ public class RazorWireStreamBuilder
     /// <returns>The current <see cref="RazorWireStreamBuilder"/> instance for fluent chaining.</returns>
     public RazorWireStreamBuilder Remove(string target)
     {
-        _actions.Add(new RawHtmlStreamAction("remove", target, null));
+        _actions.Add(new TemplateStreamAction("remove", target, content: null, TemplateContentKind.TrustedHtml));
 
         return this;
     }
@@ -308,10 +398,11 @@ public class RazorWireStreamBuilder
     public RazorWireStreamBuilder FormError(string target, string title, string message)
     {
         _hasFormError = true;
-        _actions.Add(new RawHtmlStreamAction(
+        _actions.Add(new TemplateStreamAction(
             "update",
             target,
-            BuildGeneratedFormErrorHtml(title, message, [], "server")));
+            BuildGeneratedFormErrorHtml(title, message, [], "server"),
+            TemplateContentKind.TrustedHtml));
 
         return this;
     }
@@ -353,7 +444,7 @@ public class RazorWireStreamBuilder
             ? message
             : "Check the validation messages and try again.";
 
-        _actions.Add(new RawHtmlStreamAction(
+        _actions.Add(new TemplateStreamAction(
             "update",
             target,
             BuildGeneratedFormErrorHtml(
@@ -361,7 +452,8 @@ public class RazorWireStreamBuilder
                 fallbackMessage,
                 visibleErrors,
                 "validation",
-                hiddenCount)));
+                hiddenCount),
+            TemplateContentKind.TrustedHtml));
 
         return this;
     }
@@ -512,23 +604,36 @@ public class RazorWireStreamBuilder
 
     private sealed record RazorWireValidationError(string Key, string Message);
 
-    private class RawHtmlStreamAction : ISynchronousRazorWireStreamAction
+    private enum TemplateContentKind
+    {
+        PlainText,
+        TrustedHtml
+    }
+
+    private class TemplateStreamAction : ISynchronousRazorWireStreamAction
     {
         public string Action { get; }
         public string Target { get; }
-        public string? Html { get; }
+        public string? Content { get; }
+        public TemplateContentKind ContentKind { get; }
 
         /// <summary>
-        /// Initializes a new instance with the specified turbo-stream action, target, and optional HTML template.
+        /// Initializes a new instance with the specified turbo-stream action, target, and optional template content.
         /// </summary>
         /// <param name="action">The turbo-stream action name (e.g., "append", "prepend", "replace", "update", or "remove").</param>
         /// <param name="target">The DOM target selector or identifier that the action will be applied to.</param>
-        /// <param name="html">The HTML template to use for the action; pass <c>null</c> for actions that do not require a template (such as "remove").</param>
-        public RawHtmlStreamAction(string action, string target, string? html)
+        /// <param name="content">The template content to use for the action; pass <c>null</c> for empty templates or actions that do not require a template.</param>
+        /// <param name="contentKind">Whether the template content is plain text that must be encoded or trusted HTML that can be written as-is.</param>
+        public TemplateStreamAction(
+            string action,
+            string target,
+            string? content,
+            TemplateContentKind contentKind)
         {
             Action = action;
             Target = target;
-            Html = html;
+            Content = content;
+            ContentKind = contentKind;
         }
 
         /// <summary>
@@ -546,7 +651,19 @@ public class RazorWireStreamBuilder
             }
 
             return $"<turbo-stream action=\"{encodedAction}\" target=\"{encodedTarget}\">"
-                   + $"<template>{Html}</template></turbo-stream>";
+                   + $"<template>{RenderTemplateContent()}</template></turbo-stream>";
+        }
+
+        private string RenderTemplateContent()
+        {
+            var content = Content ?? string.Empty;
+
+            return ContentKind switch
+            {
+                TemplateContentKind.PlainText => HtmlEncoder.Default.Encode(content),
+                TemplateContentKind.TrustedHtml => content,
+                _ => throw new InvalidOperationException("Unsupported RazorWire template content kind.")
+            };
         }
 
         /// <summary>

--- a/Web/ForgeTrust.RazorWire/Bridge/RazorWireStreamResult.cs
+++ b/Web/ForgeTrust.RazorWire/Bridge/RazorWireStreamResult.cs
@@ -43,7 +43,13 @@ public class RazorWireStreamResult : IActionResult
     /// <summary>
     /// Creates a <see cref="RazorWireStreamResult"/> that will stream the provided raw HTML as a single render action.
     /// </summary>
-    /// <param name="rawContent">Raw HTML to stream; if null, an empty string is used.</param>
+    /// <remarks>
+    /// This constructor is a trusted whole-stream escape hatch. RazorWire writes <paramref name="rawContent"/> exactly as
+    /// provided; it does not encode, sanitize, wrap, or validate the payload. Prefer
+    /// <see cref="RazorWireStreamBuilder"/> when composing targeted stream actions, and encode user-supplied values before
+    /// they are included in raw stream markup.
+    /// </remarks>
+    /// <param name="rawContent">Trusted raw Turbo Stream HTML to stream; if null, an empty string is used.</param>
     public RazorWireStreamResult(string? rawContent)
     {
         _actions = [new RawHtmlStreamAction(rawContent ?? string.Empty)];

--- a/Web/ForgeTrust.RazorWire/Docs/form-failures.md
+++ b/Web/ForgeTrust.RazorWire/Docs/form-failures.md
@@ -189,6 +189,12 @@ Use `FormError` or `FormValidationErrors` for server-rendered failure UI. Those 
 
 Refresh the token whenever a stream replaces form contents. Prefer `ReplacePartial` for the whole `<form>` so the MVC Form TagHelper emits a fresh token, or include `@Html.AntiForgeryToken()` inside updated form fields. See [Security & Anti-Forgery](./antiforgery.md).
 
+## Symptom: Tags Appear As Text After A Stream Update
+
+`Append`, `Prepend`, `Replace`, and `Update` treat their `content` argument as plain text and HTML-encode it. That is the safe default for validation messages, status labels, counters, and any value that could include caller-supplied text.
+
+If you intended to render app-authored markup, move the markup into a Razor partial or view component and use `AppendPartial`, `ReplacePartial`, `UpdatePartial`, or the matching component helper. For small server-authored fragments, use `AppendHtml`, `PrependHtml`, `ReplaceHtml`, or `UpdateHtml` only after encoding any user-controlled values before composing the trusted fragment.
+
 ## Safe Reporting
 
 Production users should see short recovery messages. Detailed diagnostics should stay in development or server logs. When reporting failed-form bugs, include the action route, HTTP status, response content type, whether `X-RazorWire-Form-Handled` was present, and whether the form had `data-rw-form-failure-target`.

--- a/Web/ForgeTrust.RazorWire/README.md
+++ b/Web/ForgeTrust.RazorWire/README.md
@@ -207,6 +207,50 @@ RazorWire can also send a narrow same-origin visit command with `Visit(...)`. Vi
 
 The in-memory stream hub keeps live subscriber tracking separate from opt-in replay retention. Empty live channel tracking is released after the last subscriber disconnects or publish-time cleanup prunes stale writers. Retained replay buffers are not deleted by live disconnects; they stay bounded by the replay retention policy.
 
+### Text vs Trusted HTML in Stream Templates
+
+RazorWire stream templates have a deliberate trust boundary:
+
+| API | Template content handling | Use when |
+|---|---|---|
+| `Append`, `Prepend`, `Replace`, `Update` | Treats `content` as plain text and HTML-encodes it. `null` renders as empty text. | Updating counters, status labels, validation targets, and any caller-supplied text. |
+| `AppendHtml`, `PrependHtml`, `ReplaceHtml`, `UpdateHtml` | Writes `trustedHtml` directly. RazorWire does not encode or sanitize it. | Inserting small server-authored fragments where every user value has already been encoded. |
+| `AppendPartial`, `PrependPartial`, `ReplacePartial`, `UpdatePartial` | Renders a Razor partial through MVC. | Returning app markup that belongs in a `.cshtml` partial. |
+| `AppendComponent`, `PrependComponent`, `ReplaceComponent`, `UpdateComponent` | Renders a view component through MVC. | Returning reusable app markup with component logic. |
+| `new RazorWireStreamResult(rawContent)` and `IRazorWireStreamHub.PublishAsync(channel, content)` | Raw whole-stream boundaries. Content is transported as-is. | Advanced integrations that already built trusted Turbo Stream markup. |
+
+Prefer the text APIs by default:
+
+```csharp
+return this.RazorWireStream()
+    .Update("status", displayName)
+    .BuildResult();
+```
+
+If `displayName` is `<b>Ada</b>`, the browser receives text, not markup:
+
+```html
+<template>&lt;b&gt;Ada&lt;/b&gt;</template>
+```
+
+For app-authored markup, prefer Razor-rendered helpers:
+
+```csharp
+return this.RazorWireStream()
+    .ReplacePartial("profile-card", "_ProfileCard", model)
+    .BuildResult();
+```
+
+Use `*Html` only when the string is already trusted and caller-owned. Encode user values before composing the fragment:
+
+```csharp
+var encodedName = System.Net.WebUtility.HtmlEncode(displayName);
+
+return this.RazorWireStream()
+    .UpdateHtml("status", $"<p>Saved {encodedName}.</p>")
+    .BuildResult();
+```
+
 ### Form Enhancement
 
 Standard HTML forms can return targeted stream updates instead of full reloads or redirect-first flows. The counter example above is the smallest version of that story: submit a normal MVC form, return RazorWire updates, and change only the DOM you care about.
@@ -218,6 +262,8 @@ When `EnableFailureUx` is enabled, `form[rw-active]` also marks enhanced form po
 Handling anti-forgery tokens correctly is critical when updating forms via Turbo Streams. See [Security & Anti-Forgery](Docs/antiforgery.md) for the detailed patterns and recommendations.
 
 RazorWire stream subscriptions are also safe by default: `RazorWireOptions.Streams.AuthorizationMode` starts at `RazorWireStreamAuthorizationMode.DenyAll`, so `rw:stream-source` receives `403` until the app either opts into `RazorWireStreamAuthorizationMode.AllowAll` for public/demo channels or registers `IRazorWireChannelAuthorizer`. Development responses include a safe plain-text diagnostic; production denials stay generic and logs avoid raw channel names, user identifiers, and claim values.
+
+Stream builder text APIs encode template content by default. The `*Html` builder methods, `RazorWireStreamResult(string?)`, and `IRazorWireStreamHub.PublishAsync(channel, content)` are trusted boundaries: they do not encode or sanitize raw markup. Keep user-controlled values in text APIs, Razor partials, or view components unless you explicitly encode them before composing trusted HTML.
 
 Development anti-forgery failures from RazorWire forms are rewritten into helpful form-local diagnostics when possible. Production responses stay safe and generic. See [Failed Form UX](Docs/form-failures.md#development-diagnostics).
 
@@ -237,8 +283,8 @@ RazorWire is designed for a fast feedback loop during development:
 
 ### `IRazorWireStreamHub`
 
-- `PublishAsync(channel, content)` broadcasts a Turbo Stream fragment to every subscriber on a channel.
-- `PublishAsync(channel, content, new RazorWireStreamPublishOptions { Replay = true })` broadcasts the fragment and retains it in the channel's bounded replay buffer.
+- `PublishAsync(channel, content)` broadcasts a trusted Turbo Stream fragment to every subscriber on a channel. The hub transports `content` as-is; it does not encode or sanitize template content.
+- `PublishAsync(channel, content, new RazorWireStreamPublishOptions { Replay = true })` broadcasts the trusted fragment and retains it in the channel's bounded replay buffer.
 - `Subscribe(channel)` receives only live messages published after subscription.
 - `Subscribe(channel, new RazorWireStreamSubscribeOptions { Replay = true })` receives retained replay messages first, then continues with live messages.
 
@@ -259,10 +305,11 @@ Replay is opt-in and intentionally small. The in-memory hub keeps up to 25 retai
 
 ### `this.RazorWireStream()` (controller extension)
 
-- `Append(target, content)` adds content to the end of the target element.
-- `Prepend(target, content)` adds content to the beginning.
-- `Replace(target, content)` replaces the target element entirely.
-- `Update(target, content)` replaces the inner content of the target.
+- `Append(target, content)` adds HTML-encoded text to the end of the target element.
+- `Prepend(target, content)` adds HTML-encoded text to the beginning.
+- `Replace(target, content)` replaces the target element entirely with HTML-encoded text.
+- `Update(target, content)` replaces the inner content of the target with HTML-encoded text.
+- `AppendHtml(target, trustedHtml)`, `PrependHtml(target, trustedHtml)`, `ReplaceHtml(target, trustedHtml)`, and `UpdateHtml(target, trustedHtml)` insert trusted HTML without encoding or sanitizing. Use partials/components for app markup when practical, and encode user values before composing trusted fragments.
 - `Remove(target)` removes the target element.
 - `FormError(target, title, message)` updates the target with an encoded generated error block and marks the response handled.
 - `FormValidationErrors(target, ModelState, title, maxErrors, message)` updates the target with a stable MVC validation summary and marks the response handled.

--- a/Web/ForgeTrust.RazorWire/Streams/IRazorWireStreamHub.cs
+++ b/Web/ForgeTrust.RazorWire/Streams/IRazorWireStreamHub.cs
@@ -13,18 +13,28 @@ namespace ForgeTrust.RazorWire.Streams;
 public interface IRazorWireStreamHub
 {
     /// <summary>
-    /// Publishes a string message to the specified channel.
+    /// Publishes a trusted stream message to the specified channel.
     /// </summary>
     /// <param name="channel">The name of the channel to publish the message to.</param>
-    /// <param name="message">The message payload to publish.</param>
+    /// <param name="message">
+    /// The trusted Turbo Stream payload to publish. The hub transports this string as-is; it does not encode or sanitize
+    /// template content.
+    /// </param>
     /// <returns>A <see cref="ValueTask"/> that completes when the publish operation has finished.</returns>
+    /// <remarks>
+    /// Prefer publishing output from <see cref="Bridge.RazorWireStreamBuilder"/> so plain-text values are encoded before
+    /// the message reaches the hub. If composing a raw message, encode user-supplied values before publishing.
+    /// </remarks>
     ValueTask PublishAsync(string channel, string message);
 
     /// <summary>
-    /// Publishes a string message to the specified channel with explicit delivery options.
+    /// Publishes a trusted stream message to the specified channel with explicit delivery options.
     /// </summary>
     /// <param name="channel">The name of the channel to publish the message to.</param>
-    /// <param name="message">The message payload to publish.</param>
+    /// <param name="message">
+    /// The trusted Turbo Stream payload to publish. The hub transports this string as-is; it does not encode or sanitize
+    /// template content.
+    /// </param>
     /// <param name="options">
     /// Optional publish behavior. The default interface implementation is a compatibility fallback and ignores this value
     /// by delegating to <see cref="PublishAsync(string, string)"/>. Implementations that support replay retention or other
@@ -33,7 +43,9 @@ public interface IRazorWireStreamHub
     /// <returns>A <see cref="ValueTask"/> that completes when the publish operation has finished.</returns>
     /// <remarks>
     /// Pitfall: callers should not expect <see cref="RazorWireStreamPublishOptions"/> to be honored unless the concrete
-    /// <see cref="IRazorWireStreamHub"/> implementation overrides this member.
+    /// <see cref="IRazorWireStreamHub"/> implementation overrides this member. The hub is also a raw transport boundary:
+    /// use <see cref="Bridge.RazorWireStreamBuilder"/> or encode user-supplied values before publishing raw stream
+    /// strings.
     /// </remarks>
     ValueTask PublishAsync(string channel, string message, RazorWireStreamPublishOptions? options)
     {

--- a/examples/razorwire-mvc/Controllers/ReactivityController.cs
+++ b/examples/razorwire-mvc/Controllers/ReactivityController.cs
@@ -217,7 +217,7 @@ public class ReactivityController : Controller
             var savedDisplayName = normalizedDisplayName!;
 
             return this.RazorWireStream()
-                .Update(
+                .UpdateHtml(
                     "validation-result",
                     $"""
                     <p class="text-sm font-semibold text-emerald-700">Saved {System.Net.WebUtility.HtmlEncode(savedDisplayName)}.</p>

--- a/examples/razorwire-mvc/Services/UserPresenceBackgroundService.cs
+++ b/examples/razorwire-mvc/Services/UserPresenceBackgroundService.cs
@@ -70,7 +70,7 @@ public class UserPresenceBackgroundService : CriticalService
                             "~/Views/Shared/_UserListEmpty.cshtml",
                             cancellationToken: stoppingToken);
 
-                        stream.Append("active-user-list", emptyHtml);
+                        stream.AppendHtml("active-user-list", emptyHtml);
                     }
 
                     await _hub.PublishAsync("reactivity", stream.Build());

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -161,6 +161,7 @@ Post-RC1 work is now collected here as deltas from the current release candidate
 
 ### RazorWire streams
 
+- RazorWire stream builder text APIs now HTML-encode template content by default. `Append`, `Prepend`, `Replace`, and `Update` are safe text helpers, while new `AppendHtml`, `PrependHtml`, `ReplaceHtml`, and `UpdateHtml` methods preserve trusted server-authored markup without encoding or sanitizing. Raw whole-stream paths such as `RazorWireStreamResult(string?)` and `IRazorWireStreamHub.PublishAsync(channel, content)` remain trusted boundaries.
 - RazorWire's in-memory stream hub now releases empty live channel tracking after the last subscriber disconnects or publish-time cleanup prunes stale writers. Replay buffers remain separate from live subscriber state, keep 25 retained messages per channel, prune inactive replay channels after more than 256 replay channels are retained, and are not deleted just because the last live subscriber disconnects.
 
 ### Web host development defaults
@@ -174,6 +175,7 @@ Post-RC1 work is now collected here as deltas from the current release candidate
 
 ## Migration watch
 
+- RazorWire stream markup callers should audit `.Append(`, `.Prepend(`, `.Replace(`, `.Update(`, `new RazorWireStreamResult(`, and `PublishAsync(..., string)`. Keep text/status/counter updates on the existing methods, move Razor markup to partial or component helpers when practical, and use `AppendHtml`/`PrependHtml`/`ReplaceHtml`/`UpdateHtml` only for trusted fragments with user values encoded before composition.
 - Existing RazorWire CLI users do not need command or flag changes for the process-execution migration. The main behavior difference is that target-app failures may now appear earlier with captured output instead of being hidden behind startup or readiness timeouts.
 - RazorWire stream consumers do not need application code changes for the live-channel cleanup update. Public or demo stream endpoints should still validate or namespace channel names before opting into `AllowAll`; active connection cardinality limits are tracked separately from this cleanup work.
 - Tailwind package consumers do not need source changes for the compiled MSBuild task. Maintainers should keep the packed-package smoke path green when changing task dependencies or diagnostics.


### PR DESCRIPTION
## Summary

- Implement DSS-013 by making RazorWire stream builder string APIs (`Append`, `Prepend`, `Replace`, `Update`) HTML-encoding text APIs.
- Add explicit trusted-markup APIs (`AppendHtml`, `PrependHtml`, `ReplaceHtml`, `UpdateHtml`) with XML docs that state they do not encode or sanitize.
- Document raw whole-stream trust boundaries for `RazorWireStreamResult(string?)` and `IRazorWireStreamHub.PublishAsync(channel, content)`.
- Update RazorWire samples, README guidance, troubleshooting docs, and unreleased migration notes.

Fixes: https://github.com/orgs/forge-trust/projects/4?pane=issue&itemId=193870684

## Test Coverage

All DSS-013 code paths added by this PR are covered through public APIs:

- All four safe text actions encode template content.
- All four trusted HTML actions preserve trusted markup.
- Target values encode, null content renders as empty, mixed ordering is stable.
- `Build`, `RenderAsync`, and `BuildResult` remain covered.
- `RazorWireStreamResult` raw/null behavior is covered.
- Hub live publish and replay transport preserve encoded builder output.

Solution coverage:

- Line coverage: 95.41% (31600/33121)
- Branch coverage: 88.73% (10419/11743)
- Cobertura: `TestResults/coverage-merged/coverage.cobertura.xml`

## Pre-Landing Review

No code issues found in the pre-landing review. One non-blocking observation from review was that `*Html` APIs are directly covered through `Build()` while the async/result paths are covered by the same shared template rendering path.

## Design Review

No frontend UI files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

CLEAN. The implementation matches the approved DSS-013 plan: safe text defaults, explicit trusted HTML escape hatches, sample migration, raw-boundary documentation, migration notes, and transport regression coverage.

## Plan Completion

- Safe text APIs: done.
- Trusted HTML APIs: done.
- Shared rendering behavior for builder/result async paths: done.
- Sample call-site audit/migration: done.
- README/troubleshooting/release migration docs: done.
- Builder, result, hub transport, null, target encoding, ordering, build/render/result tests: done.

## Documentation

Updated:

- `Web/ForgeTrust.RazorWire/README.md`
- `Web/ForgeTrust.RazorWire/Docs/form-failures.md`
- `releases/unreleased.md`
- XML docs for RazorWire stream builder, result, and hub APIs

Release metadata note: this repo currently has no root `VERSION` or root `package.json` version, and recent AppSurface PRs do not use version-prefixed titles. The release delta is recorded in `releases/unreleased.md`, matching the current repository convention.

## Test Plan

- [x] `dotnet test Web/ForgeTrust.RazorWire.Tests/ForgeTrust.RazorWire.Tests.csproj`
- [x] `dotnet build examples/razorwire-mvc/RazorWireWebExample.csproj`
- [x] `dotnet format --verify-no-changes`
- [x] `git diff --check`
- [x] `./scripts/coverage-solution.sh`
