### PR TITLE
ci: target stable publish at release 0.1.0

### DIFF
--- a/.github/workflows/nuget-stable-publish.yml
+++ b/.github/workflows/nuget-stable-publish.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  STABLE_BASE_REF: main
+  STABLE_BASE_REF: release/0.1.0
 
 jobs:
   validate-tag:

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -156,7 +156,7 @@ public sealed class ReleaseWorkflowPolicyTests
         Assert.DoesNotContain("pull_request", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("workflow_dispatch", workflow, StringComparison.Ordinal);
         Assert.Contains("tag_pattern='^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'", workflow, StringComparison.Ordinal);
-        Assert.Contains("STABLE_BASE_REF: main", workflow, StringComparison.Ordinal);
+        Assert.Contains("STABLE_BASE_REF: release/0.1.0", workflow, StringComparison.Ordinal);
         Assert.Contains("origin/${STABLE_BASE_REF}", workflow, StringComparison.Ordinal);
         Assert.Contains("--branch \"${STABLE_BASE_REF}\"", workflow, StringComparison.Ordinal);
         Assert.Contains("nuget-stable", workflow, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- Points the stable NuGet publish workflow at `release/0.1.0` for the 0.1.0 stable tag.
- Updates the release workflow policy test to pin that release-branch base.

## Why

The 0.1.0 release train is cutting the stable tag from `release/0.1.0`, not `main`. Without this, `nuget-stable-publish.yml` rejects the annotated `v0.1.0` tag because the tag commit is not reachable from `origin/main`.

## Validation

- `dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj --filter StableNuGetPublishWorkflowUsesStablePolicy`
- `git diff --check`
