### PR TITLE
fix(config): repair stale LocalSecrets platform index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - `ForgeTrust.AppSurface.Auth` now defines durable external-subject to app-user-id mapping contracts, with Auth core staying free of user-store, ASP.NET Core, OIDC, persistence, and tenant-authority ownership.
 - `ForgeTrust.AppSurface.Auth.AspNetCore` can now protect Minimal API endpoints with host-owned ASP.NET Core policies while returning AppSurface-shaped ProblemDetails JSON for API callers.
 - AppSurface Config can now compare sanitized audit reports, render deterministic same-host or captured-snapshot evidence, and expose command-framework-agnostic diff workflows with display-safe failures.
+- AppSurface LocalSecrets platform-backed stores now validate indexed names against live stored values during `appsurface secrets list`, prune stale names after successful repair, and let `appsurface secrets delete KEY` clean stale indexed names whose values are already gone.
 - AppSurface Flow now uses value-type execution contexts and deeper benchmark coverage to reduce and track synchronous in-memory runner allocation overhead.
 
 ## 0.1.0-rc.4 - 2026-06-16

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -75,11 +75,17 @@ appsurface secrets list --names-only --app MyApp --environment Development
 appsurface secrets get Stripe:ApiKey --app MyApp --environment Development
 ```
 
-`get` verifies presence and source without printing the secret value. `doctor` reports `Problem`, `Cause`, `Fix`,
-`Docs`, and `Retryable` so unsupported platforms, locked stores, and headless sessions fail closed instead of falling
-through to file secrets. Use `--store-file <path>` only for deterministic examples and tests; normal local development
-should use the OS-backed store when the platform adapter is available. Use environment variables, key-per-file, or a
-remote vault for CI, containers, team environments, and production.
+`get` verifies presence and source without printing the secret value. `list` prints currently retrievable names only:
+platform-backed stores validate indexed names against live values and silently remove stale names when validation and
+repair succeed. If the platform store is locked, unavailable, or the index is corrupt, `list` fails with a paste-safe
+diagnostic instead of hiding names it could not verify. `delete KEY` also repairs stale indexed names when the value is
+already gone, while keys that never existed still report `local-secret-missing`.
+
+`doctor` reports `Problem`, `Cause`, `Fix`, `Docs`, and `Retryable` so unsupported platforms, locked stores, and
+headless sessions fail closed instead of falling through to file secrets. Use `--store-file <path>` only for
+deterministic examples and tests; normal local development should use the OS-backed store when the platform adapter is
+available. Use environment variables, key-per-file, or a remote vault for CI, containers, team environments, and
+production.
 
 ### `appsurface coverage run`
 

--- a/Cli/ForgeTrust.AppSurface.Cli/SecretsCommand.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/SecretsCommand.cs
@@ -100,9 +100,9 @@ internal sealed partial class SecretsGetCommand : SecretsKeyCommandBase
 }
 
 /// <summary>
-/// Lists local secret names in a namespace.
+/// Lists currently retrievable local secret names in a namespace.
 /// </summary>
-[Command("secrets list", Description = "List AppSurface local secret names without values.")]
+[Command("secrets list", Description = "List currently retrievable AppSurface local secret names without values.")]
 internal sealed partial class SecretsListCommand : SecretsCommandBase
 {
     /// <summary>

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets.Tests/AppSurfaceLocalSecretResultContractTests.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets.Tests/AppSurfaceLocalSecretResultContractTests.cs
@@ -69,6 +69,16 @@ public sealed class AppSurfaceLocalSecretResultContractTests
     }
 
     [Fact]
+    public void ListFound_Should_OrderCaseVariantsDeterministically()
+    {
+        var result = AppSurfaceLocalSecretListResult.Found(
+            ["stripe:apikey", "SendGrid:ApiKey", "Stripe:ApiKey"],
+            "Fixed");
+
+        Assert.Equal(["SendGrid:ApiKey", "Stripe:ApiKey", "stripe:apikey"], result.Keys);
+    }
+
+    [Fact]
     public void IdentityFactories_Should_RejectNullContractInputs()
     {
         var valid = Assert.Throws<ArgumentNullException>(() => AppSurfaceLocalSecretIdentityResult.Valid(null!));

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets.Tests/PlatformAppSurfaceLocalSecretStoreTests.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets.Tests/PlatformAppSurfaceLocalSecretStoreTests.cs
@@ -178,6 +178,20 @@ public sealed class PlatformAppSurfaceLocalSecretStoreTests
     }
 
     [Fact]
+    public void IndexedStoreSet_Should_WriteCaseVariantIndexInDeterministicOrder()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var lower = normalizer.Normalize("MyApp", "Development", null, "stripe:apikey").Identity!;
+        var upper = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+
+        store.Set(lower, "lower-secret");
+        store.Set(upper, "upper-secret");
+
+        Assert.Equal(["Stripe:ApiKey", "stripe:apikey"], store.ReadIndexKeys("MyApp", "Development", null));
+    }
+
+    [Fact]
     public void IndexedStoreList_Should_PruneStaleIndexedKeys()
     {
         var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets.Tests/PlatformAppSurfaceLocalSecretStoreTests.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets.Tests/PlatformAppSurfaceLocalSecretStoreTests.cs
@@ -177,6 +177,129 @@ public sealed class PlatformAppSurfaceLocalSecretStoreTests
         Assert.Equal("upper-secret", store.Get(upper).Value);
     }
 
+    [Fact]
+    public void IndexedStoreList_Should_PruneStaleIndexedKeys()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var live = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+        var stale = normalizer.Normalize("MyApp", "Development", null, "SendGrid:ApiKey").Identity!;
+        store.SeedStoredValue(live, "live-secret");
+        store.SeedIndex("MyApp", "Development", null, live.Key, stale.Key);
+
+        var result = store.List("MyApp", "Development", null);
+
+        Assert.Equal(LocalSecretResultStatus.Found, result.Status);
+        Assert.Equal(["Stripe:ApiKey"], result.Keys);
+        Assert.Equal(["Stripe:ApiKey"], store.ReadIndexKeys("MyApp", "Development", null));
+    }
+
+    [Fact]
+    public void IndexedStoreDelete_Should_RemoveStaleIndexedKey_WhenValueIsMissing()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var stale = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+        store.SeedIndex("MyApp", "Development", null, stale.Key);
+
+        var result = store.Delete(stale);
+
+        Assert.Equal(LocalSecretResultStatus.Found, result.Status);
+        Assert.Empty(store.ReadIndexKeys("MyApp", "Development", null));
+    }
+
+    [Fact]
+    public void IndexedStoreDelete_Should_PreserveMissing_WhenValueAndIndexEntryAreMissing()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var missing = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+
+        var result = store.Delete(missing);
+
+        Assert.Equal(LocalSecretResultStatus.Missing, result.Status);
+        Assert.False(store.HasIndex("MyApp", "Development", null));
+    }
+
+    [Fact]
+    public void IndexedStoreList_Should_NotRewriteIndex_WhenIndexedValueReadFails()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var live = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+        var locked = normalizer.Normalize("MyApp", "Development", null, "SendGrid:ApiKey").Identity!;
+        store.SeedStoredValue(live, "live-secret");
+        store.SeedStoredValue(locked, "locked-secret");
+        store.SeedIndex("MyApp", "Development", null, live.Key, locked.Key);
+        store.FailRead(locked, LocalSecretResultStatus.Locked);
+
+        var result = store.List("MyApp", "Development", null);
+
+        Assert.Equal(LocalSecretResultStatus.Locked, result.Status);
+        Assert.Equal(["Stripe:ApiKey", "SendGrid:ApiKey"], store.ReadIndexKeys("MyApp", "Development", null));
+    }
+
+    [Fact]
+    public void IndexedStoreList_Should_ReturnProviderFailedAndNotRepair_WhenIndexIsCorrupt()
+    {
+        var store = new IndexedMemoryStore();
+        store.SeedRawIndex("MyApp", "Development", null, "not json");
+
+        var result = store.List("MyApp", "Development", null);
+
+        Assert.Equal(LocalSecretResultStatus.ProviderFailed, result.Status);
+        Assert.Equal("local-secret-index-invalid", result.Diagnostic?.Code);
+        Assert.Contains("Remove the invalid platform index entry", result.Diagnostic?.Fix, StringComparison.Ordinal);
+        Assert.Equal("not json", store.ReadRawIndex("MyApp", "Development", null));
+    }
+
+    [Fact]
+    public void IndexedStoreDelete_Should_ReturnProviderFailedAndNotRepair_WhenIndexIsCorrupt()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var stale = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+        store.SeedRawIndex("MyApp", "Development", null, "not json");
+
+        var result = store.Delete(stale);
+
+        Assert.Equal(LocalSecretResultStatus.ProviderFailed, result.Status);
+        Assert.Equal("local-secret-index-invalid", result.Diagnostic?.Code);
+        Assert.Contains("Remove the invalid platform index entry", result.Diagnostic?.Fix, StringComparison.Ordinal);
+        Assert.Equal("not json", store.ReadRawIndex("MyApp", "Development", null));
+    }
+
+    [Fact]
+    public void IndexedStoreList_Should_Fail_WhenRepairWriteFails()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var stale = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+        store.SeedIndex("MyApp", "Development", null, stale.Key);
+        store.FailNextWrite(LocalSecretResultStatus.Unavailable);
+
+        var result = store.List("MyApp", "Development", null);
+
+        Assert.Equal(LocalSecretResultStatus.Unavailable, result.Status);
+        Assert.Equal(["Stripe:ApiKey"], store.ReadIndexKeys("MyApp", "Development", null));
+    }
+
+    [Fact]
+    public void IndexedStoreList_Should_PruneDuplicateAndReservedIndexEntries()
+    {
+        var normalizer = new AppSurfaceLocalSecretIdentityNormalizer();
+        var store = new IndexedMemoryStore();
+        var live = normalizer.Normalize("MyApp", "Development", null, "Stripe:ApiKey").Identity!;
+        store.SeedStoredValue(live, "live-secret");
+        store.SeedIndex("MyApp", "Development", null, live.Key, live.Key, "__appsurface_index__", null, " ");
+
+        var result = store.List("MyApp", "Development", null);
+
+        Assert.Equal(LocalSecretResultStatus.Found, result.Status);
+        Assert.Equal(["Stripe:ApiKey"], result.Keys);
+        Assert.Equal(["Stripe:ApiKey"], store.ReadIndexKeys("MyApp", "Development", null));
+    }
+
     private sealed class FixedCommandRunner(PlatformAppSurfaceLocalSecretStore.PlatformSecretCommandResult result)
         : PlatformAppSurfaceLocalSecretStore.IPlatformSecretCommandRunner
     {
@@ -200,38 +323,65 @@ public sealed class PlatformAppSurfaceLocalSecretStoreTests
     private sealed class IndexedMemoryStore : PlatformAppSurfaceLocalSecretStore.IndexedLocalSecretStore
     {
         private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, AppSurfaceLocalSecretResult> _readFailures = new(StringComparer.Ordinal);
+        private LocalSecretResultStatus? _nextWriteFailure;
 
         public override string Name => nameof(IndexedMemoryStore);
 
-        protected override AppSurfaceLocalSecretResult ReadValue(AppSurfaceLocalSecretIdentity identity) =>
-            _values.TryGetValue(identity.StorageName, out var value)
-                ? AppSurfaceLocalSecretResult.Found(value, Name)
-                : AppSurfaceLocalSecretResult.Missing(Name);
+        public void SeedStoredValue(AppSurfaceLocalSecretIdentity identity, string value) => _values[identity.StorageName] = value;
 
-        protected override AppSurfaceLocalSecretResult WriteValue(AppSurfaceLocalSecretIdentity identity, string value)
+        public void SeedIndex(string applicationName, string environment, string? keyPrefix, params string?[] keys) =>
+            SeedRawIndex(applicationName, environment, keyPrefix, System.Text.Json.JsonSerializer.Serialize(keys));
+
+        public void SeedRawIndex(string applicationName, string environment, string? keyPrefix, string value) =>
+            _values[IndexStorageName(applicationName, environment, keyPrefix)] = value;
+
+        public string? ReadRawIndex(string applicationName, string environment, string? keyPrefix) =>
+            _values.GetValueOrDefault(IndexStorageName(applicationName, environment, keyPrefix));
+
+        public string[] ReadIndexKeys(string applicationName, string environment, string? keyPrefix) =>
+            System.Text.Json.JsonSerializer.Deserialize<string[]>(ReadRawIndex(applicationName, environment, keyPrefix) ?? "[]") ?? [];
+
+        public bool HasIndex(string applicationName, string environment, string? keyPrefix) =>
+            _values.ContainsKey(IndexStorageName(applicationName, environment, keyPrefix));
+
+        public void FailRead(AppSurfaceLocalSecretIdentity identity, LocalSecretResultStatus status) =>
+            _readFailures[identity.StorageName] = Failure(status);
+
+        public void FailNextWrite(LocalSecretResultStatus status) => _nextWriteFailure = status;
+
+        protected override AppSurfaceLocalSecretResult ReadStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
-            _values[identity.StorageName] = value;
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
+            if (_readFailures.TryGetValue(identity.StorageName, out var failure))
             {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
+                return failure;
             }
 
-            return UpdateIndex(identity, add: true);
+            return _values.TryGetValue(identity.StorageName, out var value)
+                ? AppSurfaceLocalSecretResult.Found(value, Name)
+                : AppSurfaceLocalSecretResult.Missing(Name);
         }
 
-        protected override AppSurfaceLocalSecretResult DeleteValue(AppSurfaceLocalSecretIdentity identity)
+        protected override AppSurfaceLocalSecretResult WriteStoredValue(AppSurfaceLocalSecretIdentity identity, string value)
+        {
+            if (_nextWriteFailure is { } status)
+            {
+                _nextWriteFailure = null;
+                return Failure(status);
+            }
+
+            _values[identity.StorageName] = value;
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
+        }
+
+        protected override AppSurfaceLocalSecretResult DeleteStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
             if (!_values.Remove(identity.StorageName))
             {
                 return AppSurfaceLocalSecretResult.Missing(Name);
             }
 
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
-            {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
-            }
-
-            return UpdateIndex(identity, add: false);
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
         }
 
         protected override AppSurfaceLocalSecretResult DoctorStore(string applicationName, string environment, string? keyPrefix) =>
@@ -242,6 +392,19 @@ public sealed class PlatformAppSurfaceLocalSecretStoreTests
                     "Indexed memory store is ready.",
                     "The fake store is available.",
                     "No action required."),
+                Name);
+
+        private static string IndexStorageName(string applicationName, string environment, string? keyPrefix) =>
+            $"appsurface:{applicationName}:{environment}:{keyPrefix}:{IndexKey}";
+
+        private AppSurfaceLocalSecretResult Failure(LocalSecretResultStatus status) =>
+            AppSurfaceLocalSecretResult.NotFound(
+                status,
+                new AppSurfaceLocalSecretDiagnostic(
+                    $"test-{status.ToString().ToLowerInvariant()}",
+                    "Injected local secret failure.",
+                    "The indexed memory store was configured to fail this operation.",
+                    "Clear the injected failure."),
                 Name);
     }
 }

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets/AppSurfaceLocalSecretListResult.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets/AppSurfaceLocalSecretListResult.cs
@@ -4,7 +4,7 @@ namespace ForgeTrust.AppSurface.Config.LocalSecrets;
 /// Describes a local secret list operation.
 /// </summary>
 /// <param name="Status">The list status.</param>
-/// <param name="Keys">The display-safe logical config keys.</param>
+/// <param name="Keys">The display-safe logical config keys that the store could verify as currently retrievable.</param>
 /// <param name="Diagnostic">The display-safe diagnostic for non-success states.</param>
 /// <param name="Source">The display-safe source name.</param>
 public sealed record AppSurfaceLocalSecretListResult(
@@ -16,7 +16,7 @@ public sealed record AppSurfaceLocalSecretListResult(
     /// <summary>
     /// Creates a successful list result.
     /// </summary>
-    /// <param name="keys">The display-safe logical config keys.</param>
+    /// <param name="keys">The display-safe logical config keys that the store could verify as currently retrievable.</param>
     /// <param name="source">The display-safe source name.</param>
     /// <returns>A list result.</returns>
     public static AppSurfaceLocalSecretListResult Found(IEnumerable<string> keys, string source) =>

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets/AppSurfaceLocalSecretListResult.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets/AppSurfaceLocalSecretListResult.cs
@@ -20,7 +20,11 @@ public sealed record AppSurfaceLocalSecretListResult(
     /// <param name="source">The display-safe source name.</param>
     /// <returns>A list result.</returns>
     public static AppSurfaceLocalSecretListResult Found(IEnumerable<string> keys, string source) =>
-        new(LocalSecretResultStatus.Found, keys.Order(StringComparer.OrdinalIgnoreCase).ToArray(), null, source);
+        new(
+            LocalSecretResultStatus.Found,
+            keys.OrderBy(static key => key, StringComparer.OrdinalIgnoreCase).ThenBy(static key => key, StringComparer.Ordinal).ToArray(),
+            null,
+            source);
 
     /// <summary>
     /// Creates a non-success list result.

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets/IAppSurfaceLocalSecretStore.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets/IAppSurfaceLocalSecretStore.cs
@@ -36,7 +36,8 @@ public interface IAppSurfaceLocalSecretStore
     /// <returns>
     /// The store result. Platform-indexed stores may return <see cref="LocalSecretResultStatus.Found"/> when the value was
     /// already missing but a stale indexed name was removed; keys that were never stored still return
-    /// <see cref="LocalSecretResultStatus.Missing"/>.
+    /// <see cref="LocalSecretResultStatus.Missing"/> when the store can confirm no stale index entry remains. If the
+    /// platform index cannot be read, platform-indexed stores fail closed instead of assuming the key was never indexed.
     /// </returns>
     AppSurfaceLocalSecretResult Delete(AppSurfaceLocalSecretIdentity identity);
 

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets/IAppSurfaceLocalSecretStore.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets/IAppSurfaceLocalSecretStore.cs
@@ -33,16 +33,24 @@ public interface IAppSurfaceLocalSecretStore
     /// Deletes a local secret.
     /// </summary>
     /// <param name="identity">The normalized local secret identity.</param>
-    /// <returns>The store result.</returns>
+    /// <returns>
+    /// The store result. Platform-indexed stores may return <see cref="LocalSecretResultStatus.Found"/> when the value was
+    /// already missing but a stale indexed name was removed; keys that were never stored still return
+    /// <see cref="LocalSecretResultStatus.Missing"/>.
+    /// </returns>
     AppSurfaceLocalSecretResult Delete(AppSurfaceLocalSecretIdentity identity);
 
     /// <summary>
-    /// Lists known local secret config keys for an application/environment namespace.
+    /// Lists currently retrievable local secret config keys for an application/environment namespace.
     /// </summary>
     /// <param name="applicationName">The normalized application name.</param>
     /// <param name="environment">The normalized environment name.</param>
     /// <param name="keyPrefix">The optional normalized key prefix.</param>
-    /// <returns>The list result.</returns>
+    /// <returns>
+    /// The list result. Platform-indexed stores validate indexed names against live stored values and may prune missing
+    /// entries after a successful validation pass. Corrupt indexes and terminal platform failures return display-safe
+    /// diagnostics instead of hiding unverified names.
+    /// </returns>
     AppSurfaceLocalSecretListResult List(string applicationName, string environment, string? keyPrefix);
 
     /// <summary>

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets/PlatformAppSurfaceLocalSecretStore.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets/PlatformAppSurfaceLocalSecretStore.cs
@@ -725,12 +725,55 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
         public AppSurfaceLocalSecretResult Doctor(string applicationName, string environment, string? keyPrefix) =>
             DoctorStore(applicationName, environment, keyPrefix);
 
+        /// <summary>
+        /// Reads one raw platform-stored value without applying indexed-store policy.
+        /// </summary>
+        /// <param name="identity">The normalized storage identity to read.</param>
+        /// <returns>
+        /// <see cref="LocalSecretResultStatus.Found"/> with the stored secret value when the value exists,
+        /// <see cref="LocalSecretResultStatus.Missing"/> when the platform confirms absence, or a terminal failure such as
+        /// <see cref="LocalSecretResultStatus.Locked"/>, <see cref="LocalSecretResultStatus.Unavailable"/>,
+        /// <see cref="LocalSecretResultStatus.UnsupportedPlatform"/>, or <see cref="LocalSecretResultStatus.ProviderFailed"/>
+        /// when the platform cannot safely answer. <see cref="List"/> depends on these statuses to distinguish stale
+        /// indexed names from stores it could not verify.
+        /// </returns>
         protected abstract AppSurfaceLocalSecretResult ReadStoredValue(AppSurfaceLocalSecretIdentity identity);
 
+        /// <summary>
+        /// Writes one raw platform-stored value without applying indexed-store policy.
+        /// </summary>
+        /// <param name="identity">The normalized storage identity to write.</param>
+        /// <param name="value">The secret value or index JSON to store.</param>
+        /// <returns>
+        /// <see cref="LocalSecretResultStatus.Found"/> with no display value when the platform write succeeds, or a
+        /// terminal failure when the platform is locked, unavailable, unsupported, or rejects the write. <see cref="Set"/>
+        /// and index repair only report success after this method succeeds for both the value and any required index write.
+        /// </returns>
         protected abstract AppSurfaceLocalSecretResult WriteStoredValue(AppSurfaceLocalSecretIdentity identity, string value);
 
+        /// <summary>
+        /// Deletes one raw platform-stored value without applying indexed-store policy.
+        /// </summary>
+        /// <param name="identity">The normalized storage identity to delete.</param>
+        /// <returns>
+        /// <see cref="LocalSecretResultStatus.Found"/> when the platform deleted an existing value,
+        /// <see cref="LocalSecretResultStatus.Missing"/> when the platform confirms absence, or a terminal failure when the
+        /// platform cannot safely delete or confirm absence. <see cref="Delete"/> uses the result together with an index
+        /// read to decide whether to remove a stale indexed name, preserve a confirmed missing result, or fail closed.
+        /// </returns>
         protected abstract AppSurfaceLocalSecretResult DeleteStoredValue(AppSurfaceLocalSecretIdentity identity);
 
+        /// <summary>
+        /// Verifies raw platform store availability for a namespace.
+        /// </summary>
+        /// <param name="applicationName">The normalized application namespace.</param>
+        /// <param name="environment">The normalized environment namespace.</param>
+        /// <param name="keyPrefix">The optional normalized key prefix.</param>
+        /// <returns>
+        /// A display-safe readiness result. Implementations should exercise raw platform read/write/delete behavior without
+        /// adding probe names to the user-visible index and should propagate locked, unavailable, unsupported, or provider
+        /// failures so CLI diagnostics remain fail-closed.
+        /// </returns>
         protected abstract AppSurfaceLocalSecretResult DoctorStore(string applicationName, string environment, string? keyPrefix);
 
         private static bool IsIndexIdentity(AppSurfaceLocalSecretIdentity identity) =>
@@ -755,7 +798,8 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
             string? keyPrefix,
             IEnumerable<string> keys)
         {
-            var index = JsonSerializer.Serialize(keys.Order(StringComparer.OrdinalIgnoreCase).ToArray());
+            var index = JsonSerializer.Serialize(
+                keys.OrderBy(static key => key, StringComparer.OrdinalIgnoreCase).ThenBy(static key => key, StringComparer.Ordinal).ToArray());
             var write = WriteStoredValue(IndexIdentity(applicationName, environment, keyPrefix), index);
             return write.Status == LocalSecretResultStatus.Found
                 ? AppSurfaceLocalSecretResult.Found(string.Empty, Name)

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets/PlatformAppSurfaceLocalSecretStore.cs
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets/PlatformAppSurfaceLocalSecretStore.cs
@@ -123,7 +123,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
 
         public override string Name => "macOS Keychain";
 
-        protected override AppSurfaceLocalSecretResult ReadValue(AppSurfaceLocalSecretIdentity identity)
+        protected override AppSurfaceLocalSecretResult ReadStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
             var names = BuildKeychainName(identity);
             var status = SecKeychainFindGenericPassword(
@@ -157,7 +157,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
             }
         }
 
-        protected override AppSurfaceLocalSecretResult WriteValue(AppSurfaceLocalSecretIdentity identity, string value)
+        protected override AppSurfaceLocalSecretResult WriteStoredValue(AppSurfaceLocalSecretIdentity identity, string value)
         {
             var names = BuildKeychainName(identity);
             var password = Encoding.UTF8.GetBytes(value);
@@ -182,15 +182,10 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                 return MapMacOsStatus(status, "write");
             }
 
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
-            {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
-            }
-
-            return UpdateIndex(identity, add: true);
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
         }
 
-        protected override AppSurfaceLocalSecretResult DeleteValue(AppSurfaceLocalSecretIdentity identity)
+        protected override AppSurfaceLocalSecretResult DeleteStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
             var status = FindItem(identity, out var itemRef);
             try
@@ -216,12 +211,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                 ReleaseIfNeeded(itemRef);
             }
 
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
-            {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
-            }
-
-            return UpdateIndex(identity, add: false);
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
         }
 
         protected override AppSurfaceLocalSecretResult DoctorStore(string applicationName, string environment, string? keyPrefix) =>
@@ -377,7 +367,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
 
         public override string Name => "Linux Secret Service";
 
-        protected override AppSurfaceLocalSecretResult ReadValue(AppSurfaceLocalSecretIdentity identity)
+        protected override AppSurfaceLocalSecretResult ReadStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
             var result = Run(
                 _secretToolPath,
@@ -393,7 +383,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                 : MapCommandFailure(result, "read");
         }
 
-        protected override AppSurfaceLocalSecretResult WriteValue(AppSurfaceLocalSecretIdentity identity, string value)
+        protected override AppSurfaceLocalSecretResult WriteStoredValue(AppSurfaceLocalSecretIdentity identity, string value)
         {
             var label = $"AppSurface {identity.ApplicationName} {identity.Environment} {identity.Key}";
             var result = Run(
@@ -405,15 +395,10 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                 return MapCommandFailure(result, "write");
             }
 
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
-            {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
-            }
-
-            return UpdateIndex(identity, add: true);
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
         }
 
-        protected override AppSurfaceLocalSecretResult DeleteValue(AppSurfaceLocalSecretIdentity identity)
+        protected override AppSurfaceLocalSecretResult DeleteStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
             var result = Run(
                 _secretToolPath,
@@ -426,12 +411,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                     : MapCommandFailure(result, "delete");
             }
 
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
-            {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
-            }
-
-            return UpdateIndex(identity, add: false);
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
         }
 
         protected override AppSurfaceLocalSecretResult DoctorStore(string applicationName, string environment, string? keyPrefix)
@@ -482,7 +462,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
 
         public override string Name => "Windows Credential Manager";
 
-        protected override AppSurfaceLocalSecretResult ReadValue(AppSurfaceLocalSecretIdentity identity)
+        protected override AppSurfaceLocalSecretResult ReadStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
             if (!CredReadW(TargetName(identity), CredentialTypeGeneric, 0, out var credentialPointer))
             {
@@ -509,7 +489,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
             }
         }
 
-        protected override AppSurfaceLocalSecretResult WriteValue(AppSurfaceLocalSecretIdentity identity, string value)
+        protected override AppSurfaceLocalSecretResult WriteStoredValue(AppSurfaceLocalSecretIdentity identity, string value)
         {
             var targetName = TargetName(identity);
             var blob = Encoding.Unicode.GetBytes(value);
@@ -546,15 +526,10 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                 blobHandle.Free();
             }
 
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
-            {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
-            }
-
-            return UpdateIndex(identity, add: true);
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
         }
 
-        protected override AppSurfaceLocalSecretResult DeleteValue(AppSurfaceLocalSecretIdentity identity)
+        protected override AppSurfaceLocalSecretResult DeleteStoredValue(AppSurfaceLocalSecretIdentity identity)
         {
             if (!CredDeleteW(TargetName(identity), CredentialTypeGeneric, 0))
             {
@@ -563,12 +538,7 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                     : WindowsFailure("delete", LocalSecretResultStatus.Unavailable);
             }
 
-            if (string.Equals(identity.Key, IndexKey, StringComparison.Ordinal))
-            {
-                return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
-            }
-
-            return UpdateIndex(identity, add: false);
+            return AppSurfaceLocalSecretResult.Found(string.Empty, Name);
         }
 
         protected override AppSurfaceLocalSecretResult DoctorStore(string applicationName, string environment, string? keyPrefix)
@@ -579,14 +549,14 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
                 keyPrefix,
                 "__appsurface_doctor__",
                 $"appsurface:{applicationName}:{environment}:{keyPrefix}:__appsurface_doctor__");
-            var write = WriteValue(probeIdentity, "ready");
+            var write = WriteStoredValue(probeIdentity, "ready");
             if (write.Status != LocalSecretResultStatus.Found)
             {
                 return write;
             }
 
-            var read = ReadValue(probeIdentity);
-            _ = DeleteValue(probeIdentity);
+            var read = ReadStoredValue(probeIdentity);
+            _ = DeleteStoredValue(probeIdentity);
             return read.Status == LocalSecretResultStatus.Found
                 ? AppSurfaceLocalSecretResult.NotFound(
                     LocalSecretResultStatus.Missing,
@@ -653,86 +623,213 @@ public sealed partial class PlatformAppSurfaceLocalSecretStore : IAppSurfaceLoca
 
         public abstract string Name { get; }
 
-        public AppSurfaceLocalSecretResult Get(AppSurfaceLocalSecretIdentity identity) => ReadValue(identity);
+        public AppSurfaceLocalSecretResult Get(AppSurfaceLocalSecretIdentity identity) => ReadStoredValue(identity);
 
-        public AppSurfaceLocalSecretResult Set(AppSurfaceLocalSecretIdentity identity, string value) => WriteValue(identity, value);
-
-        public AppSurfaceLocalSecretResult Delete(AppSurfaceLocalSecretIdentity identity) => DeleteValue(identity);
-
-        public AppSurfaceLocalSecretListResult List(string applicationName, string environment, string? keyPrefix)
+        public AppSurfaceLocalSecretResult Set(AppSurfaceLocalSecretIdentity identity, string value)
         {
-            var indexIdentity = new AppSurfaceLocalSecretIdentity(applicationName, environment, keyPrefix, IndexKey, $"appsurface:{applicationName}:{environment}:{keyPrefix}:{IndexKey}");
-            var result = ReadValue(indexIdentity);
-            if (result.Status == LocalSecretResultStatus.Missing)
+            if (IsIndexIdentity(identity))
             {
-                return AppSurfaceLocalSecretListResult.Found([], Name);
+                return WriteStoredValue(identity, value);
             }
 
-            if (result.Status != LocalSecretResultStatus.Found || result.Value == null)
-            {
-                return AppSurfaceLocalSecretListResult.Failed(result.Status, result.Diagnostic!, Name);
-            }
-
-            try
-            {
-                var keys = JsonSerializer.Deserialize<string[]>(result.Value) ?? [];
-                return AppSurfaceLocalSecretListResult.Found(keys.Where(key => !string.Equals(key, IndexKey, StringComparison.Ordinal)), Name);
-            }
-            catch (JsonException)
-            {
-                return AppSurfaceLocalSecretListResult.Failed(
-                    LocalSecretResultStatus.ProviderFailed,
-                    new AppSurfaceLocalSecretDiagnostic(
-                        "local-secret-index-invalid",
-                        "Local secret index is invalid.",
-                        "The platform store index entry could not be parsed.",
-                        "Delete and recreate the LocalSecrets namespace with `appsurface secrets init`.",
-                        "local-secrets-troubleshooting"),
-                    Name);
-            }
+            var write = WriteStoredValue(identity, value);
+            return write.Status == LocalSecretResultStatus.Found
+                ? AddToIndex(identity)
+                : write;
         }
 
-        public AppSurfaceLocalSecretResult Doctor(string applicationName, string environment, string? keyPrefix) =>
-            DoctorStore(applicationName, environment, keyPrefix);
-
-        protected abstract AppSurfaceLocalSecretResult ReadValue(AppSurfaceLocalSecretIdentity identity);
-
-        protected abstract AppSurfaceLocalSecretResult WriteValue(AppSurfaceLocalSecretIdentity identity, string value);
-
-        protected abstract AppSurfaceLocalSecretResult DeleteValue(AppSurfaceLocalSecretIdentity identity);
-
-        protected abstract AppSurfaceLocalSecretResult DoctorStore(string applicationName, string environment, string? keyPrefix);
-
-        protected AppSurfaceLocalSecretResult UpdateIndex(AppSurfaceLocalSecretIdentity identity, bool add)
+        public AppSurfaceLocalSecretResult Delete(AppSurfaceLocalSecretIdentity identity)
         {
-            var current = List(identity.ApplicationName, identity.Environment, identity.KeyPrefix);
-            if (current.Status != LocalSecretResultStatus.Found)
+            if (IsIndexIdentity(identity))
             {
-                return AppSurfaceLocalSecretResult.NotFound(current.Status, current.Diagnostic!, Name);
+                return DeleteStoredValue(identity);
             }
 
-            var keys = current.Keys.ToHashSet(StringComparer.Ordinal);
-            if (add)
+            var delete = DeleteStoredValue(identity);
+            if (delete.Status != LocalSecretResultStatus.Found && delete.Status != LocalSecretResultStatus.Missing)
             {
-                keys.Add(identity.Key);
-            }
-            else
-            {
-                keys.Remove(identity.Key);
+                return delete;
             }
 
-            var indexIdentity = identity with
+            var index = ReadIndex(identity.ApplicationName, identity.Environment, identity.KeyPrefix);
+            if (index.Status != LocalSecretResultStatus.Found)
             {
-                Key = IndexKey,
-                StorageName = $"appsurface:{identity.ApplicationName}:{identity.Environment}:{identity.KeyPrefix}:{IndexKey}"
-            };
-            var index = JsonSerializer.Serialize(keys.Order(StringComparer.OrdinalIgnoreCase).ToArray());
-            var write = WriteValue(indexIdentity, index);
+                return AppSurfaceLocalSecretResult.NotFound(index.Status, index.Diagnostic!, Name);
+            }
+
+            var keys = index.Keys.ToHashSet(StringComparer.Ordinal);
+            var wasIndexed = keys.Remove(identity.Key);
+            if (!wasIndexed)
+            {
+                return delete.Status == LocalSecretResultStatus.Found
+                    ? AppSurfaceLocalSecretResult.Found(string.Empty, Name)
+                    : delete;
+            }
+
+            var write = WriteIndex(identity.ApplicationName, identity.Environment, identity.KeyPrefix, keys);
             return write.Status == LocalSecretResultStatus.Found
                 ? AppSurfaceLocalSecretResult.Found(string.Empty, Name)
                 : write;
         }
 
+        public AppSurfaceLocalSecretListResult List(string applicationName, string environment, string? keyPrefix)
+        {
+            var index = ReadIndex(applicationName, environment, keyPrefix);
+            if (index.Status != LocalSecretResultStatus.Found)
+            {
+                return AppSurfaceLocalSecretListResult.Failed(index.Status, index.Diagnostic!, Name);
+            }
+
+            var liveKeys = new HashSet<string>(StringComparer.Ordinal);
+            var needsRepair = index.NeedsRepair;
+
+            foreach (var key in index.Keys)
+            {
+                var keyIdentity = KeyIdentity(applicationName, environment, keyPrefix, key);
+                if (!keyIdentity.Succeeded)
+                {
+                    return AppSurfaceLocalSecretListResult.Failed(
+                        LocalSecretResultStatus.ProviderFailed,
+                        InvalidIndexDiagnostic("The platform store index entry contains an invalid local secret key."),
+                        Name);
+                }
+
+                var value = ReadStoredValue(keyIdentity.Identity!);
+                if (value.Status == LocalSecretResultStatus.Found)
+                {
+                    liveKeys.Add(key);
+                    continue;
+                }
+
+                if (value.Status == LocalSecretResultStatus.Missing)
+                {
+                    needsRepair = true;
+                    continue;
+                }
+
+                return AppSurfaceLocalSecretListResult.Failed(value.Status, value.Diagnostic!, Name);
+            }
+
+            if (needsRepair)
+            {
+                var write = WriteIndex(applicationName, environment, keyPrefix, liveKeys);
+                if (write.Status != LocalSecretResultStatus.Found)
+                {
+                    return AppSurfaceLocalSecretListResult.Failed(write.Status, write.Diagnostic!, Name);
+                }
+            }
+
+            return AppSurfaceLocalSecretListResult.Found(liveKeys, Name);
+        }
+
+        public AppSurfaceLocalSecretResult Doctor(string applicationName, string environment, string? keyPrefix) =>
+            DoctorStore(applicationName, environment, keyPrefix);
+
+        protected abstract AppSurfaceLocalSecretResult ReadStoredValue(AppSurfaceLocalSecretIdentity identity);
+
+        protected abstract AppSurfaceLocalSecretResult WriteStoredValue(AppSurfaceLocalSecretIdentity identity, string value);
+
+        protected abstract AppSurfaceLocalSecretResult DeleteStoredValue(AppSurfaceLocalSecretIdentity identity);
+
+        protected abstract AppSurfaceLocalSecretResult DoctorStore(string applicationName, string environment, string? keyPrefix);
+
+        private static bool IsIndexIdentity(AppSurfaceLocalSecretIdentity identity) =>
+            string.Equals(identity.Key, IndexKey, StringComparison.Ordinal);
+
+        private AppSurfaceLocalSecretResult AddToIndex(AppSurfaceLocalSecretIdentity identity)
+        {
+            var index = ReadIndex(identity.ApplicationName, identity.Environment, identity.KeyPrefix);
+            if (index.Status != LocalSecretResultStatus.Found)
+            {
+                return AppSurfaceLocalSecretResult.NotFound(index.Status, index.Diagnostic!, Name);
+            }
+
+            var keys = index.Keys.ToHashSet(StringComparer.Ordinal);
+            keys.Add(identity.Key);
+            return WriteIndex(identity.ApplicationName, identity.Environment, identity.KeyPrefix, keys);
+        }
+
+        private AppSurfaceLocalSecretResult WriteIndex(
+            string applicationName,
+            string environment,
+            string? keyPrefix,
+            IEnumerable<string> keys)
+        {
+            var index = JsonSerializer.Serialize(keys.Order(StringComparer.OrdinalIgnoreCase).ToArray());
+            var write = WriteStoredValue(IndexIdentity(applicationName, environment, keyPrefix), index);
+            return write.Status == LocalSecretResultStatus.Found
+                ? AppSurfaceLocalSecretResult.Found(string.Empty, Name)
+                : write;
+        }
+
+        private IndexReadResult ReadIndex(string applicationName, string environment, string? keyPrefix)
+        {
+            var result = ReadStoredValue(IndexIdentity(applicationName, environment, keyPrefix));
+            if (result.Status == LocalSecretResultStatus.Missing)
+            {
+                return IndexReadResult.Found([], needsRepair: false);
+            }
+
+            if (result.Status != LocalSecretResultStatus.Found || result.Value == null)
+            {
+                return IndexReadResult.Failed(result.Status, result.Diagnostic!);
+            }
+
+            string?[] indexedKeys;
+            try
+            {
+                indexedKeys = JsonSerializer.Deserialize<string?[]>(result.Value) ?? [];
+            }
+            catch (JsonException)
+            {
+                return IndexReadResult.Failed(LocalSecretResultStatus.ProviderFailed, InvalidIndexDiagnostic("The platform store index entry could not be parsed."));
+            }
+
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            var needsRepair = false;
+            foreach (var key in indexedKeys)
+            {
+                if (string.IsNullOrWhiteSpace(key) || string.Equals(key, IndexKey, StringComparison.Ordinal))
+                {
+                    needsRepair = true;
+                    continue;
+                }
+
+                if (!keys.Add(key))
+                {
+                    needsRepair = true;
+                }
+            }
+
+            return IndexReadResult.Found(keys, needsRepair);
+        }
+
+        private static AppSurfaceLocalSecretIdentity IndexIdentity(string applicationName, string environment, string? keyPrefix) =>
+            new(applicationName, environment, keyPrefix, IndexKey, $"appsurface:{applicationName}:{environment}:{keyPrefix}:{IndexKey}");
+
+        private static AppSurfaceLocalSecretIdentityResult KeyIdentity(string applicationName, string environment, string? keyPrefix, string key) =>
+            new AppSurfaceLocalSecretIdentityNormalizer().Normalize(applicationName, environment, keyPrefix, key);
+
+        private static AppSurfaceLocalSecretDiagnostic InvalidIndexDiagnostic(string cause) =>
+            new(
+                "local-secret-index-invalid",
+                "Local secret index is invalid.",
+                cause,
+                "Remove the invalid platform index entry, then set the intended LocalSecrets keys again.",
+                "local-secrets-troubleshooting");
+
+        private sealed record IndexReadResult(
+            LocalSecretResultStatus Status,
+            IReadOnlyCollection<string> Keys,
+            bool NeedsRepair,
+            AppSurfaceLocalSecretDiagnostic? Diagnostic)
+        {
+            public static IndexReadResult Found(IReadOnlyCollection<string> keys, bool needsRepair) =>
+                new(LocalSecretResultStatus.Found, keys, needsRepair, null);
+
+            public static IndexReadResult Failed(LocalSecretResultStatus status, AppSurfaceLocalSecretDiagnostic diagnostic) =>
+                new(status, [], false, diagnostic);
+        }
     }
 
     internal abstract class CommandBackedLocalSecretStore : IndexedLocalSecretStore

--- a/Config/ForgeTrust.AppSurface.Config.LocalSecrets/README.md
+++ b/Config/ForgeTrust.AppSurface.Config.LocalSecrets/README.md
@@ -26,6 +26,18 @@ appsurface config diagnostics
 
 The diagnostics path reports where a value came from without printing the raw secret value.
 
+## Listing And Cleanup
+
+`appsurface secrets list` prints only currently retrievable logical key names, never values. Platform-backed stores keep
+a local name index so they can list safely across macOS Keychain, Linux Secret Service, and Windows Credential Manager.
+When `list` can read the index and validate the named values, it silently prunes indexed names whose values are already
+missing. If the platform store is locked, unavailable, or the index is corrupt, `list` fails with a paste-safe diagnostic
+instead of hiding names it could not verify.
+
+`appsurface secrets delete KEY` is narrowly idempotent for stale indexed names: if the value is already missing but the
+platform index still contains `KEY`, delete removes the stale name and reports success. A key that has no value and no
+index entry still reports `local-secret-missing`.
+
 ## Posture Modes
 
 - `DevelopmentOnly` is the default. It permits `Development`, `Local`, and `Dev`.

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -7,6 +7,8 @@ This is the living release note for the next coordinated AppSurface version afte
 - `ForgeTrust.AppSurface.Auth` now defines durable external-subject to app-user-id mapping contracts without taking on user-store, ASP.NET Core, OIDC, EF Core, Aspire, or tenant-authority responsibilities.
 - `ForgeTrust.AppSurface.Auth.AspNetCore` now includes AppSurface-shaped Minimal API policy helpers: `AddAppSurfacePolicy(...)` keeps policy definition in ASP.NET Core, while `RequireSurfacePolicy(...)` evaluates the named host policy through the existing AppSurface evaluator and returns API-safe ProblemDetails JSON for challenge, forbid, missing-policy, missing-service, and missing-subject outcomes instead of triggering browser redirects.
 - Sanitized AppSurface Config audit diffs for comparing captured runtime configuration reports.
+- LocalSecrets platform-index self-healing so `appsurface secrets list` no longer surfaces stale names whose stored
+  values are missing.
 
 ## Included in the next coordinated version
 
@@ -16,6 +18,10 @@ This is the living release note for the next coordinated AppSurface version afte
 - Added `ExternalSubject`, `AppUserId`, `IAppSurfaceUserIdentityResolver`, `AppSurfaceUserIdentityResolutionContext`, `AppSurfaceUserIdentityResult`, and `AppSurfaceUserIdentityStatus`, with README guidance for uniqueness, idempotency, cancellation, concurrency, PII-safe diagnostics, and ASP.NET Core adapter integration planning.
 - `ForgeTrust.AppSurface.Auth.AspNetCore` documents the new Minimal API policy helper flow, package chooser metadata, safe ProblemDetails failure shape, and when native ASP.NET Core `RequireAuthorization(...)` remains the better choice.
 - AppSurface Config now exposes a sanitized config audit diff surface. `ConfigAuditReportDiffer` compares two existing `ConfigAuditReport` snapshots without re-resolving providers, `ConfigAuditDiffTextRenderer` renders deterministic same-host or captured-snapshot evidence with redaction uncertainty called out, and `ConfigAuditDiffCommandRunner` gives apps command-framework-agnostic same-host and captured JSON workflows with display-safe problem/cause/fix/docs-link failures.
+- AppSurface LocalSecrets platform-backed stores now validate indexed names against live stored values during
+  `appsurface secrets list`. Missing values are pruned from the index when validation and repair succeed, and
+  `appsurface secrets delete KEY` repairs a stale indexed name when the value is already gone while preserving
+  `local-secret-missing` for keys that never existed.
 
 ### AppSurface Flow
 


### PR DESCRIPTION
## Summary

Fixes stale LocalSecrets platform index behavior for OS-backed stores:

- `appsurface secrets list` now validates indexed names against live stored values before returning them.
- Stale indexed names whose values are missing are pruned after a successful validation and repair pass.
- `appsurface secrets delete KEY` now removes a stale indexed name when the value is already gone, while preserving `local-secret-missing` for keys that never existed.
- Platform adapters now expose raw stored-value operations while the shared indexed store owns index mutation policy.
- Docs and release notes now describe the “currently retrievable names” contract and the narrow stale-delete idempotency behavior.

## Test Coverage

All new LocalSecrets paths have regression coverage through `PlatformAppSurfaceLocalSecretStoreTests`.

- Stale indexed key pruned by `list`
- Stale indexed key removed by `delete`
- Never-existing key still returns `Missing`
- Terminal value-read failures do not rewrite the index
- Corrupt index fails closed without repair
- Repair write failure preserves the old index
- Duplicate and reserved index entries are pruned
- Case-variant keys remain distinct

Solution coverage:

- Line coverage: 96.19%
- Branch coverage: 89.90%
- Coverage artifacts: `TestResults/coverage-merged`

## Pre-Landing Review

No issues found.

Standalone review plus a subagent review both found no behavioral regressions. Residual risk is limited to live platform integration coverage: the repair policy is covered through the fake indexed store rather than real macOS Keychain, Windows Credential Manager, or Linux Secret Service mutation.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: fix stale names in platform-backed LocalSecrets list/delete behavior.

Delivered: shared indexed-store self-healing for list and delete, plus docs, release notes, and regression tests.

## Plan Completion

Plan: `/Users/andrew/.gstack/projects/forge-trust-AppSurface/andrew-main-design-20260619-221441-localsecrets-stale-index.md`

- DONE: shared indexed-store raw value/index split
- DONE: list validates indexed names against live values and prunes stale missing entries
- DONE: delete repairs stale indexed names while preserving never-existing `Missing`
- DONE: terminal failures and corrupt indexes fail closed without repair
- DONE: case variants, duplicate entries, reserved entries, repair failure, and stale cases covered by tests
- DONE: XML docs, package README, CLI README, CHANGELOG, and unreleased release note updated
- DONE: package index verification passed

## Verification Results

- [x] `dotnet build Config/ForgeTrust.AppSurface.Config.LocalSecrets/ForgeTrust.AppSurface.Config.LocalSecrets.csproj --no-restore`
- [x] `dotnet test Config/ForgeTrust.AppSurface.Config.LocalSecrets.Tests/ForgeTrust.AppSurface.Config.LocalSecrets.Tests.csproj --no-restore` — 80 passed
- [x] `dotnet test Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj --no-restore` — 356 passed
- [x] `dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj -- verify`
- [x] `dotnet format --verify-no-changes --no-restore`
- [x] `git diff --check`
- [x] `./scripts/coverage-solution.sh` — 29/29 test projects passed, line 96.19%, branch 89.90%

## TODOS

No root `TODOS.md` exists; no TODO items updated.

## Test plan

- [x] LocalSecrets package build passes
- [x] LocalSecrets regression tests pass
- [x] CLI tests pass
- [x] Package index verification passes
- [x] Formatting and whitespace checks pass
- [x] Full solution coverage gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
