### PR TITLE
test: harden Tailwind runtime policy guard

### DIFF
--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -23,6 +23,7 @@ This is the living release note for the next coordinated AppSurface version afte
 - CI now includes a measured NuGet cache rollout for selected build, docs export, and code-quality jobs while keeping package-gate restores isolated.
 - PackageIndex verification now ignores hidden local cache directories such as `.pnpm-store` and workspace `.nuget/packages` so local cache contents do not require package manifest entries.
 - Fast non-package CI that does not compile Tailwind-consuming projects can now skip Tailwind runtime binary resolution while package validation and release paths force binary resolution on and fail before creating an empty runtime package.
+- PackageIndex workflow policy tests now reject additional `TailwindRuntimeBinaryResolutionEnabled=false` forms, including long MSBuild property switches, semicolon property lists, and shell environment assignments.
 
 ### RazorWire package guidance
 

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
@@ -1734,7 +1734,7 @@ public sealed class PackageArtifactValidationTests : IDisposable
         var packageGateWorkflow = await File.ReadAllTextAsync(Path.Join(repositoryRoot, ".github", "workflows", "package-gate.yml"));
         var packageArtifactsWorkflow = await File.ReadAllTextAsync(Path.Join(repositoryRoot, ".github", "workflows", "package-artifacts.yml"));
         const string disabledRuntimeResolutionSetting =
-            """(?im)(?:^\s*TailwindRuntimeBinaryResolutionEnabled:\s*(?:"false"|'false'|false)\s*$|(?:/p:|-p:)TailwindRuntimeBinaryResolutionEnabled=false\b)""";
+            """(?im)(?:^\s*TailwindRuntimeBinaryResolutionEnabled:\s*(?:"false"|'false'|false)\s*$|(?:^|\s)(?:env\s+)?TailwindRuntimeBinaryResolutionEnabled=false\b|(?:/p:|-p:|/property:|-property:)(?:[^\s'"]*;)*TailwindRuntimeBinaryResolutionEnabled=false\b)""";
 
         Assert.DoesNotMatch(disabledRuntimeResolutionSetting, buildWorkflow);
         Assert.DoesNotMatch(disabledRuntimeResolutionSetting, codeQualityWorkflow);
@@ -1744,6 +1744,12 @@ public sealed class PackageArtifactValidationTests : IDisposable
         Assert.Contains("TailwindRuntimeBinaryResolutionEnabled: \"true\"", packageArtifactsWorkflow, StringComparison.Ordinal);
         Assert.DoesNotMatch(disabledRuntimeResolutionSetting, packageGateWorkflow);
         Assert.DoesNotMatch(disabledRuntimeResolutionSetting, packageArtifactsWorkflow);
+        Assert.Matches(disabledRuntimeResolutionSetting, "/property:TailwindRuntimeBinaryResolutionEnabled=false");
+        Assert.Matches(disabledRuntimeResolutionSetting, "-property:TailwindRuntimeBinaryResolutionEnabled=false");
+        Assert.Matches(disabledRuntimeResolutionSetting, "/p:Configuration=Debug;TailwindRuntimeBinaryResolutionEnabled=false");
+        Assert.Matches(disabledRuntimeResolutionSetting, "-property:Configuration=Debug;TailwindRuntimeBinaryResolutionEnabled=false");
+        Assert.Matches(disabledRuntimeResolutionSetting, "TailwindRuntimeBinaryResolutionEnabled=false dotnet build");
+        Assert.Matches(disabledRuntimeResolutionSetting, "env TailwindRuntimeBinaryResolutionEnabled=false dotnet build");
     }
 
     [Fact]

--- a/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
+++ b/tools/ForgeTrust.AppSurface.PackageIndex.Tests/PackageArtifactValidationTests.cs
@@ -1744,6 +1744,7 @@ public sealed class PackageArtifactValidationTests : IDisposable
         Assert.Contains("TailwindRuntimeBinaryResolutionEnabled: \"true\"", packageArtifactsWorkflow, StringComparison.Ordinal);
         Assert.DoesNotMatch(disabledRuntimeResolutionSetting, packageGateWorkflow);
         Assert.DoesNotMatch(disabledRuntimeResolutionSetting, packageArtifactsWorkflow);
+        Assert.Matches(disabledRuntimeResolutionSetting, "-p:TailwindRuntimeBinaryResolutionEnabled=false");
         Assert.Matches(disabledRuntimeResolutionSetting, "/property:TailwindRuntimeBinaryResolutionEnabled=false");
         Assert.Matches(disabledRuntimeResolutionSetting, "-property:TailwindRuntimeBinaryResolutionEnabled=false");
         Assert.Matches(disabledRuntimeResolutionSetting, "/p:Configuration=Debug;TailwindRuntimeBinaryResolutionEnabled=false");


### PR DESCRIPTION
## Summary

Follow-up to #496. This tightens the static workflow policy test for `TailwindRuntimeBinaryResolutionEnabled=false` so protected/package-sensitive workflows cannot hide a disabled Tailwind runtime resolution setting behind alternate MSBuild or shell forms.

- Detects long MSBuild property forms: `/property:` and `-property:`.
- Detects semicolon-separated MSBuild property lists.
- Detects shell and `env` assignment forms that MSBuild imports as properties.
- Records the policy-test hardening in `releases/unreleased.md` for the release contract.

## Test Coverage

Test-only diff. No application code paths changed.

## Pre-Landing Review

No issues found in the local diff-scoped review after adding shell/env assignment coverage.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: harden the Tailwind runtime binary resolution policy guard added in #496.

Delivered: PackageIndex policy test coverage for additional valid disable spellings plus the required unreleased note.

## Plan Completion

No plan file detected.

## Verification Results

- `dotnet test tools/ForgeTrust.AppSurface.PackageIndex.Tests/ForgeTrust.AppSurface.PackageIndex.Tests.csproj` — passed, 216/216.
- `git diff --check` — passed before and after the release-note update.
- `dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes --no-restore --verbosity diagnostic` — passed, formatted 0 files.

## TODOS

No `TODOS.md` exists in this repository.

## Documentation

Updated `releases/unreleased.md` with the Tailwind runtime policy guard hardening note.

## Test plan

- [x] PackageIndex tests pass.
- [x] Diff whitespace check passes.
- [x] Formatting verification passes.

Generated with OpenAI Codex.