### PR TITLE
perf(flow): reduce in-memory runner routing overhead

### DIFF
--- a/Flow/ForgeTrust.AppSurface.Flow.Tests/FlowExecutionNodeTests.cs
+++ b/Flow/ForgeTrust.AppSurface.Flow.Tests/FlowExecutionNodeTests.cs
@@ -1,0 +1,33 @@
+namespace ForgeTrust.AppSurface.Flow.Tests;
+
+public sealed class FlowExecutionNodeTests
+{
+    [Fact]
+    public void Constructor_WithNullDescriptor_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FlowExecutionNode<TestState>(null!));
+    }
+
+    [Fact]
+    public void SetNextNodes_WithNullNextNodes_ThrowsArgumentNullException()
+    {
+        var executionNode = new FlowExecutionNode<TestState>(
+            new FlowNodeDescriptor<TestState>(
+                "start",
+                new CompleteNode(),
+                new HashSet<string>(StringComparer.Ordinal)));
+
+        Assert.Throws<ArgumentNullException>(() => executionNode.SetNextNodes(null!));
+    }
+
+    private sealed record TestState;
+
+    private sealed class CompleteNode : IFlowNode<TestState>
+    {
+        public ValueTask<FlowNodeOutcome<TestState>> ExecuteAsync(
+            FlowExecutionContext<TestState> context,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<FlowNodeOutcome<TestState>>(
+                FlowNodeOutcome<TestState>.Complete(context.State));
+    }
+}

--- a/Flow/ForgeTrust.AppSurface.Flow.Tests/InMemoryFlowRunnerTests.cs
+++ b/Flow/ForgeTrust.AppSurface.Flow.Tests/InMemoryFlowRunnerTests.cs
@@ -48,6 +48,62 @@ public sealed class InMemoryFlowRunnerTests
     }
 
     [Fact]
+    public async Task RunAsync_WithReentrantNextTarget_Completes()
+    {
+        var definition = FlowGraphBuilder<TestState>
+            .Create("approval")
+            .AddNode("start", new ReentrantNode(limit: 3), "start")
+            .StartAt("start")
+            .Build();
+
+        var result = await Runner().RunAsync(definition, new TestState(0, "created"));
+
+        Assert.Equal(FlowRunStatus.Completed, result.Status);
+        Assert.Equal("start", result.NodeId);
+        Assert.Equal(new TestState(3, "complete"), result.Context);
+    }
+
+    [Fact]
+    public async Task RunAsync_AfterSourceNodeDictionaryMutation_UsesCopiedDefinition()
+    {
+        var nodes = new Dictionary<string, FlowNodeDescriptor<TestState>>(StringComparer.Ordinal)
+        {
+            ["start"] = Descriptor("start", new NextNode("finish"), "finish"),
+            ["finish"] = Descriptor("finish", new CompleteNode()),
+        };
+        var definition = new FlowDefinition<TestState>("approval", "1", "start", nodes);
+        nodes["start"] = Descriptor("start", new CompleteNode());
+        nodes.Remove("finish");
+
+        var result = await Runner().RunAsync(definition, new TestState(0, "created"));
+
+        Assert.Equal(FlowRunStatus.Completed, result.Status);
+        Assert.Equal("finish", result.NodeId);
+        Assert.Equal(new TestState(1, "complete"), result.Context);
+    }
+
+    [Fact]
+    public async Task RunAsync_AfterSourceNextNodeIdsMutation_RejectsUndeclaredRuntimeTarget()
+    {
+        var nextNodeIds = new HashSet<string>(StringComparer.Ordinal) { "finish" };
+        var mutableNode = new MutableNextNode("finish");
+        var nodes = new Dictionary<string, FlowNodeDescriptor<TestState>>(StringComparer.Ordinal)
+        {
+            ["start"] = new("start", mutableNode, nextNodeIds),
+            ["finish"] = Descriptor("finish", new CompleteNode()),
+        };
+        var definition = new FlowDefinition<TestState>("approval", "1", "start", nodes);
+        nodes["late"] = Descriptor("late", new CompleteNode());
+        nextNodeIds.Add("late");
+        mutableNode.Target = "late";
+
+        var exception = await Assert.ThrowsAsync<FlowDefinitionException>(async () =>
+            await Runner().RunAsync(definition, new TestState(0, "created")));
+
+        Assert.Contains("undeclared target", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task RunAsync_StopsAtWait()
     {
         var timeout = new FlowTimeout(TimeSpan.FromMinutes(10));
@@ -82,6 +138,27 @@ public sealed class InMemoryFlowRunnerTests
 
         Assert.Equal(FlowRunStatus.Completed, result.Status);
         Assert.Equal(new TestState(0, "approved:andrew"), result.Context);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_WithValidNonStartNode_RunsThatNode()
+    {
+        var definition = FlowGraphBuilder<TestState>
+            .Create("approval")
+            .AddNode("start", new WaitNode(new FlowTimeout(TimeSpan.FromMinutes(10))))
+            .AddNode("finish", new CompleteNode())
+            .StartAt("start")
+            .Build();
+
+        var result = await Runner().ResumeAsync(
+            definition,
+            "finish",
+            new TestState(0, "waiting"),
+            new FlowResumeEvent("approved", "andrew"));
+
+        Assert.Equal(FlowRunStatus.Completed, result.Status);
+        Assert.Equal("finish", result.NodeId);
+        Assert.Equal(new TestState(0, "complete"), result.Context);
     }
 
     [Fact]
@@ -237,6 +314,12 @@ public sealed class InMemoryFlowRunnerTests
     private static InMemoryFlowRunner<TestState> Runner(int maxSteps = 1000) =>
         new(Options.Create(new AppSurfaceFlowOptions { MaxStepsPerRun = maxSteps }));
 
+    private static FlowNodeDescriptor<TestState> Descriptor(
+        string nodeId,
+        IFlowNode<TestState> node,
+        params string[] nextNodeIds) =>
+        new(nodeId, node, new HashSet<string>(nextNodeIds, StringComparer.Ordinal));
+
     private sealed record TestState(int Count, string Status);
 
     private sealed class NextNode : IFlowNode<TestState>
@@ -253,6 +336,46 @@ public sealed class InMemoryFlowRunnerTests
             CancellationToken cancellationToken = default) =>
             ValueTask.FromResult<FlowNodeOutcome<TestState>>(
                 FlowNodeOutcome<TestState>.Next(_target, context.State with { Count = context.State.Count + 1 }));
+    }
+
+    private sealed class MutableNextNode : IFlowNode<TestState>
+    {
+        internal MutableNextNode(string target)
+        {
+            Target = target;
+        }
+
+        internal string Target { get; set; }
+
+        public ValueTask<FlowNodeOutcome<TestState>> ExecuteAsync(
+            FlowExecutionContext<TestState> context,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<FlowNodeOutcome<TestState>>(
+                FlowNodeOutcome<TestState>.Next(Target, context.State with { Count = context.State.Count + 1 }));
+    }
+
+    private sealed class ReentrantNode : IFlowNode<TestState>
+    {
+        private readonly int _limit;
+
+        internal ReentrantNode(int limit)
+        {
+            _limit = limit;
+        }
+
+        public ValueTask<FlowNodeOutcome<TestState>> ExecuteAsync(
+            FlowExecutionContext<TestState> context,
+            CancellationToken cancellationToken = default)
+        {
+            if (context.State.Count >= _limit)
+            {
+                return ValueTask.FromResult<FlowNodeOutcome<TestState>>(
+                    FlowNodeOutcome<TestState>.Complete(context.State with { Status = "complete" }));
+            }
+
+            return ValueTask.FromResult<FlowNodeOutcome<TestState>>(
+                FlowNodeOutcome<TestState>.Next("start", context.State with { Count = context.State.Count + 1 }));
+        }
     }
 
     private sealed class CompleteNode : IFlowNode<TestState>

--- a/Flow/ForgeTrust.AppSurface.Flow/FlowDefinition.cs
+++ b/Flow/ForgeTrust.AppSurface.Flow/FlowDefinition.cs
@@ -33,7 +33,10 @@ public sealed class FlowDefinition<TContext>
         FlowId = RequireText(flowId, nameof(flowId));
         Version = RequireText(version, nameof(version));
         StartNodeId = RequireText(startNodeId, nameof(startNodeId));
-        Nodes = ValidateAndCopyNodes(FlowId, Version, StartNodeId, nodes);
+        var validatedNodes = ValidateAndCopyNodes(FlowId, Version, StartNodeId, nodes);
+        Nodes = validatedNodes.Nodes;
+        ExecutionNodes = validatedNodes.ExecutionNodes;
+        StartExecutionNode = validatedNodes.StartExecutionNode;
     }
 
     /// <summary>
@@ -56,6 +59,20 @@ public sealed class FlowDefinition<TContext>
     /// </summary>
     public IReadOnlyDictionary<string, FlowNodeDescriptor<TContext>> Nodes { get; }
 
+    /// <summary>
+    /// Gets the internal execution view keyed by node id.
+    /// </summary>
+    /// <remarks>
+    /// The execution view is built from the copied and validated node dictionary. It preserves the public
+    /// <see cref="Nodes"/> graph view while giving runners pre-resolved next-node targets.
+    /// </remarks>
+    internal IReadOnlyDictionary<string, FlowExecutionNode<TContext>> ExecutionNodes { get; }
+
+    /// <summary>
+    /// Gets the pre-resolved start node used by in-process runners.
+    /// </summary>
+    internal FlowExecutionNode<TContext> StartExecutionNode { get; }
+
     internal static string RequireText(string value, string parameterName)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -66,7 +83,7 @@ public sealed class FlowDefinition<TContext>
         return value;
     }
 
-    private static IReadOnlyDictionary<string, FlowNodeDescriptor<TContext>> ValidateAndCopyNodes(
+    private static ValidatedFlowNodes ValidateAndCopyNodes(
         string flowId,
         string version,
         string startNodeId,
@@ -121,6 +138,36 @@ public sealed class FlowDefinition<TContext>
             }
         }
 
-        return new ReadOnlyDictionary<string, FlowNodeDescriptor<TContext>>(copy);
+        var publicNodes = new ReadOnlyDictionary<string, FlowNodeDescriptor<TContext>>(copy);
+        var executionNodes = BuildExecutionNodes(copy);
+        return new ValidatedFlowNodes(publicNodes, executionNodes, executionNodes[startNodeId]);
     }
+
+    private static IReadOnlyDictionary<string, FlowExecutionNode<TContext>> BuildExecutionNodes(
+        IReadOnlyDictionary<string, FlowNodeDescriptor<TContext>> nodes)
+    {
+        var executionNodes = new Dictionary<string, FlowExecutionNode<TContext>>(StringComparer.Ordinal);
+        foreach (var item in nodes)
+        {
+            executionNodes.Add(item.Key, new FlowExecutionNode<TContext>(item.Value));
+        }
+
+        foreach (var executionNode in executionNodes.Values)
+        {
+            var nextNodes = new Dictionary<string, FlowExecutionNode<TContext>>(StringComparer.Ordinal);
+            foreach (var nextNodeId in executionNode.Descriptor.NextNodeIds)
+            {
+                nextNodes.Add(nextNodeId, executionNodes[nextNodeId]);
+            }
+
+            executionNode.SetNextNodes(new ReadOnlyDictionary<string, FlowExecutionNode<TContext>>(nextNodes));
+        }
+
+        return new ReadOnlyDictionary<string, FlowExecutionNode<TContext>>(executionNodes);
+    }
+
+    private sealed record ValidatedFlowNodes(
+        IReadOnlyDictionary<string, FlowNodeDescriptor<TContext>> Nodes,
+        IReadOnlyDictionary<string, FlowExecutionNode<TContext>> ExecutionNodes,
+        FlowExecutionNode<TContext> StartExecutionNode);
 }

--- a/Flow/ForgeTrust.AppSurface.Flow/FlowExecutionNode.cs
+++ b/Flow/ForgeTrust.AppSurface.Flow/FlowExecutionNode.cs
@@ -1,0 +1,44 @@
+using System.Collections.ObjectModel;
+
+namespace ForgeTrust.AppSurface.Flow;
+
+/// <summary>
+/// Internal, prevalidated node view used by runners to avoid repeated graph-routing lookups.
+/// </summary>
+/// <typeparam name="TContext">Serializable context type carried by the flow.</typeparam>
+/// <remarks>
+/// Instances are created only by <see cref="FlowDefinition{TContext}"/> after the public node dictionary has been
+/// copied and validated. The public API remains <see cref="FlowDefinition{TContext}.Nodes"/>; this type exists only to
+/// keep execution routing internal and fail-closed.
+/// </remarks>
+internal sealed class FlowExecutionNode<TContext>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FlowExecutionNode{TContext}"/> class.
+    /// </summary>
+    /// <param name="descriptor">Public node descriptor represented by this execution node.</param>
+    internal FlowExecutionNode(FlowNodeDescriptor<TContext> descriptor)
+    {
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        NextNodes = ReadOnlyDictionary<string, FlowExecutionNode<TContext>>.Empty;
+    }
+
+    /// <summary>
+    /// Gets the public descriptor executed for this node.
+    /// </summary>
+    internal FlowNodeDescriptor<TContext> Descriptor { get; }
+
+    /// <summary>
+    /// Gets the prevalidated next-node targets keyed by allowed target id.
+    /// </summary>
+    internal IReadOnlyDictionary<string, FlowExecutionNode<TContext>> NextNodes { get; private set; }
+
+    /// <summary>
+    /// Assigns the prevalidated next-node map once all execution nodes have been created.
+    /// </summary>
+    /// <param name="nextNodes">Resolved next-node targets.</param>
+    internal void SetNextNodes(IReadOnlyDictionary<string, FlowExecutionNode<TContext>> nextNodes)
+    {
+        NextNodes = nextNodes ?? throw new ArgumentNullException(nameof(nextNodes));
+    }
+}

--- a/Flow/ForgeTrust.AppSurface.Flow/InMemoryFlowRunner.cs
+++ b/Flow/ForgeTrust.AppSurface.Flow/InMemoryFlowRunner.cs
@@ -32,7 +32,7 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(definition);
-        return ExecuteAsync(definition, definition.StartNodeId, initialContext, null, cancellationToken);
+        return ExecuteAsync(definition, definition.StartExecutionNode, initialContext, null, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -47,7 +47,7 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
         ArgumentNullException.ThrowIfNull(resumeEvent);
         return ExecuteAsync(
             definition,
-            FlowDefinition<TContext>.RequireText(nodeId, nameof(nodeId)),
+            ResolveExecutionNode(definition, FlowDefinition<TContext>.RequireText(nodeId, nameof(nodeId))),
             context,
             resumeEvent,
             cancellationToken);
@@ -55,7 +55,7 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
 
     private async ValueTask<FlowRunResult<TContext>> ExecuteAsync(
         FlowDefinition<TContext> definition,
-        string nodeId,
+        FlowExecutionNode<TContext> executionNode,
         TContext context,
         FlowResumeEvent? resumeEvent,
         CancellationToken cancellationToken)
@@ -66,7 +66,7 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
             throw new InvalidOperationException("AppSurfaceFlowOptions.MaxStepsPerRun must be at least 1.");
         }
 
-        var currentNodeId = nodeId;
+        var currentExecutionNode = executionNode;
         var currentContext = FlowNodeOutcome<TContext>.RequireContext(context);
         var currentResumeEvent = resumeEvent;
 
@@ -74,14 +74,8 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!definition.Nodes.TryGetValue(currentNodeId, out var descriptor))
-            {
-                throw new FlowDefinitionException(
-                    string.Create(
-                        CultureInfo.InvariantCulture,
-                        $"Flow '{definition.FlowId}' version '{definition.Version}' does not contain node '{currentNodeId}'."));
-            }
-
+            var descriptor = currentExecutionNode.Descriptor;
+            var currentNodeId = descriptor.NodeId;
             var executionContext = new FlowExecutionContext<TContext>(
                 definition.FlowId,
                 definition.Version,
@@ -95,8 +89,7 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
             switch (outcome)
             {
                 case FlowNext<TContext> next:
-                    ValidateNextTarget(definition, descriptor, next.NodeId);
-                    currentNodeId = next.NodeId;
+                    currentExecutionNode = ResolveNextExecutionNode(definition, currentExecutionNode, next.NodeId);
                     currentContext = next.Context;
                     break;
                 case FlowWait<TContext> wait:
@@ -113,7 +106,7 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
         }
 
         return FlowRunResult<TContext>.Faulted(
-            currentNodeId,
+            currentExecutionNode.Descriptor.NodeId,
             new FlowFault(
                 "flow.max-steps-exceeded",
                 string.Create(
@@ -121,25 +114,34 @@ public sealed class InMemoryFlowRunner<TContext> : IFlowRunner<TContext>
                     $"Flow '{definition.FlowId}' version '{definition.Version}' exceeded {maxSteps} in-memory steps.")));
     }
 
-    private static void ValidateNextTarget(
+    private static FlowExecutionNode<TContext> ResolveExecutionNode(
         FlowDefinition<TContext> definition,
-        FlowNodeDescriptor<TContext> descriptor,
-        string nextNodeId)
+        string nodeId)
     {
-        if (!descriptor.NextNodeIds.Contains(nextNodeId))
+        if (!definition.ExecutionNodes.TryGetValue(nodeId, out var executionNode))
         {
             throw new FlowDefinitionException(
                 string.Create(
                     CultureInfo.InvariantCulture,
-                    $"Flow '{definition.FlowId}' version '{definition.Version}' node '{descriptor.NodeId}' returned undeclared target '{nextNodeId}'."));
+                    $"Flow '{definition.FlowId}' version '{definition.Version}' does not contain node '{nodeId}'."));
         }
 
-        if (!definition.Nodes.ContainsKey(nextNodeId))
+        return executionNode;
+    }
+
+    private static FlowExecutionNode<TContext> ResolveNextExecutionNode(
+        FlowDefinition<TContext> definition,
+        FlowExecutionNode<TContext> executionNode,
+        string nextNodeId)
+    {
+        if (!executionNode.NextNodes.TryGetValue(nextNodeId, out var nextExecutionNode))
         {
             throw new FlowDefinitionException(
                 string.Create(
                     CultureInfo.InvariantCulture,
-                    $"Flow '{definition.FlowId}' version '{definition.Version}' node '{descriptor.NodeId}' returned missing target '{nextNodeId}'."));
+                    $"Flow '{definition.FlowId}' version '{definition.Version}' node '{executionNode.Descriptor.NodeId}' returned undeclared target '{nextNodeId}'."));
         }
+
+        return nextExecutionNode;
     }
 }

--- a/Flow/ForgeTrust.AppSurface.Flow/README.md
+++ b/Flow/ForgeTrust.AppSurface.Flow/README.md
@@ -146,6 +146,8 @@ public sealed class ApprovalReviewNode : IFlowNode<ApprovalState>
 - Generated envelopes include concrete nullable context slots and a public serializer constructor so Durable Task JSON round-trip validation can inspect them.
 - Declare every `Next` target in `AddNode`. The builder validates missing targets, and runners reject undeclared runtime targets.
 - The in-memory runner stops at waits. It does not persist state, deliver events, or create timers.
+- The in-memory runner uses prevalidated internal routing metadata from `FlowDefinition<TContext>` so local execution does not repeat graph-existence checks on every `Next` transition. This preserves the public `Nodes` graph view and the runtime `undeclared target` diagnostic.
+- Flow benchmarks isolate runner orchestration overhead. Use Flow for graph safety, long-running process contracts, and durable-host alignment; use a direct loop when all you need is a pure in-process tight state machine.
 - Use `FlowWait<TContext>.Timeout` as metadata for durable hosts. The core runner reports the timeout request but does not race timers.
 - Keep context types serializer-friendly if you plan to use Durable Task. The Durable Task adapter validates JSON round-trips before evaluating nodes.
 - Native C# discriminated unions can become authoring sugar later, but this package intentionally ships stable sealed records today.

--- a/Flow/ForgeTrust.AppSurface.Flow/README.md
+++ b/Flow/ForgeTrust.AppSurface.Flow/README.md
@@ -146,7 +146,7 @@ public sealed class ApprovalReviewNode : IFlowNode<ApprovalState>
 - Generated envelopes include concrete nullable context slots and a public serializer constructor so Durable Task JSON round-trip validation can inspect them.
 - Declare every `Next` target in `AddNode`. The builder validates missing targets, and runners reject undeclared runtime targets.
 - The in-memory runner stops at waits. It does not persist state, deliver events, or create timers.
-- The in-memory runner uses prevalidated internal routing metadata from `FlowDefinition<TContext>` so local execution does not repeat graph-existence checks on every `Next` transition. This preserves the public `Nodes` graph view and the runtime `undeclared target` diagnostic.
+- The in-memory runner uses prevalidated internal routing metadata from `FlowDefinition<TContext>` so local execution does not repeat graph-existence checks on every `Next` transition. This preserves the public `Nodes` graph view and the undeclared target diagnostic from `FlowDefinition<TContext>` construction.
 - Flow benchmarks isolate runner orchestration overhead. Use Flow for graph safety, long-running process contracts, and durable-host alignment; use a direct loop when all you need is a pure in-process tight state machine.
 - Use `FlowWait<TContext>.Timeout` as metadata for durable hosts. The core runner reports the timeout request but does not race timers.
 - Keep context types serializer-friendly if you plan to use Durable Task. The Durable Task adapter validates JSON round-trips before evaluating nodes.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,10 +10,10 @@ projects. They measure:
 Benchmarks are compiled separately per library using conditional
 compilation, ensuring that only the code under test is loaded for each job.
 
-Run them in release mode to get optimized measurements:
+From the repository root, run them in release mode to get optimized measurements:
 
 ```bash
-dotnet run -c Release --project AppSurfaceBenchmarks
+dotnet run -c Release --project benchmarks/AppSurfaceBenchmarks/AppSurfaceBenchmarks.csproj
 ```
 
 Run only the Flow benchmarks when investigating state-machine overhead:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,8 +19,14 @@ dotnet run -c Release --project AppSurfaceBenchmarks
 Run only the Flow benchmarks when investigating state-machine overhead:
 
 ```bash
-dotnet run -c Release --project AppSurfaceBenchmarks -- --filter "*FlowRunnerBenchmarks*"
+dotnet run -c Release --project benchmarks/AppSurfaceBenchmarks/AppSurfaceBenchmarks.csproj -- --filter "*FlowRunnerBenchmarks*"
 ```
+
+The Flow benchmark is synthetic runner-overhead evidence. It compares the
+in-memory runner with a direct lower-bound loop so changes to routing,
+execution-context creation, and result handling remain visible. Do not treat
+it as product-level throughput guidance for real workflows; add a workload
+benchmark that resembles production node work before making adoption claims.
 
 ---
 [🏠 Back to Root](../README.md)

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -12,6 +12,10 @@ This is the living release note for the next coordinated AppSurface version afte
 
 - Add release-facing changes here.
 
+### AppSurface Flow
+
+- Reduce internal `InMemoryFlowRunner<TContext>` routing overhead by using prevalidated `FlowDefinition<TContext>` execution metadata while keeping public Flow APIs unchanged.
+
 ## Migration watch
 
 - Record breaking or behavior-changing guidance here before it moves into the tagged release note.


### PR DESCRIPTION
## Summary

Fixes #545.

**Performance**
- Adds internal prevalidated execution metadata to `FlowDefinition<TContext>` while keeping the public `Nodes` graph view unchanged.
- Updates `InMemoryFlowRunner<TContext>` to carry resolved execution nodes through `Next` transitions instead of repeating per-step graph lookups.
- Preserves fail-closed runtime behavior for undeclared targets and missing resume nodes.

**Tests**
- Adds regression coverage for reentrant/self-loop transitions, source node dictionary mutation, source next-node-id mutation, and valid non-start resume.
- Keeps existing complete, wait, timed-out, faulted, canceled, null outcome, invalid max steps, max-step fault, generated-authoring, and Durable Task coverage green.

**Docs**
- Documents Flow benchmark interpretation and the direct-loop caveat.
- Clarifies root-safe benchmark commands.
- Adds unreleased release-note coverage for the internal runner optimization.

## Benchmark Evidence

Fresh post-change run on this branch:

```text
BenchmarkDotNet v0.15.8, macOS Tahoe 26.4.1, Apple M4 Pro
.NET SDK 10.0.102 / .NET 10.0.2
Command: dotnet run -c Release --project benchmarks/AppSurfaceBenchmarks/AppSurfaceBenchmarks.csproj -- --filter "*FlowRunnerBenchmarks*"
```

| StepCount | Direct state machine | Flow in-memory runner | Allocated |
| --- | ---: | ---: | ---: |
| 10 | 3.575 ns | 231.272 ns | 1056 B |
| 100 | 27.646 ns | 1,863.655 ns | 8976 B |
| 1000 | 269.214 ns | 17,538.612 ns | 88176 B |

Before/after comparison from the same local machine/config during implementation:

| StepCount | Before | After | Allocation |
| --- | ---: | ---: | ---: |
| 10 | 287.766 ns | 227.135 ns | unchanged, 1056 B |
| 100 | 2,547.942 ns | 1,882.774 ns | unchanged, 8976 B |
| 1000 | 24,853.228 ns | 18,755.853 ns | unchanged, 88176 B |

The benchmark is synthetic runner-overhead evidence, not product-level workflow throughput guidance.

## Test Coverage

All changed code paths are covered through public Flow behavior.

```text
CODE PATHS
[+] FlowDefinition<TContext>
  ├── [★★★ TESTED] copied node dictionary drives execution after source dictionary mutation
  ├── [★★★ TESTED] copied next-node execution map rejects late source next-node mutation as undeclared target
  ├── [★★★ TESTED] declared missing target remains constructor-time validation
  └── [★★★ TESTED] internal execution metadata stays internal and public Nodes remains the public graph view

[+] InMemoryFlowRunner<TContext>
  ├── [★★★ TESTED] RunAsync starts from resolved start execution node
  ├── [★★★ TESTED] FlowNext advances through resolved next execution node
  ├── [★★★ TESTED] reentrant/self-loop Next target completes
  ├── [★★★ TESTED] ResumeAsync resolves a valid non-start node
  ├── [★★★ TESTED] missing resume node keeps "does not contain node '<id>'" diagnostic
  ├── [★★★ TESTED] undeclared runtime target keeps "undeclared target" diagnostic
  └── [★★★ TESTED] max-step fault reports current execution node

COVERAGE: 10/10 changed paths covered (100%)
QUALITY: ★★★:10 ★★:0 ★:0 | GAPS: 0
```

Solution coverage gate:

```text
./scripts/coverage-solution.sh
28/28 test projects passed
Line coverage: 96.12%
Branch coverage: 89.85%
```

## Pre-Landing Review

Pre-Landing Review: No issues found.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: Reduce `InMemoryFlowRunner<TContext>` overhead against the Flow benchmark baseline without changing public Flow APIs.

Delivered: Internal execution metadata, runner routing update, focused regression tests, benchmark docs, and release note.

## Plan Completion

Plan: `/Users/andrew/.gstack/projects/forge-trust-Runnable/andrew-main-design-20260618-231031-issue545-flow-runner-execution-plan.md`

- [DONE] Capture before/after Flow benchmark evidence.
- [DONE] Add internal execution metadata to `FlowDefinition<TContext>` while keeping `Nodes` public API unchanged.
- [DONE] Update `InMemoryFlowRunner<TContext>` to use resolved execution nodes for per-step routing.
- [DONE] Preserve missing resume node and undeclared runtime target diagnostics.
- [DONE] Add cache-divergence, non-start resume, and self-loop regression tests.
- [DONE] Verify Flow, Durable Task, and generated-authoring tests.
- [DONE] Build benchmark project and rerun Flow benchmark.
- [DONE] Update Flow README, benchmark README, and unreleased release note.

Completion: 8/8 DONE, 0 deferred, 0 unverifiable.

## Verification Results

No browser/dev-server verification needed; this is a backend package performance change.

## TODOS

No `TODOS.md` exists in this repository; no TODO items were updated.

## Test plan

- [x] `dotnet test Flow/ForgeTrust.AppSurface.Flow.Tests/ForgeTrust.AppSurface.Flow.Tests.csproj` — 110 passed
- [x] `dotnet test Flow/ForgeTrust.AppSurface.Flow.DurableTask.Tests/ForgeTrust.AppSurface.Flow.DurableTask.Tests.csproj` — 89 passed
- [x] `dotnet test Flow/ForgeTrust.AppSurface.Flow.Generators.Tests/ForgeTrust.AppSurface.Flow.Generators.Tests.csproj` — 80 passed
- [x] `dotnet build benchmarks/AppSurfaceBenchmarks/AppSurfaceBenchmarks.csproj -c Release` — 0 warnings, 0 errors
- [x] `dotnet run -c Release --project benchmarks/AppSurfaceBenchmarks/AppSurfaceBenchmarks.csproj -- --filter "*FlowRunnerBenchmarks*"`
- [x] `dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes --no-restore --verbosity diagnostic` — formatted 0 files
- [x] `git diff --check origin/main...HEAD`
- [x] `./scripts/coverage-solution.sh` — 28/28 projects passed, 96.12% line, 89.85% branch

Generated with OpenAI Codex.
