### PR TITLE
test: isolate generated NuGet package caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - RazorWire hybrid islands now block inline `data:` module specifiers and protocol-relative `//...` module URLs; serve client modules from relative, root-relative, same-origin, explicit HTTPS, or import-map specifiers instead.
 - RazorWire stream authorization can now return `AppSurfaceAuthResult` outcomes before SSE starts, while existing bool authorizers keep working through a compatibility adapter.
 - RazorWire now provides stable local form interactions for conditional targets and one-dimensional ASP.NET Core model-bound collections without page-local JavaScript.
+- Package verification tests now keep Tailwind packed-consumer smoke restores out of the user-level NuGet package cache and remove generated RazorWire ToolVerifier package entries after the tool contract proof completes.
 
 ## 0.1.0-rc.4 - 2026-06-16
 

--- a/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
@@ -1396,13 +1396,16 @@ public sealed class TailwindBuildTargetsTests : IDisposable
         var configuredPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
         if (!string.IsNullOrWhiteSpace(configuredPath))
         {
+            Directory.CreateDirectory(configuredPath);
             return configuredPath;
         }
 
-        return Path.Join(
+        var packagesPath = Path.Join(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".nuget",
             "packages");
+        Directory.CreateDirectory(packagesPath);
+        return packagesPath;
     }
 
     private string CreateNuGetPackageCacheDirectory(string name)

--- a/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/TailwindBuildTargetsTests.cs
@@ -1174,6 +1174,7 @@ public sealed class TailwindBuildTargetsTests : IDisposable
     {
         var feedDirectory = Path.Join(_tempRoot, "feed");
         Directory.CreateDirectory(feedDirectory);
+        var nugetPackagesDirectory = CreateNuGetPackageCacheDirectory("packed-consumer-nuget-packages");
         var repoRoot = GetRepositoryRoot();
         var packageVersion = CreateSmokePackageVersion();
 
@@ -1213,6 +1214,7 @@ public sealed class TailwindBuildTargetsTests : IDisposable
                 <TargetFramework>net10.0</TargetFramework>
                 <Nullable>enable</Nullable>
                 <RestoreSources>{{EscapeForXml(feedDirectory)}};$(RestoreSources)</RestoreSources>
+                <RestoreFallbackFolders>{{EscapeForXml(GetNuGetFallbackPackagesPath())}}</RestoreFallbackFolders>
                 <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>
                 <StaticWebAssetBasePath>_content/PackedConsumer</StaticWebAssetBasePath>
                 <TailwindInputPath>wwwroot/css/app.css</TailwindInputPath>
@@ -1227,7 +1229,10 @@ public sealed class TailwindBuildTargetsTests : IDisposable
             </Project>
             """);
 
-        var buildResult = await RunDotNetAsync(["build", projectPath, "-nologo", "-v:minimal"], projectDirectory);
+        var buildResult = await RunDotNetAsync(
+            ["build", projectPath, "-nologo", "-v:minimal"],
+            projectDirectory,
+            ("NUGET_PACKAGES", nugetPackagesDirectory));
         var buildOutput = buildResult.Stdout + Environment.NewLine + buildResult.Stderr;
         Assert.Equal(0, buildResult.ExitCode);
         Assert.True(File.Exists(markerPath), buildOutput);
@@ -1236,7 +1241,10 @@ public sealed class TailwindBuildTargetsTests : IDisposable
         var manifestPath = GetStaticWebAssetsBuildManifestPath(projectDirectory, buildOutput);
         await AssertBuildManifestContainsGeneratedCssAsync(manifestPath);
 
-        var publishResult = await RunDotNetAsync(["publish", projectPath, "-nologo", "-v:minimal", "--no-restore"], projectDirectory);
+        var publishResult = await RunDotNetAsync(
+            ["publish", projectPath, "-nologo", "-v:minimal", "--no-restore"],
+            projectDirectory,
+            ("NUGET_PACKAGES", nugetPackagesDirectory));
         var publishOutput = publishResult.Stdout + Environment.NewLine + publishResult.Stderr;
         Assert.Equal(0, publishResult.ExitCode);
         Assert.True(
@@ -1250,6 +1258,7 @@ public sealed class TailwindBuildTargetsTests : IDisposable
     {
         var feedDirectory = Path.Join(_tempRoot, "default-runtime-feed");
         Directory.CreateDirectory(feedDirectory);
+        var nugetPackagesDirectory = CreateNuGetPackageCacheDirectory("packed-default-runtime-consumer-nuget-packages");
         var repoRoot = GetRepositoryRoot();
         var packageVersion = CreateSmokePackageVersion();
 
@@ -1276,6 +1285,7 @@ public sealed class TailwindBuildTargetsTests : IDisposable
                 <TargetFramework>net10.0</TargetFramework>
                 <Nullable>enable</Nullable>
                 <RestoreSources>{{EscapeForXml(feedDirectory)}};$(RestoreSources)</RestoreSources>
+                <RestoreFallbackFolders>{{EscapeForXml(GetNuGetFallbackPackagesPath())}}</RestoreFallbackFolders>
                 <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>
                 <StaticWebAssetBasePath>_content/PackedDefaultRuntimeConsumer</StaticWebAssetBasePath>
                 <TailwindInputPath>wwwroot/css/app.css</TailwindInputPath>
@@ -1289,7 +1299,10 @@ public sealed class TailwindBuildTargetsTests : IDisposable
             </Project>
             """);
 
-        var buildResult = await RunDotNetAsync(["build", projectPath, "-nologo", "-v:minimal"], projectDirectory);
+        var buildResult = await RunDotNetAsync(
+            ["build", projectPath, "-nologo", "-v:minimal"],
+            projectDirectory,
+            ("NUGET_PACKAGES", nugetPackagesDirectory));
         var buildOutput = buildResult.Stdout + Environment.NewLine + buildResult.Stderr;
 
         Assert.True(buildResult.ExitCode == 0, buildOutput);
@@ -1376,6 +1389,27 @@ public sealed class TailwindBuildTargetsTests : IDisposable
     private static string CreateSmokePackageVersion()
     {
         return "0.1.0-smoke." + Guid.NewGuid().ToString("N");
+    }
+
+    private static string GetNuGetFallbackPackagesPath()
+    {
+        var configuredPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return configuredPath;
+        }
+
+        return Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".nuget",
+            "packages");
+    }
+
+    private string CreateNuGetPackageCacheDirectory(string name)
+    {
+        var path = Path.Join(_tempRoot, name);
+        Directory.CreateDirectory(path);
+        return path;
     }
 
     private static async Task<string> CreatePackagedTargetsCopyAsync(string projectDirectory)

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
@@ -285,7 +285,7 @@ public sealed class ToolPackageContractTests
         {
             var packageIdSegment = GetSafePackagePathSegment(packageId, nameof(packageId));
             var packageVersionSegment = GetSafePackagePathSegment(packageVersion, nameof(packageVersion));
-            var packageVersionDirectory = System.IO.Path.Combine(
+            var packageVersionDirectory = TestPathUtils.PathUnder(
                 nugetPackagesDirectory,
                 packageIdSegment,
                 packageVersionSegment);

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
@@ -26,6 +26,7 @@ public sealed class ToolPackageContractTests
         var exportDirectory = workspace.CreateSubdirectory("export-output");
         var version = "0.0.0-toolverifier." + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
         var nugetPackagesDirectory = GetDefaultNuGetPackagesPath();
+        using var packageCacheCleanup = new GeneratedPackageCacheCleanup(nugetPackagesDirectory, PackageId, version);
         var repositoryRunner = new ToolProcessRunner(
             repositoryRoot,
             new Dictionary<string, string?>
@@ -271,6 +272,34 @@ public sealed class ToolPackageContractTests
             Assert.True(
                 ExitCode == 0,
                 $"{message}{Environment.NewLine}Command: {CommandLine}{Environment.NewLine}Exit code: {ExitCode?.ToString(CultureInfo.InvariantCulture) ?? "<timeout>"}{Environment.NewLine}STDOUT:{Environment.NewLine}{Stdout}{Environment.NewLine}STDERR:{Environment.NewLine}{Stderr}");
+        }
+    }
+
+    private sealed class GeneratedPackageCacheCleanup(
+        string nugetPackagesDirectory,
+        string packageId,
+        string packageVersion) : IDisposable
+    {
+        public void Dispose()
+        {
+            var packageVersionDirectory = System.IO.Path.Combine(
+                nugetPackagesDirectory,
+                packageId.ToLowerInvariant(),
+                packageVersion.ToLowerInvariant());
+
+            try
+            {
+                if (Directory.Exists(packageVersionDirectory))
+                {
+                    Directory.Delete(packageVersionDirectory, recursive: true);
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
     }
 

--- a/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
+++ b/Web/ForgeTrust.RazorWire.Cli.Tests/ToolPackageContractTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
 using System.Text;
@@ -282,10 +283,12 @@ public sealed class ToolPackageContractTests
     {
         public void Dispose()
         {
+            var packageIdSegment = GetSafePackagePathSegment(packageId, nameof(packageId));
+            var packageVersionSegment = GetSafePackagePathSegment(packageVersion, nameof(packageVersion));
             var packageVersionDirectory = System.IO.Path.Combine(
                 nugetPackagesDirectory,
-                packageId.ToLowerInvariant(),
-                packageVersion.ToLowerInvariant());
+                packageIdSegment,
+                packageVersionSegment);
 
             try
             {
@@ -294,12 +297,32 @@ public sealed class ToolPackageContractTests
                     Directory.Delete(packageVersionDirectory, recursive: true);
                 }
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+                Trace.TraceWarning(
+                    "Could not delete generated NuGet package cache directory '{0}': {1}",
+                    packageVersionDirectory,
+                    ex);
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
+                Trace.TraceWarning(
+                    "Could not delete generated NuGet package cache directory '{0}': {1}",
+                    packageVersionDirectory,
+                    ex);
             }
+        }
+
+        private static string GetSafePackagePathSegment(string value, string parameterName)
+        {
+            if (System.IO.Path.IsPathRooted(value)
+                || value.IndexOf(System.IO.Path.DirectorySeparatorChar, StringComparison.Ordinal) >= 0
+                || value.IndexOf(System.IO.Path.AltDirectorySeparatorChar, StringComparison.Ordinal) >= 0)
+            {
+                throw new InvalidOperationException($"{parameterName} must be a NuGet package path segment.");
+            }
+
+            return value.ToLowerInvariant();
         }
     }
 
@@ -332,11 +355,13 @@ public sealed class ToolPackageContractTests
             {
                 Directory.Delete(Path, recursive: true);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+                Trace.TraceWarning("Could not delete temporary directory '{0}': {1}", Path, ex);
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
+                Trace.TraceWarning("Could not delete temporary directory '{0}': {1}", Path, ex);
             }
         }
     }

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -50,8 +50,8 @@ This is the living release note for the next coordinated AppSurface version afte
 - AppSurface Web CORS startup validation now fails closed before policy registration when non-development
   `CorsOptions.AllowedOrigins` includes the exact literal `*`, while preserving Development all-origin convenience and
   wildcard subdomain origins such as `https://*.example.com`.
-- Package verification tests now keep packed-tool smoke restores out of the user-level NuGet package cache and clean up
-  generated RazorWire ToolVerifier package entries after the tool contract proof completes.
+- Package verification tests now keep Tailwind packed-consumer smoke restores out of the user-level NuGet package cache
+  and clean up generated RazorWire ToolVerifier package entries after the tool contract proof completes.
 
 ### AppSurface Flow
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -50,6 +50,8 @@ This is the living release note for the next coordinated AppSurface version afte
 - AppSurface Web CORS startup validation now fails closed before policy registration when non-development
   `CorsOptions.AllowedOrigins` includes the exact literal `*`, while preserving Development all-origin convenience and
   wildcard subdomain origins such as `https://*.example.com`.
+- Package verification tests now keep packed-tool smoke restores out of the user-level NuGet package cache and clean up
+  generated RazorWire ToolVerifier package entries after the tool contract proof completes.
 
 ### AppSurface Flow
 


### PR DESCRIPTION
## Summary
- Isolate Tailwind packed-consumer smoke restores in per-test NuGet package roots so `0.1.0-smoke.*` packages do not accumulate in the user global cache.
- Keep RazorWire ToolVerifier dependencies on the stable NuGet cache, but delete only the generated `ForgeTrust.RazorWire.Cli/<0.0.0-toolverifier.*>` package entry after the contract proof completes.
- Record the cache cleanup behavior in `CHANGELOG.md` under `Unreleased`.

## Test Coverage
Test-only diff. No new application code paths to audit.

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed. Design review skipped.

## Eval Results
No prompt-related files changed. Evals skipped.

## Scope Drift
Scope Check: CLEAN. The diff is limited to package-verification cache cleanup and release ledger documentation.

## Plan Completion
No plan file detected.

## Verification Results
- `dotnet restore Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/ForgeTrust.AppSurface.Web.Tailwind.Tests.csproj`
- `dotnet restore Web/ForgeTrust.RazorWire.Cli.Tests/ForgeTrust.RazorWire.Cli.Tests.csproj`
- `dotnet test Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/ForgeTrust.AppSurface.Web.Tailwind.Tests.csproj --no-restore --filter "FullyQualifiedName~PackedPackageConsumption"` — passed, 2 tests
- `dotnet test Web/ForgeTrust.RazorWire.Cli.Tests/ForgeTrust.RazorWire.Cli.Tests.csproj --no-restore --filter "FullyQualifiedName~PackagedTool_Should_Run_Through_Dnx_ToolInstall_And_InstalledExport"` — passed, 1 test when run sequentially after Tailwind
- `dotnet format Web/ForgeTrust.AppSurface.Web.Tailwind.Tests/ForgeTrust.AppSurface.Web.Tailwind.Tests.csproj --no-restore --verify-no-changes`
- `dotnet format Web/ForgeTrust.RazorWire.Cli.Tests/ForgeTrust.RazorWire.Cli.Tests.csproj --no-restore --verify-no-changes`
- `git diff --check`
- Dummy NuGet cache pattern check: `0` directories matching `0.1.0-smoke.*` or `0.0.0-toolverifier.*` after final passing reruns

## Versioning
This repository does not currently have a root `VERSION` file, so this draft PR follows the existing `CHANGELOG.md` Unreleased ledger instead of adding a new version file.

## Test plan
- [x] Tailwind packed-package smoke tests pass
- [x] RazorWire CLI ToolVerifier package contract test passes
- [x] Generated dummy NuGet cache entries remain cleaned up after rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)