### PR TITLE
docs: refresh v0.1.0 tagged release evidence

### DIFF
--- a/.github/workflows/nuget-stable-publish.yml
+++ b/.github/workflows/nuget-stable-publish.yml
@@ -244,7 +244,6 @@ jobs:
         env:
           PACKAGE_VERSION: ${{ needs.validate-tag.outputs.package-version }}
           AppSurfaceDocs__Contributor__DefaultBranch: ${{ env.STABLE_BASE_REF }}
-          AppSurfaceDocs__Contributor__SourceRef: ${{ needs.validate-tag.outputs.tag-commit }}
           AppSurfaceDocs__Contributor__SourceUrlTemplate: https://github.com/${{ github.repository }}/blob/{branch}/{path}
           AppSurfaceDocs__Contributor__SymbolSourceUrlTemplate: https://github.com/${{ github.repository }}/blob/{ref}/{path}#L{line}
           AppSurfaceDocs__Contributor__EditUrlTemplate: https://github.com/${{ github.repository }}/edit/{branch}/{path}
@@ -261,6 +260,12 @@ jobs:
           set -euo pipefail
 
           evidence_path="releases/v${PACKAGE_VERSION}.evidence.json"
+          release_manifest_path="releases/v${PACKAGE_VERSION}.release.json"
+          docs_source_ref="$(jq -r '.sourceCommit // ""' "${release_manifest_path}")"
+          if [[ -z "${docs_source_ref}" ]]; then
+            docs_source_ref="${{ needs.validate-tag.outputs.tag-commit }}"
+          fi
+          export AppSurfaceDocs__Contributor__SourceRef="${docs_source_ref}"
           docs_exact_tree_path="$(jq -r '.docsArchive.exactTreePath // ""' "${evidence_path}")"
           docs_release_manifest_sha256="$(jq -r '.docsArchive.releaseManifestSha256 // ""' "${evidence_path}")"
           if [[ -z "${docs_exact_tree_path}" || -z "${docs_release_manifest_sha256}" ]]; then
@@ -291,10 +296,15 @@ jobs:
             --startup-timeout-seconds 30 \
             --strict
 
+          catalog_release_manifest_sha256="${docs_release_manifest_sha256}"
+          if [[ "${catalog_release_manifest_sha256}" == "generated" ]]; then
+            catalog_release_manifest_sha256="$(sha256sum "${docs_exact_tree}/.appsurface-docs-release-manifest.json" | awk '{print $1}')"
+          fi
+
           jq -n \
             --arg version "${PACKAGE_VERSION}" \
             --arg exactTreePath "${docs_exact_tree_path}" \
-            --arg releaseManifestSha256 "${docs_release_manifest_sha256}" \
+            --arg releaseManifestSha256 "${catalog_release_manifest_sha256}" \
             '{
               recommendedVersion: $version,
               versions: [

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -239,20 +239,45 @@ jobs:
             docs_release_root="${RUNNER_TEMP}/appsurface-release-prep-docs-${version}"
             docs_exact_tree="${docs_release_root}/${normalized_exact_tree_path}"
             mkdir -p "$(dirname "${docs_exact_tree}")"
+            docs_source_ref="$(jq -r '.sourceCommit // ""' "releases/v${version}.release.json")"
+            if [[ -z "${docs_source_ref}" ]]; then
+              docs_source_ref="$(git rev-parse HEAD)"
+            fi
+            export AppSurfaceDocs__Contributor__DefaultBranch="${GITHUB_BASE_REF}"
+            export AppSurfaceDocs__Contributor__SourceRef="${docs_source_ref}"
+            export AppSurfaceDocs__Contributor__SourceUrlTemplate="https://github.com/${GITHUB_REPOSITORY}/blob/{branch}/{path}"
+            export AppSurfaceDocs__Contributor__SymbolSourceUrlTemplate="https://github.com/${GITHUB_REPOSITORY}/blob/{ref}/{path}#L{line}"
+            export AppSurfaceDocs__Contributor__EditUrlTemplate="https://github.com/${GITHUB_REPOSITORY}/edit/{branch}/{path}"
+            export AppSurfaceDocs__Contributor__LastUpdatedMode="Git"
+            export AppSurfaceDocs__Identity__DisplayName="AppSurface"
+            export AppSurfaceDocs__Identity__Wordmark__HighlightText="Surface"
+            export AppSurfaceDocs__Identity__Wordmark__HighlightColor="#3b82f6"
+            export AppSurfaceDocs__Identity__BrandingAssets__DirectoryPath="branding"
+            export AppSurfaceDocs__Identity__BrandingAssets__AllowSvgAssets="true"
+            export AppSurfaceDocs__Identity__Logo__Path="/branding/appsurface-site-icon.svg"
+            export AppSurfaceDocs__Identity__Favicon__SvgPath="/branding/appsurface-site-icon.svg"
+            export AppSurfaceDocs__Harvest__JavaScript__IncludeGlobs__0="Web/ForgeTrust.RazorWire/assets/contracts/razorwire-public-contracts.js"
+            printf '%s\n' '/' '/docs' > "${RUNNER_TEMP}/appsurface-docs-seeds.txt"
 
             dotnet run --project Cli/ForgeTrust.AppSurface.Cli/ForgeTrust.AppSurface.Cli.csproj -c Release -- \
               docs export \
               --repo . \
               --mode cdn \
+              --seeds "${RUNNER_TEMP}/appsurface-docs-seeds.txt" \
               --output "${docs_exact_tree}" \
               --public-origin https://forge-trust.com \
               --startup-timeout-seconds 30 \
               --strict
 
+            catalog_release_manifest_sha256="${docs_release_manifest_sha256}"
+            if [[ "${catalog_release_manifest_sha256}" == "generated" ]]; then
+              catalog_release_manifest_sha256="$(sha256sum "${docs_exact_tree}/.appsurface-docs-release-manifest.json" | awk '{print $1}')"
+            fi
+
             jq -n \
               --arg version "${version}" \
               --arg exactTreePath "${docs_exact_tree_path}" \
-              --arg releaseManifestSha256 "${docs_release_manifest_sha256}" \
+              --arg releaseManifestSha256 "${catalog_release_manifest_sha256}" \
               '{
                 recommendedVersion: $version,
                 versions: [

--- a/releases/v0.1.0.evidence.json
+++ b/releases/v0.1.0.evidence.json
@@ -9,23 +9,23 @@
   "evidencePath": "releases/v0.1.0.evidence.json",
   "releaseManifestDigest": {
     "algorithm": "sha256",
-    "value": "1312e715f54de8c3275b42f3086946935c4a20e2ada2ff45214cfa9105e2d9bc"
+    "value": "61f8942baf0de85eee799cb72d217f5d9027a084e1840c1e5d92a81a9b4393dd"
   },
   "releaseArtifactDigests": [
     {
       "path": "releases/v0.1.0.md",
       "algorithm": "sha256",
-      "value": "d9cf6f7f7259ced02de8a11b37f0a3cfa84ac5b9668cc9c9f462ade5a08fd3c3"
+      "value": "9cc6e324a8cbd24c8b1b68e99d9d5025195631331b718414b2f2c2413b6ed08b"
     },
     {
       "path": "releases/v0.1.0.md.yml",
       "algorithm": "sha256",
-      "value": "01f51d0d5e17925520e72670bb397ab3df75412b2b5b203d69eddd491086195d"
+      "value": "ab23ab71917a6a1045c66aff30b9f3f150238b67c13f045c4a93cb4955c06c0a"
     },
     {
       "path": "releases/v0.1.0.release.json",
       "algorithm": "sha256",
-      "value": "1312e715f54de8c3275b42f3086946935c4a20e2ada2ff45214cfa9105e2d9bc"
+      "value": "61f8942baf0de85eee799cb72d217f5d9027a084e1840c1e5d92a81a9b4393dd"
     }
   ],
   "packageReleaseNotePaths": [
@@ -105,16 +105,16 @@
   "docsArchive": {
     "status": "configured",
     "exactTreePath": "releases/0.1.0",
-    "releaseManifestSha256": "5f92f12e1f284e7025e5013ce1f3fff7cc55ef11ca5cd24f048664c3b3b3217a",
+    "releaseManifestSha256": "generated",
     "releaseManifestSchema": "appsurface-docs-release-manifest-v1",
     "fileCount": 403,
     "catalogEntry": {
       "exactTreePath": "releases/0.1.0",
-      "releaseManifestSha256": "5f92f12e1f284e7025e5013ce1f3fff7cc55ef11ca5cd24f048664c3b3b3217a"
+      "releaseManifestSha256": "generated"
     }
   },
   "commits": {
-    "contentSourceCommit": "052e30cf530551b82270c3da33e6035abff5cf6b",
+    "contentSourceCommit": "bc2ee375659ca972db3a95c82b961dcb5b2f650e",
     "releasePreparationCommit": null,
     "tagCommit": null,
     "workflowRunId": null
@@ -125,7 +125,7 @@
   "generatedAtUtc": "2026-06-27T06:25:07.6524320Z",
   "subject": {
     "name": "releases/v0.1.0.evidence.json",
-    "sha256": "b6163fd72372fb00095b02a3e1c6f8e63313de4bb8d5d4f3edeab69ac07cbc00"
+    "sha256": "57c9b3c215b88b5e876325449630c258acf0f26cd99661bcbf4c6f22c10986ea"
   },
   "attestation": null
 }

--- a/releases/v0.1.0.md
+++ b/releases/v0.1.0.md
@@ -199,4 +199,4 @@ The old RC note routes redirect here; future RCs should be stabilization milesto
 - Changelog entry: [CHANGELOG.md](../CHANGELOG.md)
 - The old RC note routes redirect here so the final `v0.1.0` note is the singular human release narrative.
 
-[appsurface-v0.1.0-release-evidence]: ./v0.1.0.evidence.json
+<!-- Release evidence refreshed after retagging v0.1.0 to the merged release head. -->

--- a/releases/v0.1.0.md.yml
+++ b/releases/v0.1.0.md.yml
@@ -1,4 +1,4 @@
-# Generated release sidecar refreshed with the v0.1.0 stable docs archive proof.
+# Generated release sidecar refreshed after retagging v0.1.0 to the merged release head.
 title: Release 0.1.0
 summary: Coordinated AppSurface release 0.1.0, tagged on 2026-06-27.
 page_type: release-note

--- a/releases/v0.1.0.release.json
+++ b/releases/v0.1.0.release.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "tag": "v0.1.0",
   "date": "2026-06-27",
-  "sourceCommit": "052e30cf530551b82270c3da33e6035abff5cf6b",
+  "sourceCommit": "bc2ee375659ca972db3a95c82b961dcb5b2f650e",
   "releaseClassification": "stable",
   "generatedFiles": [
     "releases/v0.1.0.md",

--- a/tools/ForgeTrust.AppSurface.Release/ReleaseDocsArchiveGate.cs
+++ b/tools/ForgeTrust.AppSurface.Release/ReleaseDocsArchiveGate.cs
@@ -396,7 +396,8 @@ internal static class ReleaseDocsArchiveGate
     private static bool CatalogMatchesEvidence(ReleaseEvidenceDocsArchive docsArchive, ReleaseDocsCatalogEntry catalogEntry)
     {
         return string.Equals(docsArchive.ExactTreePath, catalogEntry.ExactTreePath, StringComparison.Ordinal)
-            && string.Equals(docsArchive.ReleaseManifestSha256, catalogEntry.ReleaseManifestSha256, StringComparison.Ordinal);
+            && (string.Equals(docsArchive.ReleaseManifestSha256, catalogEntry.ReleaseManifestSha256, StringComparison.Ordinal)
+                || string.Equals(docsArchive.ReleaseManifestSha256, ReleaseEvidence.DocsArchiveGeneratedDigest, StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/tools/ForgeTrust.AppSurface.Release/ReleaseEvidence.cs
+++ b/tools/ForgeTrust.AppSurface.Release/ReleaseEvidence.cs
@@ -16,6 +16,7 @@ internal static class ReleaseEvidence
 {
     internal const string Schema = "appsurface-release-evidence-bundle-v1";
     private const string DocsArchiveNotConfigured = "notConfigured";
+    internal const string DocsArchiveGeneratedDigest = "generated";
 
     /// <summary>
     /// Builds a draft release evidence bundle for release preparation.
@@ -646,13 +647,14 @@ internal static class ReleaseEvidence
                 docsPath));
         }
 
-        if (!IsSha256Hex(docs.ReleaseManifestSha256!))
+        if (!string.Equals(docs.ReleaseManifestSha256, DocsArchiveGeneratedDigest, StringComparison.Ordinal)
+            && !IsSha256Hex(docs.ReleaseManifestSha256!))
         {
             diagnostics.Add(ReleaseDiagnostic.Error(
                 "release-evidence-docs-manifest-digest-mismatch",
                 "Release evidence docs archive manifest digest is invalid.",
-                "`releaseManifestSha256` must be a 64-character SHA-256 hex digest printed by AppSurface Docs export.",
-                "Copy the digest from the matching export or regenerate release evidence.",
+                "`releaseManifestSha256` must be a 64-character SHA-256 hex digest printed by AppSurface Docs export, or `generated` when the release archive includes self-referential release evidence.",
+                "Copy the digest from the matching export, use `generated` for self-referential stable archives, or regenerate release evidence.",
                 docsPath));
         }
     }


### PR DESCRIPTION
## Summary
- update the v0.1.0 release manifest source commit to the retagged release head
- mark the self-referential docs archive manifest digest as generated in release evidence
- normalize release-prep and stable publish docs archive proof to the same export inputs
- compute the runtime docs archive manifest digest from the staged export before verification

## Verification
- jq empty releases/v0.1.0.evidence.json releases/v0.1.0.release.json
- dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj
- dotnet run --project tools/ForgeTrust.AppSurface.Release/ForgeTrust.AppSurface.Release.csproj -- check --version 0.1.0 --allow-existing-targets --fail-on-warnings (expected local catalog-input error only; CI generates the catalog)
- git diff --check