### PR TITLE
ci: add measured NuGet cache rollout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 20
     env:
       CODECOV_TOKEN_PRESENT: ${{ secrets.CODECOV_TOKEN != '' }}
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
     steps:
       - name: Checkout code
@@ -32,10 +33,34 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET SDK
+        id: setup-dotnet
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: |
             10.0.x
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
+
+      - name: Restore .NET packages (locked, cache-aware)
+        run: |
+          start_seconds="$(date +%s)"
+          dotnet nuget locals global-packages --list
+          dotnet restore ForgeTrust.AppSurface.slnx --locked-mode
+          restore_seconds="$(( $(date +%s) - start_seconds ))"
+          package_size="$(du -sh "$NUGET_PACKAGES" 2>/dev/null | cut -f1 || true)"
+
+          {
+            echo "### NuGet cache summary"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Workflow job | build.yml / build |"
+            echo "| Cache hit | ${{ steps.setup-dotnet.outputs.cache-hit }} |"
+            echo "| Cache dependency path | \`**/packages.lock.json\` |"
+            echo "| NUGET_PACKAGES | \`$NUGET_PACKAGES\` |"
+            echo "| Package folder size | ${package_size:-unknown} |"
+            echo "| Locked restore duration | ${restore_seconds}s |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -51,11 +76,11 @@ jobs:
 
       - name: Verify generated package chooser
         run: |
-          dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- verify
+          dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj --configuration Release --no-restore -- verify
 
       - name: Verify generated Markdown snippets
         run: |
-          dotnet run --project tools/ForgeTrust.AppSurface.MarkdownSnippets/ForgeTrust.AppSurface.MarkdownSnippets.csproj -- verify
+          dotnet run --project tools/ForgeTrust.AppSurface.MarkdownSnippets/ForgeTrust.AppSurface.MarkdownSnippets.csproj --configuration Release --no-restore -- verify
 
       - name: Verify web assets
         run: |
@@ -68,6 +93,7 @@ jobs:
       - name: Run solution coverage
         env:
           BUILD_CONFIGURATION: Release
+          BUILD_NO_RESTORE: true
         run: |
           ./scripts/coverage-solution.sh
 
@@ -92,6 +118,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
     steps:
       - name: Checkout code
@@ -101,20 +129,44 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET SDK
+        id: setup-dotnet
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: |
             10.0.x
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
+
+      - name: Restore AppSurface CLI packages (locked, cache-aware)
+        run: |
+          start_seconds="$(date +%s)"
+          dotnet nuget locals global-packages --list
+          dotnet restore Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj --locked-mode
+          restore_seconds="$(( $(date +%s) - start_seconds ))"
+          package_size="$(du -sh "$NUGET_PACKAGES" 2>/dev/null | cut -f1 || true)"
+
+          {
+            echo "### NuGet cache summary"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Workflow job | build.yml / export-appsurface-docs |"
+            echo "| Cache hit | ${{ steps.setup-dotnet.outputs.cache-hit }} |"
+            echo "| Cache dependency path | \`**/packages.lock.json\` |"
+            echo "| NUGET_PACKAGES | \`$NUGET_PACKAGES\` |"
+            echo "| Package folder size | ${package_size:-unknown} |"
+            echo "| Locked restore duration | ${restore_seconds}s |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build AppSurface CLI (Release)
         run: |
-          dotnet build Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release
+          dotnet build Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release --no-restore
 
       - name: Verify AppSurface Docs harvest health
         env:
           AppSurfaceDocs__Harvest__JavaScript__IncludeGlobs__0: Web/ForgeTrust.RazorWire/assets/contracts/razorwire-public-contracts.js
         run: |
-          dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release --no-build -- \
+          dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release --no-build --no-restore -- \
             docs verify-health \
             --repo . \
             --require-complete-event-doclets \
@@ -140,7 +192,7 @@ jobs:
         run: |
           printf '%s\n' '/' '/docs' > "$RUNNER_TEMP/appsurface-docs-seeds.txt"
           # CI docs export can spend just over 10s in cold host startup while generating the first harvest snapshot.
-          dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release --no-build -- \
+          dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release --no-build --no-restore -- \
             docs export \
             --repo . \
             --mode cdn \

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,6 +20,8 @@ jobs:
   dotnet-format:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
     steps:
       - name: Checkout code
@@ -28,13 +30,34 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET SDK
+        id: setup-dotnet
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: |
             10.0.x
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
 
-      - name: Restore packages
-        run: dotnet restore ForgeTrust.AppSurface.slnx --locked-mode
+      - name: Restore packages (locked, cache-aware)
+        run: |
+          start_seconds="$(date +%s)"
+          dotnet nuget locals global-packages --list
+          dotnet restore ForgeTrust.AppSurface.slnx --locked-mode
+          restore_seconds="$(( $(date +%s) - start_seconds ))"
+          package_size="$(du -sh "$NUGET_PACKAGES" 2>/dev/null | cut -f1 || true)"
+
+          {
+            echo "### NuGet cache summary"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Workflow job | code-quality.yml / dotnet-format |"
+            echo "| Cache hit | ${{ steps.setup-dotnet.outputs.cache-hit }} |"
+            echo "| Cache dependency path | \`**/packages.lock.json\` |"
+            echo "| NUGET_PACKAGES | \`$NUGET_PACKAGES\` |"
+            echo "| Package folder size | ${package_size:-unknown} |"
+            echo "| Locked restore duration | ${restore_seconds}s |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build project
         run: dotnet build ForgeTrust.AppSurface.slnx --configuration Release --no-restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - AppSurface Docs JavaScript harvesting now skips symlinks, junctions, and other reparse points before explicit include reads, include-root traversal, and recursive child descent. Configured JavaScript link includes emit `appsurfacedocs.javascript.reparse_point_skipped` with redacted recovery guidance and block strict JavaScript health when JavaScript participates.
 - RazorWire stream endpoints now reject malformed channels with `400`, deny unauthorized channels with `403`, and return `429` when per-process live-channel or subscription admission limits are exhausted before hub subscriber state is allocated.
 - Config audit discovered-key reports now expose value display state and omit raw unknown or broad-descendant scalar values unless the exact leaf key is registered or the value is redacted.
+- CI now includes a measured NuGet cache rollout for selected build, docs export, and code-quality jobs while keeping package-gate restores isolated.
+- PackageIndex verification now ignores hidden local cache directories such as `.pnpm-store` and workspace `.nuget/packages` so local cache contents do not require package manifest entries.
 
 ## 0.1.0-rc.1 - 2026-05-29
 

--- a/eng/ci-critical-path.md
+++ b/eng/ci-critical-path.md
@@ -41,3 +41,34 @@ Future CI performance changes should compare:
 - Keep PR tests in a single coverage-bearing lane until measured group runs prove they reduce total GitHub Actions minutes, not just wall-clock time.
 - Keep experimental test groups bounded and readable: `core`, `tools`, `web`, `docs`, `razorwire`, and `integration`.
 - Preserve a single merged Cobertura output at `TestResults/coverage-merged/coverage.cobertura.xml` for Codecov and local contributors.
+
+## NuGet cache policy
+
+Issue #479 treats NuGet package caching as a measured CI hygiene change, not as the primary fix for the solution coverage long pole. Caching is enabled only for jobs that repeatedly restore the shared locked dependency graph:
+
+- `build.yml` / `build`
+- `build.yml` / `export-appsurface-docs`
+- `code-quality.yml` / `dotnet-format`
+
+Each cache-enabled job sets `NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages` at the job level before `actions/setup-dotnet`, then uses `setup-dotnet` with `cache: true` and `cache-dependency-path: '**/packages.lock.json'`. The broad lock-file path is intentional for this first rollout because the selected solution-shaped jobs restore project graphs spread across the repository. A dependency or lock-file change anywhere in that graph can invalidate the cache; that is expected and safer than silently omitting a restored project from the cache key. If future timing data shows lock-file churn dominates cache misses, split the cache dependency paths by job/project scope in a follow-up.
+
+Cache-enabled build jobs should restore explicitly before later .NET commands. When `build.yml` runs `scripts/coverage-solution.sh` after that restore, it sets `BUILD_NO_RESTORE=true` so the script's solution build does not hide additional restore work inside the coverage timing.
+
+Package-sensitive workflows stay uncached unless a separate issue evaluates their trust boundary. In particular, `package-gate.yml` must keep its isolated `${{ runner.temp }}/nuget-packages` restore and `NuGet.package-gate.config` source policy. Publish, smoke-restore, trusted-publishing, and package validation workflows should not inherit the shared NuGet cache by convention.
+
+Cache misses are normal after dependency updates, lock-file updates, or cache eviction. The cache is only useful if warm runs reduce selected workflow time or runner minutes without regressing the all-green decision path. For cache experiments, record at least:
+
+| Run | Cache state | Setup .NET | Locked restore | Build/tests/docs | Workflow total | Notes |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| Baseline after #476 | none | | | | | |
+| First #479 run | miss/populate | | | | | |
+| Warm #479 run | hit | | | | | |
+
+Use the GitHub UI for action step duration and the job summary for cache-hit, package path, package folder size, and locked restore duration. Merge cache changes only when warm-cache evidence shows at least a 30 second net improvement in one selected workflow or at least a 5% total runner-minute/all-green improvement without regression. If the threshold is not met, remove the cache workflow changes and keep only the measurement notes.
+
+Common restore failures:
+
+- A locked restore failure usually means package references or central package versions changed without updating `packages.lock.json`. Run `dotnet restore --force-evaluate`, commit the updated lock files, and rerun CI.
+- `NU1403` after enabling setup-dotnet caching can happen because the action restores only the global packages folder. If CI hits this, add or test `DisableImplicitNuGetFallbackFolder` centrally before widening the cache rollout.
+
+Rollback is per job: remove `cache: true`, remove `cache-dependency-path`, and remove job-level `NUGET_PACKAGES` from the affected cache-enabled job. Leave package-gate's isolated temp `NUGET_PACKAGES` in place.

--- a/scripts/coverage-solution.sh
+++ b/scripts/coverage-solution.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SOLUTION_PATH="$ROOT_DIR/ForgeTrust.AppSurface.slnx"
 OUTPUT_DIR="$ROOT_DIR/TestResults/coverage-merged"
 BUILD_CONFIGURATION="${BUILD_CONFIGURATION:-Debug}"
+BUILD_NO_RESTORE="${BUILD_NO_RESTORE:-false}"
 INCLUDE_FILTER="${INCLUDE_FILTER:-[ForgeTrust.AppSurface.*]*}"
 EXCLUDE_FILTER="${EXCLUDE_FILTER:-[*.Tests]*,[*.IntegrationTests]*}"
 EXCLUDE_FILTER="${EXCLUDE_FILTER//,/%2c}"
@@ -27,6 +28,7 @@ Groups:
 Environment:
   BUILD_CONFIGURATION   Test configuration. Defaults to Debug.
   BUILD_SOLUTION        true/false. Defaults to true for all, false for named groups.
+  BUILD_NO_RESTORE      true/false. Adds --no-restore to the solution build after a prior restore.
   INCLUDE_FILTER        Coverlet include filter.
   EXCLUDE_FILTER        Coverlet exclude filter.
 EOF
@@ -414,7 +416,12 @@ build_seconds=0
 if [[ "$BUILD_SOLUTION" == true ]]; then
   echo "Building solution..."
   build_start="$(seconds_now)"
-  if ! dotnet build "$SOLUTION_PATH" --configuration "$BUILD_CONFIGURATION" -v minimal; then
+  build_args=(dotnet build "$SOLUTION_PATH" --configuration "$BUILD_CONFIGURATION" -v minimal)
+  if [[ "$BUILD_NO_RESTORE" == true ]]; then
+    build_args+=(--no-restore)
+  fi
+
+  if ! "${build_args[@]}"; then
     echo "Build failed for $SOLUTION_PATH" >&2
     exit 1
   fi

--- a/scripts/coverage-solution.sh
+++ b/scripts/coverage-solution.sh
@@ -29,7 +29,7 @@ Environment:
   TEST_GROUP            Test group to run. Defaults to all.
   BUILD_CONFIGURATION   Test configuration. Defaults to Debug.
   BUILD_SOLUTION        true/false. Defaults to true for all, false for named groups.
-  BUILD_NO_RESTORE      true/false. Adds --no-restore to the solution build after a prior restore.
+  BUILD_NO_RESTORE      true/false. Adds --no-restore to build and test commands after a prior restore.
   INCLUDE_FILTER        Coverlet include filter.
   EXCLUDE_FILTER        Coverlet exclude filter.
 EOF
@@ -497,6 +497,10 @@ for i in "${!test_projects[@]}"; do
 
   if [[ "$BUILD_SOLUTION" == true ]]; then
     args+=(--no-build)
+  fi
+
+  if [[ "$BUILD_NO_RESTORE" == true ]]; then
+    args+=(--no-restore)
   fi
 
   project_start="$(seconds_now)"

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageIndexGeneratorTests.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageIndexGeneratorTests.cs
@@ -2471,6 +2471,18 @@ public sealed class PackageIndexGeneratorTests : IDisposable
     }
 
     [Fact]
+    public async Task DiscoverProjects_PrunesHiddenCacheDirectories()
+    {
+        await WriteFileAsync("Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "<Project />");
+        await WriteFileAsync(".pnpm-store/v11/projects/cache-key/Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj", "<Project />");
+        await WriteFileAsync(".nuget/packages/example/1.0.0/contentFiles/any/net10.0/CachedProject.csproj", "<Project />");
+
+        var projects = new PackageProjectScanner().DiscoverProjects(_repositoryRoot);
+
+        Assert.Equal(["Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj"], projects);
+    }
+
+    [Fact]
     [Trait("Category", "Integration")]
     public async Task DotNetProjectMetadataProvider_ParsesRealMsbuildOutput()
     {

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageIndexGeneratorTests.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageIndexGeneratorTests.cs
@@ -2465,6 +2465,8 @@ public sealed class PackageIndexGeneratorTests : IDisposable
         Assert.False(PackageProjectScanner.IsCandidateProject("examples/web-app/WebAppExample.csproj"));
         Assert.False(PackageProjectScanner.IsCandidateProject("Web/ForgeTrust.RazorWire.IntegrationTests/ForgeTrust.RazorWire.IntegrationTests.csproj"));
         Assert.False(PackageProjectScanner.IsCandidateProject("Config/ForgeTrust.AppSurface.Config.Tests/ForgeTrust.AppSurface.Config.Tests.csproj"));
+        Assert.False(PackageProjectScanner.IsCandidateProject(".pnpm-store/v11/projects/cache-key/Web/ForgeTrust.AppSurface.Web/ForgeTrust.AppSurface.Web.csproj"));
+        Assert.False(PackageProjectScanner.IsCandidateProject(".nuget/packages/example/1.0.0/contentFiles/any/net10.0/CachedProject.csproj"));
         Assert.True(PackageProjectScanner.IsCandidateProject("Web/ForgeTrust.AppSurface.Docs.Standalone/ForgeTrust.AppSurface.Docs.Standalone.csproj"));
     }
 

--- a/tools/ForgeTrust.AppSurface.PackageIndex/PackageIndexGenerator.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/PackageIndexGenerator.cs
@@ -1842,7 +1842,7 @@ internal sealed class PackageProjectScanner
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repositoryRoot);
 
-        return Directory.EnumerateFiles(repositoryRoot, "*.csproj", SearchOption.AllDirectories)
+        return EnumerateProjectFiles(repositoryRoot)
             .Select(path => Path.GetRelativePath(repositoryRoot, path).Replace('\\', '/'))
             .Where(IsCandidateProject)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
@@ -1898,6 +1898,33 @@ internal sealed class PackageProjectScanner
         return directory
             .Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar])
             .Any(segment => segment.StartsWith(".", StringComparison.Ordinal));
+    }
+
+    private static IEnumerable<string> EnumerateProjectFiles(string directory)
+    {
+        foreach (var projectPath in Directory.EnumerateFiles(directory, "*.csproj", SearchOption.TopDirectoryOnly))
+        {
+            yield return projectPath;
+        }
+
+        foreach (var childDirectory in Directory.EnumerateDirectories(directory))
+        {
+            if (!ShouldDescendIntoDirectory(childDirectory))
+            {
+                continue;
+            }
+
+            foreach (var projectPath in EnumerateProjectFiles(childDirectory))
+            {
+                yield return projectPath;
+            }
+        }
+    }
+
+    private static bool ShouldDescendIntoDirectory(string directory)
+    {
+        var directoryName = Path.GetFileName(directory);
+        return !directoryName.StartsWith(".", StringComparison.Ordinal);
     }
 }
 

--- a/tools/ForgeTrust.AppSurface.PackageIndex/PackageIndexGenerator.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex/PackageIndexGenerator.cs
@@ -1827,8 +1827,9 @@ internal sealed record PackageProjectMetadata(
 /// Discovers candidate projects that should be classified by the package chooser manifest.
 /// </summary>
 /// <remarks>
-/// The scanner intentionally excludes tests, examples, tooling, and generated directories so the manifest only
-/// needs to classify packages that are meaningful to external adopters or package-surface maintainers.
+/// The scanner intentionally excludes tests, examples, tooling, generated directories, and hidden local cache
+/// directories so the manifest only needs to classify packages that are meaningful to external adopters or
+/// package-surface maintainers.
 /// </remarks>
 internal sealed class PackageProjectScanner
 {
@@ -1855,38 +1856,48 @@ internal sealed class PackageProjectScanner
     /// <returns><c>true</c> when the path should be classified by the chooser manifest; otherwise, <c>false</c>.</returns>
     internal static bool IsCandidateProject(string relativePath)
     {
-        var normalizedPath = "/" + relativePath.Replace('\\', '/').Trim('/').ToLowerInvariant();
+        var normalizedPath = relativePath.Replace('\\', '/').Trim('/');
+        var normalizedPathLower = "/" + normalizedPath.ToLowerInvariant();
         var projectName = Path.GetFileNameWithoutExtension(relativePath).ToLowerInvariant();
 
-        if (normalizedPath.Contains("/.git/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/.gstack/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/.agent/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/.claude/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/.codex/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/bin/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/obj/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/node_modules/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/tools/", StringComparison.Ordinal))
+        if (HasHiddenDirectorySegment(normalizedPath)
+            || normalizedPathLower.Contains("/bin/", StringComparison.Ordinal)
+            || normalizedPathLower.Contains("/obj/", StringComparison.Ordinal)
+            || normalizedPathLower.Contains("/node_modules/", StringComparison.Ordinal)
+            || normalizedPathLower.Contains("/tools/", StringComparison.Ordinal))
         {
             return false;
         }
 
-        if (normalizedPath.Contains("/examples/", StringComparison.Ordinal)
-            || normalizedPath.Contains("/benchmarks/", StringComparison.Ordinal)
+        if (normalizedPathLower.Contains("/examples/", StringComparison.Ordinal)
+            || normalizedPathLower.Contains("/benchmarks/", StringComparison.Ordinal)
             || projectName.Contains("benchmarks", StringComparison.Ordinal))
         {
             return false;
         }
 
-        if (normalizedPath.Contains("/tests/", StringComparison.Ordinal)
-            || normalizedPath.Contains(".tests", StringComparison.Ordinal)
-            || normalizedPath.Contains("integrationtests", StringComparison.Ordinal)
+        if (normalizedPathLower.Contains("/tests/", StringComparison.Ordinal)
+            || normalizedPathLower.Contains(".tests", StringComparison.Ordinal)
+            || normalizedPathLower.Contains("integrationtests", StringComparison.Ordinal)
             || projectName.Contains("tests", StringComparison.Ordinal))
         {
             return false;
         }
 
         return true;
+    }
+
+    private static bool HasHiddenDirectorySegment(string relativePath)
+    {
+        var directory = Path.GetDirectoryName(relativePath.Replace('/', Path.DirectorySeparatorChar));
+        if (string.IsNullOrEmpty(directory))
+        {
+            return false;
+        }
+
+        return directory
+            .Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar])
+            .Any(segment => segment.StartsWith(".", StringComparison.Ordinal));
     }
 }
 


### PR DESCRIPTION
## Summary

Refs #479.

**NuGet cache rollout**
- Enables `actions/setup-dotnet` NuGet caching only in selected cache-safe jobs: `build.yml` primary build, `build.yml` docs export, and `code-quality.yml` dotnet-format.
- Sets job-level `NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages` before `setup-dotnet` in each cache-enabled job.
- Uses `cache-dependency-path: '**/packages.lock.json'`, explicit locked restore steps, and downstream `--no-restore` where restore coverage is clear.
- Adds cache-hit, package path, package size, and locked restore timing rows to job summaries.

**Package-gate isolation**
- Leaves `package-gate.yml` uncached for NuGet and keeps its isolated `${{ runner.temp }}/nuget-packages` package path.
- Documents the package-gate exclusion, expected misses, rollback steps, and the measured rollout policy in `eng/ci-critical-path.md`.

**Local cache verifier fix**
- Updates PackageIndex project discovery to ignore hidden local cache directories such as `.pnpm-store` and workspace `.nuget/packages`.
- Adds regression assertions so cache directories cannot create fake unclassified package projects during local verification.

**Release notes**
- Adds `CHANGELOG.md` Unreleased entries for the measured CI cache rollout and the PackageIndex hidden-cache verifier fix.

## Test Coverage

```text
CODE PATHS                                            USER / CI FLOWS
[+] PackageProjectScanner.IsCandidateProject()        [+] Local PackageIndex verification
  ├── [★★★ TESTED] tools path excluded                  ├── [★★★ TESTED] PackageIndex verify passes
  ├── [★★★ TESTED] examples path excluded               ├── [★★★ TESTED] PackageIndex tests pass
  ├── [★★★ TESTED] test/integration path excluded       └── [★★★ TESTED] local .pnpm-store no longer poisons verify
  ├── [★★★ TESTED] .pnpm-store hidden cache excluded
  ├── [★★★ TESTED] .nuget/packages hidden cache excluded
  └── [★★★ TESTED] real package project remains included

[+] CI workflow cache policy                          [+] GitHub Actions measurement flow
  ├── [★★★ TESTED] YAML parses                         ├── [GAP] Cold/miss cache run must be recorded in Actions
  ├── [★★★ TESTED] cache only in selected jobs          ├── [GAP] Warm/hit cache run must be recorded in Actions
  ├── [★★★ TESTED] package-gate remains uncached        └── [GAP] Merge decision waits for timing threshold
  └── [★★★ TESTED] coverage helper supports no-restore

COVERAGE: 10/13 paths tested (77%)
QUALITY: ★★★:10 ★★:0 ★:0 | GAPS: 3 external CI measurement gates
```

Coverage gate: PASS for local code and policy paths. The remaining gaps are the intended GitHub Actions cold/warm timing measurements that determine whether this draft should graduate to mergeable.

## Pre-Landing Review

No issues found.

Known process caveat: this is a stacked draft PR targeting `codex/appsurface-ci-build-time`. Workflows filtered to `pull_request.branches: main` may not auto-run until the PR is retargeted to `main`, or the relevant workflows are run with `workflow_dispatch`.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: implement #479 as a measured, selected-job NuGet cache experiment on top of #476.

Delivered: selected workflow cache configuration, package-gate exclusion, timing/policy documentation, and a local PackageIndex scanner fix for hidden cache directories discovered during QA.

## Plan Completion

- [x] Enable setup-dotnet NuGet caching only for selected cache-safe jobs.
- [x] Set job-level `NUGET_PACKAGES` in each cache-enabled job.
- [x] Use explicit `cache-dependency-path: '**/packages.lock.json'`.
- [x] Add explicit locked restore steps and downstream `--no-restore` where practical.
- [x] Keep package-gate uncached and isolated.
- [x] Update `eng/ci-critical-path.md` with policy, expected misses, rollback, and package-gate exclusion.
- [x] Fix local PackageIndex verification so ignored hidden cache directories do not appear as manifest candidates.
- [ ] Record GitHub Actions baseline, cold/miss run, and warm/hit run before merging.

## Verification Results

Local verification passed after merging `origin/codex/appsurface-ci-build-time`:

- [x] Workflow YAML parse for `build.yml`, `code-quality.yml`, and `package-gate.yml`.
- [x] NuGet cache policy guard.
- [x] `package-gate.yml` NuGet cache exclusion guard.
- [x] `bash -n scripts/coverage-solution.sh`.
- [x] `git diff --check origin/codex/appsurface-ci-build-time...HEAD`.
- [x] `dotnet restore ForgeTrust.AppSurface.slnx --locked-mode`.
- [x] `dotnet build ForgeTrust.AppSurface.slnx --configuration Release -v minimal --no-restore`.
- [x] `dotnet test ForgeTrust.AppSurface.slnx --configuration Release --no-restore --no-build` — 4,493 passed, 0 failed.
- [x] `dotnet test tools/ForgeTrust.AppSurface.PackageIndex.Tests/ForgeTrust.AppSurface.PackageIndex.Tests.csproj --configuration Release --no-restore --no-build` — 206 passed, 0 failed.
- [x] `dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj --configuration Release --no-build --no-restore -- verify`.
- [x] `dotnet run --project tools/ForgeTrust.AppSurface.MarkdownSnippets/ForgeTrust.AppSurface.MarkdownSnippets.csproj --configuration Release --no-build --no-restore -- verify`.
- [x] `dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes --no-restore --verbosity minimal`.

QA rerun evidence:

- [x] Fresh docs host on `http://127.0.0.1:6179/docs`.
- [x] Docs home, docs search, PackageIndex API mobile route, package chooser route, and packages section route loaded cleanly.
- [x] No browser console errors.
- [x] `PackageIndex` docs search returned 14 results.

QA report: `/Users/andrew/Projects/forge-trust/runnable__venus/.gstack/qa-reports/qa-report-issue479-rerun-2026-06-03.md`

## TODOS

No `TODOS.md` exists in this repository. No TODO items were updated.

## Documentation

- Updated `eng/ci-critical-path.md` with the NuGet cache policy, timing table, package-gate exclusion, expected misses, fallback guidance, rollback steps, and `BUILD_NO_RESTORE` contract.
- Updated `CHANGELOG.md` Unreleased with the measured cache rollout and PackageIndex hidden-cache verifier fix.

## Measurement Gate

Do not mark this PR ready or merge it until CI evidence shows at least one of:

- Warm-cache evidence shows at least 30 seconds net improvement in one selected workflow.
- Warm-cache evidence shows at least 5% runner-minute/all-green improvement without regression.

If timing data does not meet that threshold, remove or revert the cache workflow changes and keep only the useful docs/tooling rationale.

🤖 Generated with OpenAI Codex
