### PR TITLE
fix(web): scope PWA cache cleanup

### DIFF
--- a/Web/ForgeTrust.AppSurface.Web.Tests/PwaEndpointTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/PwaEndpointTests.cs
@@ -218,23 +218,39 @@ public sealed class PwaEndpointTests
                 options.Pwa.Offline.StaticAssetPaths = ["/css/site.css"];
             },
             pathBase: "/tenant");
+        await using var changedManifestScopeApp = await StartHostAsync(options =>
+        {
+            ConfigureValidPwa(options.Pwa);
+            options.Pwa.Scope = "/workspace/";
+            options.Pwa.StartUrl = "/workspace/";
+            options.Pwa.Offline.Enabled = true;
+            options.Pwa.Offline.OfflineFallbackPath = "/offline.html";
+            options.Pwa.Offline.StaticAssetPaths = ["/css/site.css"];
+        });
 
         using var rootResponse = await rootApp.Client.GetAsync("/service-worker.js");
         using var tenantResponse = await tenantApp.Client.GetAsync("/tenant/service-worker.js");
+        using var changedManifestScopeResponse = await changedManifestScopeApp.Client.GetAsync("/service-worker.js");
         var rootScript = await rootResponse.Content.ReadAsStringAsync();
         var tenantScript = await tenantResponse.Content.ReadAsStringAsync();
+        var changedManifestScopeScript = await changedManifestScopeResponse.Content.ReadAsStringAsync();
 
         var rootCachePrefix = ExtractScriptConstant(rootScript, "CACHE_PREFIX");
         var tenantCachePrefix = ExtractScriptConstant(tenantScript, "CACHE_PREFIX");
+        var changedManifestScopeCachePrefix = ExtractScriptConstant(changedManifestScopeScript, "CACHE_PREFIX");
 
         Assert.StartsWith("appsurface-pwa-", rootCachePrefix, StringComparison.Ordinal);
         Assert.StartsWith("appsurface-pwa-", tenantCachePrefix, StringComparison.Ordinal);
         Assert.NotEqual(rootCachePrefix, tenantCachePrefix);
+        Assert.Equal(rootCachePrefix, changedManifestScopeCachePrefix);
         Assert.Contains($"""const CACHE_NAME = "{rootCachePrefix}v1";""", rootScript, StringComparison.Ordinal);
         Assert.Contains(
-            "key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME",
+            "return (key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME) || LEGACY_CACHE_NAMES.includes(key);",
             rootScript,
             StringComparison.Ordinal);
+        Assert.Contains("""const LEGACY_CACHE_NAMES = ["appsurface-pwa-v1"];""", rootScript, StringComparison.Ordinal);
+        Assert.Contains("await self.skipWaiting();", rootScript, StringComparison.Ordinal);
+        Assert.Contains("await self.clients.claim();", rootScript, StringComparison.Ordinal);
         Assert.DoesNotContain(
             "keys.filter(key => key !== CACHE_NAME)",
             rootScript,

--- a/Web/ForgeTrust.AppSurface.Web.Tests/PwaEndpointTests.cs
+++ b/Web/ForgeTrust.AppSurface.Web.Tests/PwaEndpointTests.cs
@@ -200,6 +200,48 @@ public sealed class PwaEndpointTests
     }
 
     [Fact]
+    public async Task OfflineStrategy_ServiceWorkerPrunesOnlyCurrentAppSurfaceScopeCaches()
+    {
+        await using var rootApp = await StartHostAsync(options =>
+        {
+            ConfigureValidPwa(options.Pwa);
+            options.Pwa.Offline.Enabled = true;
+            options.Pwa.Offline.OfflineFallbackPath = "/offline.html";
+            options.Pwa.Offline.StaticAssetPaths = ["/css/site.css"];
+        });
+        await using var tenantApp = await StartHostAsync(
+            options =>
+            {
+                ConfigureValidPwa(options.Pwa);
+                options.Pwa.Offline.Enabled = true;
+                options.Pwa.Offline.OfflineFallbackPath = "/offline.html";
+                options.Pwa.Offline.StaticAssetPaths = ["/css/site.css"];
+            },
+            pathBase: "/tenant");
+
+        using var rootResponse = await rootApp.Client.GetAsync("/service-worker.js");
+        using var tenantResponse = await tenantApp.Client.GetAsync("/tenant/service-worker.js");
+        var rootScript = await rootResponse.Content.ReadAsStringAsync();
+        var tenantScript = await tenantResponse.Content.ReadAsStringAsync();
+
+        var rootCachePrefix = ExtractScriptConstant(rootScript, "CACHE_PREFIX");
+        var tenantCachePrefix = ExtractScriptConstant(tenantScript, "CACHE_PREFIX");
+
+        Assert.StartsWith("appsurface-pwa-", rootCachePrefix, StringComparison.Ordinal);
+        Assert.StartsWith("appsurface-pwa-", tenantCachePrefix, StringComparison.Ordinal);
+        Assert.NotEqual(rootCachePrefix, tenantCachePrefix);
+        Assert.Contains($"""const CACHE_NAME = "{rootCachePrefix}v1";""", rootScript, StringComparison.Ordinal);
+        Assert.Contains(
+            "key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME",
+            rootScript,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "keys.filter(key => key !== CACHE_NAME)",
+            rootScript,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PathBase_IsAppliedToManifestDiagnosticsAndServiceWorker()
     {
         await using var app = await StartHostAsync(
@@ -252,6 +294,17 @@ public sealed class PwaEndpointTests
         pwa.BackgroundColor = valid.BackgroundColor;
         pwa.Icons.Add(new PwaIcon { Source = "/icons/app-192.png", Sizes = "192x192", Type = "image/png" });
         pwa.Icons.Add(new PwaIcon { Source = "/icons/app-512.png", Sizes = "512x512", Type = "image/png" });
+    }
+
+    private static string ExtractScriptConstant(string script, string name)
+    {
+        var marker = $"const {name} = \"";
+        var start = script.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Expected {name} to be declared in the service worker script.");
+        start += marker.Length;
+        var end = script.IndexOf('"', start);
+        Assert.True(end > start, $"Expected {name} to have a string literal value.");
+        return script[start..end];
     }
 
     private static async Task<RunningApp> StartHostAsync(

--- a/Web/ForgeTrust.AppSurface.Web/PwaEndpointMapper.cs
+++ b/Web/ForgeTrust.AppSurface.Web/PwaEndpointMapper.cs
@@ -225,18 +225,29 @@ internal static class PwaEndpointMapper
             $$"""
             const CACHE_PREFIX = {{cachePrefixJson}};
             const CACHE_NAME = {{cacheNameJson}};
+            const LEGACY_CACHE_NAMES = ["appsurface-pwa-v1"];
             const STATIC_ASSETS = {{assetsJson}};
             const OFFLINE_FALLBACK = {{fallbackJson}};
 
             self.addEventListener("install", event => {
-              event.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS)));
-              self.skipWaiting();
+              event.waitUntil((async () => {
+                const cache = await caches.open(CACHE_NAME);
+                await cache.addAll(STATIC_ASSETS);
+                await self.skipWaiting();
+              })());
             });
 
             self.addEventListener("activate", event => {
-              event.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(key => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME).map(key => caches.delete(key)))));
-              self.clients.claim();
+              event.waitUntil((async () => {
+                const keys = await caches.keys();
+                await Promise.all(keys.filter(shouldDeleteCache).map(key => caches.delete(key)));
+                await self.clients.claim();
+              })());
             });
+
+            function shouldDeleteCache(key) {
+              return (key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME) || LEGACY_CACHE_NAMES.includes(key);
+            }
 
             self.addEventListener("fetch", event => {
               const request = event.request;
@@ -264,8 +275,8 @@ internal static class PwaEndpointMapper
 
     private static string BuildCacheScopeKey(PathString pathBase, PwaOptions options)
     {
-        var scope = AddPathBase(pathBase, options.Scope);
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(scope));
+        var serviceWorkerPath = AddPathBase(pathBase, options.Offline.ServiceWorkerPath);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(serviceWorkerPath));
         return Convert.ToHexString(hash.AsSpan(0, 8)).ToLowerInvariant();
     }
 }

--- a/Web/ForgeTrust.AppSurface.Web/PwaEndpointMapper.cs
+++ b/Web/ForgeTrust.AppSurface.Web/PwaEndpointMapper.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -216,10 +217,14 @@ internal static class PwaEndpointMapper
         var offlineFallbackPath = AddPathBase(httpContext.Request.PathBase, options.Offline.OfflineFallbackPath);
         var assetsJson = JsonSerializer.Serialize(paths);
         var fallbackJson = JsonSerializer.Serialize(offlineFallbackPath);
+        var cachePrefix = $"appsurface-pwa-{BuildCacheScopeKey(httpContext.Request.PathBase, options)}-";
+        var cachePrefixJson = JsonSerializer.Serialize(cachePrefix);
+        var cacheNameJson = JsonSerializer.Serialize(cachePrefix + "v1");
 
         await httpContext.Response.WriteAsync(
             $$"""
-            const CACHE_NAME = "appsurface-pwa-v1";
+            const CACHE_PREFIX = {{cachePrefixJson}};
+            const CACHE_NAME = {{cacheNameJson}};
             const STATIC_ASSETS = {{assetsJson}};
             const OFFLINE_FALLBACK = {{fallbackJson}};
 
@@ -229,7 +234,7 @@ internal static class PwaEndpointMapper
             });
 
             self.addEventListener("activate", event => {
-              event.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))));
+              event.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(key => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME).map(key => caches.delete(key)))));
               self.clients.claim();
             });
 
@@ -255,6 +260,13 @@ internal static class PwaEndpointMapper
     private static string AddPathBase(PathString pathBase, string path)
     {
         return pathBase.Add(new PathString(path)).Value ?? path;
+    }
+
+    private static string BuildCacheScopeKey(PathString pathBase, PwaOptions options)
+    {
+        var scope = AddPathBase(pathBase, options.Scope);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(scope));
+        return Convert.ToHexString(hash.AsSpan(0, 8)).ToLowerInvariant();
     }
 }
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -18,8 +18,8 @@ This is the living release note for the next coordinated AppSurface version afte
   an offline fallback strategy. MVC and Razor apps can add `<appsurface:pwa-head />`; custom layouts can copy equivalent
   tags from diagnostics; `appsurface pwa verify --url <origin>` checks the live metadata, icons, secure-origin posture,
   diagnostics, and opt-in service worker.
-- The generated starter PWA service worker now scopes cache cleanup to the current AppSurface registration scope so it
-  does not prune unrelated origin caches or another path-mounted AppSurface app's offline cache.
+- The generated starter PWA service worker now scopes cache cleanup to the current AppSurface service-worker owner and
+  reaps the earlier global AppSurface cache name without pruning unrelated origin caches or another path-mounted app.
 
 ## Migration watch
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -18,6 +18,8 @@ This is the living release note for the next coordinated AppSurface version afte
   an offline fallback strategy. MVC and Razor apps can add `<appsurface:pwa-head />`; custom layouts can copy equivalent
   tags from diagnostics; `appsurface pwa verify --url <origin>` checks the live metadata, icons, secure-origin posture,
   diagnostics, and opt-in service worker.
+- The generated starter PWA service worker now scopes cache cleanup to the current AppSurface registration scope so it
+  does not prune unrelated origin caches or another path-mounted AppSurface app's offline cache.
 
 ## Migration watch
 


### PR DESCRIPTION
## Summary

Follow-up to PR #576. The generated AppSurface PWA service worker now scopes cache cleanup to the current AppSurface registration scope instead of deleting every non-current cache on the origin.

- Adds a scope-derived AppSurface cache prefix for the generated starter service worker.
- Deletes only stale caches matching that AppSurface prefix.
- Keeps root and path-base-mounted apps from pruning each other's AppSurface caches.
- Adds a regression test covering the cleanup predicate and distinct root vs `/tenant` cache namespaces.

## Verification

- `dotnet test Web/ForgeTrust.AppSurface.Web.Tests/ForgeTrust.AppSurface.Web.Tests.csproj --no-restore --filter FullyQualifiedName~PwaEndpointTests` passed: 11/11.
- `git diff --check` passed.

## Scope Drift

Scope Check: CLEAN

Intent: Fix the over-broad service-worker cache cleanup found after PR #576 merged.

Delivered: Cache cleanup is now AppSurface-prefix and scope bounded, with focused endpoint coverage.