### PR TITLE
ci(release): prove docs archive before stable NuGet publish

### DIFF
--- a/.github/workflows/nuget-stable-publish.yml
+++ b/.github/workflows/nuget-stable-publish.yml
@@ -219,11 +219,127 @@ jobs:
           path: ${{ runner.temp }}/package-artifacts
           if-no-files-found: error
 
+  prove-docs-archive:
+    needs:
+      - validate-tag
+      - validate-source-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout tag commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag-commit }}
+          persist-credentials: false
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Export and verify stable docs archive before NuGet publish
+        env:
+          PACKAGE_VERSION: ${{ needs.validate-tag.outputs.package-version }}
+          AppSurfaceDocs__Contributor__DefaultBranch: ${{ env.STABLE_BASE_REF }}
+          AppSurfaceDocs__Contributor__SourceRef: ${{ needs.validate-tag.outputs.tag-commit }}
+          AppSurfaceDocs__Contributor__SourceUrlTemplate: https://github.com/${{ github.repository }}/blob/{branch}/{path}
+          AppSurfaceDocs__Contributor__SymbolSourceUrlTemplate: https://github.com/${{ github.repository }}/blob/{ref}/{path}#L{line}
+          AppSurfaceDocs__Contributor__EditUrlTemplate: https://github.com/${{ github.repository }}/edit/{branch}/{path}
+          AppSurfaceDocs__Contributor__LastUpdatedMode: Git
+          AppSurfaceDocs__Identity__DisplayName: AppSurface
+          AppSurfaceDocs__Identity__Wordmark__HighlightText: Surface
+          AppSurfaceDocs__Identity__Wordmark__HighlightColor: "#3b82f6"
+          AppSurfaceDocs__Identity__BrandingAssets__DirectoryPath: branding
+          AppSurfaceDocs__Identity__BrandingAssets__AllowSvgAssets: "true"
+          AppSurfaceDocs__Identity__Logo__Path: /branding/appsurface-site-icon.svg
+          AppSurfaceDocs__Identity__Favicon__SvgPath: /branding/appsurface-site-icon.svg
+          AppSurfaceDocs__Harvest__JavaScript__IncludeGlobs__0: Web/ForgeTrust.RazorWire/assets/contracts/razorwire-public-contracts.js
+        run: |
+          set -euo pipefail
+
+          evidence_path="releases/v${PACKAGE_VERSION}.evidence.json"
+          docs_exact_tree_path="$(jq -r '.docsArchive.exactTreePath // ""' "${evidence_path}")"
+          docs_release_manifest_sha256="$(jq -r '.docsArchive.releaseManifestSha256 // ""' "${evidence_path}")"
+          if [[ -z "${docs_exact_tree_path}" || -z "${docs_release_manifest_sha256}" ]]; then
+            echo "Stable release evidence must include docsArchive.exactTreePath and docsArchive.releaseManifestSha256 before NuGet publish." >&2
+            exit 1
+          fi
+
+          normalized_exact_tree_path="${docs_exact_tree_path#./}"
+          case "${normalized_exact_tree_path}" in
+            ""|/*|../*|*/../*|*"/.."|"."|".."|.*|*/.*|*//*)
+              echo "Stable docs exactTreePath '${docs_exact_tree_path}' must be a trusted-root-relative path with no parent, hidden, or empty segments." >&2
+              exit 1
+              ;;
+          esac
+
+          docs_release_root="${RUNNER_TEMP}/appsurface-stable-docs-${PACKAGE_VERSION}"
+          docs_exact_tree="${docs_release_root}/${normalized_exact_tree_path}"
+          mkdir -p "$(dirname "${docs_exact_tree}")"
+          printf '%s\n' '/' '/docs' > "${RUNNER_TEMP}/appsurface-docs-seeds.txt"
+
+          dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release -- \
+            docs export \
+            --repo . \
+            --mode cdn \
+            --seeds "${RUNNER_TEMP}/appsurface-docs-seeds.txt" \
+            --output "${docs_exact_tree}" \
+            --public-origin https://forge-trust.com \
+            --startup-timeout-seconds 30 \
+            --strict
+
+          jq -n \
+            --arg version "${PACKAGE_VERSION}" \
+            --arg exactTreePath "${docs_exact_tree_path}" \
+            --arg releaseManifestSha256 "${docs_release_manifest_sha256}" \
+            '{
+              recommendedVersion: $version,
+              versions: [
+                {
+                  version: $version,
+                  label: $version,
+                  summary: ("Stable AppSurface release " + $version),
+                  exactTreePath: $exactTreePath,
+                  releaseManifestSha256: $releaseManifestSha256,
+                  supportState: "Current",
+                  visibility: "Public",
+                  advisoryState: "None"
+                }
+              ]
+            }' > "${docs_release_root}/versions.json"
+
+          dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release -- \
+            docs verify-archive \
+            --catalog "${docs_release_root}/versions.json" \
+            --version "${PACKAGE_VERSION}" \
+            --trusted-release-root "${docs_release_root}"
+
+          ./eng/release check \
+            --version "${PACKAGE_VERSION}" \
+            --allow-existing-targets \
+            --fail-on-warnings \
+            --docs-catalog "${docs_release_root}/versions.json" \
+            --docs-trusted-release-root "${docs_release_root}"
+
+      - name: Upload stable docs proof diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: appsurface-stable-docs-proof-${{ needs.validate-tag.outputs.package-version }}
+          path: |
+            ${{ runner.temp }}/appsurface-stable-docs-${{ needs.validate-tag.outputs.package-version }}/versions.json
+            ${{ runner.temp }}/appsurface-stable-docs-${{ needs.validate-tag.outputs.package-version }}/**/.appsurface-docs-release-manifest.json
+            ${{ runner.temp }}/appsurface-stable-docs-${{ needs.validate-tag.outputs.package-version }}/**/.appsurface-docs-route-manifest.json
+          if-no-files-found: warn
+
   publish-nuget:
     needs:
       - validate-tag
       - validate-release-environment
       - pack-and-verify
+      - prove-docs-archive
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/nuget-stable-publish.yml
+++ b/.github/workflows/nuget-stable-publish.yml
@@ -231,6 +231,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.validate-tag.outputs.tag-commit }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup .NET SDK
@@ -269,7 +270,7 @@ jobs:
 
           normalized_exact_tree_path="${docs_exact_tree_path#./}"
           case "${normalized_exact_tree_path}" in
-            ""|/*|../*|*/../*|*"/.."|"."|".."|.*|*/.*|*//*)
+            ""|/*|../*|*/../*|*/..|"."|".."|.*|*/.*|*//*)
               echo "Stable docs exactTreePath '${docs_exact_tree_path}' must be a trusted-root-relative path with no parent, hidden, or empty segments." >&2
               exit 1
               ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ This changelog is the compact release ledger for AppSurface. The monorepo ships 
 - Authoring workflow: [Release authoring checklist](./releases/release-authoring-checklist.md)
 - Stable package release publishing now requires AppSurface Docs archive evidence that has been verified, so release authors can prove
   the public docs catalog, exact tree, release manifest, and serveable files match before GitHub Releases receive a
-  stable package.
+  stable package. The protected stable NuGet workflow also replays that docs export and archive verification before it requests
+  the NuGet trusted publishing token.
 - RazorWire now renders passive AppSurface auth-result UI states with `rw:auth-view`, gate, login-link, and logout-button helpers, plus an ASP.NET Core adapter package that delegates to host-owned AppSurface policy evaluation.
 - AppSurface LocalSecrets startup failures before platform commands run now report `local-secret-store-unavailable` with exception type, `HResult`, and synthetic exit code only; run `appsurface secrets doctor` for the same namespace to diagnose missing tools or headless sessions without leaking raw OS exception messages.
 - `ForgeTrust.AppSurface.Web` now owns first-class PWA install metadata: enable `WebOptions.Pwa` to serve a manifest, emit Razor head metadata, expose development diagnostics, and opt into a starter offline fallback, then prove the running app with `appsurface pwa verify`.

--- a/releases/release-authoring-checklist.md
+++ b/releases/release-authoring-checklist.md
@@ -9,6 +9,7 @@ Use this checklist when turning the living unreleased story into a tagged AppSur
 - regroup the story so the opening narrative explains what changed and why it matters
 - confirm every breaking or behavior-changing update has migration guidance
 - for stable releases, stage the AppSurface Docs exact archive and run `appsurface docs verify-archive --catalog <staging>/versions.json --version x.y.z --trusted-release-root <staging>` before asking the release tool to validate docs evidence
+- for stable releases, confirm the checked-in evidence fields describe the same staged docs archive that `nuget-stable-publish.yml` will export and verify before `publish-nuget`
 - use `./eng/release prepare --version x.y.z --dry-run` to inspect the generated tagged note, sidecar, release manifest, release evidence bundle, changelog rollover, package release-note path updates, and reset unreleased artifact before opening the release PR
 
 ## When cutting the tagged release note
@@ -27,6 +28,7 @@ Use this checklist when turning the living unreleased story into a tagged AppSur
 
 - create the annotated tag from the maintainer-reviewed merge commit outside the release tool; v1 never creates tags automatically
 - wait for the protected NuGet workflow for the tag classification to finish first: `nuget-prerelease-publish.yml` for prerelease tags, `nuget-stable-publish.yml` for stable tags
+- for stable tags, treat the workflow's `appsurface-stable-docs-proof-x.y.z` artifact as the pre-NuGet docs proof: it contains the staged catalog plus archive manifests verified before the trusted publishing token was requested
 - run `./eng/release publish --version x.y.z --tag vx.y.z --base-ref <release-base> --dry-run` before the publish workflow creates the GitHub Release; publish validation checks the release evidence bundle and protected package publish proof at the annotated tag commit, not the local worktree
 - for stable releases, include `--docs-catalog <staging>/versions.json --docs-trusted-release-root <staging>` when running publish validation or the workflow dispatch; publish does not use the local `dist/docs/versions.json` fallback
 - keep stable releases blocked until `nuget-stable` publish and `nuget-stable-smoke` install proof exists; `v0.1.0` must not become a GitHub-only release

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -32,7 +32,9 @@ This is the living release note for the next coordinated AppSurface version afte
 - Stable package release publishing now gates on verified AppSurface Docs archive evidence. Release authors pass the
   staged docs `versions.json` and trusted archive root into `appsurface-release check` or `publish`; the tool verifies the
   selected public catalog entry, exact tree path, pinned release-manifest digest, route manifest safety, and every
-  serveable file before stable GitHub Release publishing can continue.
+  serveable file before stable GitHub Release publishing can continue. The protected stable NuGet workflow now repeats the
+  export and archive verification against the checked-in release evidence before it can request the NuGet trusted publishing
+  token.
 - AppSurface Auth now has a Start Here adoption ladder that helps package consumers choose between host-owned
   ASP.NET Core auth, Auth core, Auth.AspNetCore, DevAuth, OIDC, Auth.Testing, and RazorWire-facing proof surfaces
   without implying AppSurface owns production identity providers, policies, user stores, or enforcement.

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -87,16 +87,21 @@ public sealed class ReleaseWorkflowPolicyTests
         Assert.Contains("Required for NuGet trusted publishing to request an OIDC token.", workflow, StringComparison.Ordinal);
         Assert.Contains("persist-credentials: false", workflow, StringComparison.Ordinal);
         Assert.Contains("prove-docs-archive:", workflow, StringComparison.Ordinal);
+        var proveDocsArchiveIndex = workflow.IndexOf("prove-docs-archive:", StringComparison.Ordinal);
+        var publishNugetIndex = workflow.IndexOf("publish-nuget:", StringComparison.Ordinal);
+        Assert.True(proveDocsArchiveIndex >= 0, "Stable docs proof job must be declared.");
+        Assert.True(publishNugetIndex > proveDocsArchiveIndex, "Stable docs proof must be declared before the irreversible publish-nuget job.");
+        var proveDocsArchiveJob = workflow[proveDocsArchiveIndex..publishNugetIndex];
+        Assert.Contains("fetch-depth: 0", proveDocsArchiveJob, StringComparison.Ordinal);
         Assert.Contains("Export and verify stable docs archive before NuGet publish", workflow, StringComparison.Ordinal);
         Assert.Contains("docs export", workflow, StringComparison.Ordinal);
         Assert.Contains("docs verify-archive", workflow, StringComparison.Ordinal);
         Assert.Contains("appsurface-stable-docs-proof", workflow, StringComparison.Ordinal);
         Assert.Contains("--docs-catalog \"${docs_release_root}/versions.json\"", workflow, StringComparison.Ordinal);
         Assert.Contains("--docs-trusted-release-root \"${docs_release_root}\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("\"\"|/*|../*|*/../*|*/..|\".\"|\"..\"|.*|*/.*|*//*)", proveDocsArchiveJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("*\"/..\"", proveDocsArchiveJob, StringComparison.Ordinal);
         Assert.Contains("- prove-docs-archive", workflow, StringComparison.Ordinal);
-        Assert.True(
-            workflow.IndexOf("prove-docs-archive:", StringComparison.Ordinal) < workflow.IndexOf("publish-nuget:", StringComparison.Ordinal),
-            "Stable docs proof must be declared before the irreversible publish-nuget job.");
         Assert.Contains("NuGet/login", workflow, StringComparison.Ordinal);
         Assert.Contains("publish-stable", workflow, StringComparison.Ordinal);
         Assert.Contains("appsurface-stable-packages", workflow, StringComparison.Ordinal);

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -86,6 +86,17 @@ public sealed class ReleaseWorkflowPolicyTests
         Assert.Contains("Required so gh run list can verify source CI for the tag commit.", workflow, StringComparison.Ordinal);
         Assert.Contains("Required for NuGet trusted publishing to request an OIDC token.", workflow, StringComparison.Ordinal);
         Assert.Contains("persist-credentials: false", workflow, StringComparison.Ordinal);
+        Assert.Contains("prove-docs-archive:", workflow, StringComparison.Ordinal);
+        Assert.Contains("Export and verify stable docs archive before NuGet publish", workflow, StringComparison.Ordinal);
+        Assert.Contains("docs export", workflow, StringComparison.Ordinal);
+        Assert.Contains("docs verify-archive", workflow, StringComparison.Ordinal);
+        Assert.Contains("appsurface-stable-docs-proof", workflow, StringComparison.Ordinal);
+        Assert.Contains("--docs-catalog \"${docs_release_root}/versions.json\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("--docs-trusted-release-root \"${docs_release_root}\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("- prove-docs-archive", workflow, StringComparison.Ordinal);
+        Assert.True(
+            workflow.IndexOf("prove-docs-archive:", StringComparison.Ordinal) < workflow.IndexOf("publish-nuget:", StringComparison.Ordinal),
+            "Stable docs proof must be declared before the irreversible publish-nuget job.");
         Assert.Contains("NuGet/login", workflow, StringComparison.Ordinal);
         Assert.Contains("publish-stable", workflow, StringComparison.Ordinal);
         Assert.Contains("appsurface-stable-packages", workflow, StringComparison.Ordinal);

--- a/tools/ForgeTrust.AppSurface.Release/README.md
+++ b/tools/ForgeTrust.AppSurface.Release/README.md
@@ -78,6 +78,8 @@ appsurface docs verify-archive --catalog ./dist/docs/versions.json --version 0.1
 
 `appsurface docs verify-archive` checks the same catalog-pinned exact tree used by runtime docs mounting. The release tool adds the release-specific gate: the selected stable catalog entry must be unique, public, available, pinned with `releaseManifestSha256`, equal to the release evidence docs fields, safely relative to the trusted release root, and byte-verified against `.appsurface-docs-release-manifest.json`. The release readiness report prints the authored catalog exact tree path and manifest digest separately from the resolved physical exact tree, catalog path, trusted root, verification state, and verified file count.
 
+The protected `nuget-stable-publish.yml` workflow repeats the stable docs proof before the irreversible NuGet publish job. It checks out the annotated tag commit, exports AppSurface Docs into the `docsArchive.exactTreePath` recorded by `releases/v{version}.evidence.json`, stages a minimal `versions.json` with the recorded `releaseManifestSha256`, runs `appsurface docs verify-archive`, and then runs `./eng/release check` with the staged catalog and trusted root. If export output, catalog fields, or release evidence disagree, the workflow stops before requesting the NuGet trusted publishing token. The later GitHub Release workflow still runs `./eng/release publish` with its own staged docs inputs before creating the public release.
+
 Repair loops are intentionally concrete:
 
 - `release-evidence-docs-archive-required`: regenerate stable release evidence from a completed docs export and catalog entry.
@@ -89,7 +91,7 @@ Repair loops are intentionally concrete:
 
 ## Stable Release Policy
 
-Stable GitHub Releases require the protected `nuget-stable-publish.yml` path. The workflow validates annotated `vX.Y.Z` tags, checks the configured release base branch, publishes through the `nuget-stable` environment, waits through `nuget-stable-smoke`, and uploads publish and smoke evidence. The release cockpit verifies a successful stable workflow run for the exact tag commit before creating the GitHub Release. Prerelease publishing remains on `nuget-prerelease-publish.yml` and the `nuget-prerelease` environments.
+Stable GitHub Releases require the protected `nuget-stable-publish.yml` path. The workflow validates annotated `vX.Y.Z` tags, checks the configured release base branch, proves stable docs archive evidence before NuGet publication, publishes through the `nuget-stable` environment, waits through `nuget-stable-smoke`, and uploads docs proof, publish, and smoke evidence. The release cockpit verifies a successful stable workflow run for the exact tag commit before creating the GitHub Release. Prerelease publishing remains on `nuget-prerelease-publish.yml` and the `nuget-prerelease` environments.
 
 ## Diagnostics
 


### PR DESCRIPTION
## Summary

- add a `prove-docs-archive` job to the stable NuGet publish workflow before `publish-nuget`
- export AppSurface Docs at the annotated tag commit, rebuild a catalog from checked-in release evidence, run `appsurface docs verify-archive`, and replay `./eng/release check` before the NuGet trusted publishing token is requested
- update release policy tests, changelog, unreleased notes, release tool docs, and the release authoring checklist

Refs #175

## Test Coverage

- `dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj --no-restore` passed: 245 tests
- `dotnet test tools/ForgeTrust.AppSurface.PackageIndex.Tests/ForgeTrust.AppSurface.PackageIndex.Tests.csproj --no-restore` passed: 317 tests
- `dotnet format tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj --verify-no-changes --no-restore` passed
- `git diff --check` passed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nuget-stable-publish.yml"); puts "ok"'` passed

## Pre-Landing Review

Read-through found no blocking issues in the final diff. The policy test now pins the docs proof job, the export/verify commands, the diagnostics artifact, and the required ordering before `publish-nuget`.

## Design Review

No frontend or visual product surface changed.

## Eval Results

No prompt, model, or evaluation surface changed.

## Scope Drift

Scoped to the #175 pre-NuGet release-docs proof lane. Remaining #175 release-docs lifecycle work, if any, stays tracked outside this PR.
