### PR TITLE
fix: accept generated docs evidence digest

### DIFF
--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseToolTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseToolTests.cs
@@ -1404,6 +1404,24 @@ public sealed class ReleaseToolTests : IDisposable
     }
 
     [Fact]
+    public async Task PublishAllowsStableReleaseWithGeneratedDocsManifestDigestBeforeDocsPublicationPlanExists()
+    {
+        await SeedRepositoryAsync();
+        var docs = (await SeedDocsArchiveAsync("0.1.0")) with
+        {
+            ReleaseManifestSha256 = ReleaseEvidence.DocsArchiveGeneratedDigest
+        };
+        var runner = CreateSuccessfulStablePublishRunner(docs: docs);
+
+        var result = await RunAsync(
+            ["publish", "--version", "0.1.0", "--tag", "v0.1.0", "--dry-run"],
+            runner);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains($"\"docsReleaseManifestSha256\": \"{ReleaseEvidence.DocsArchiveGeneratedDigest}\"", result.Stdout, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PublishRejectsStableReleaseWithoutDocsArchiveEvidence()
     {
         await SeedRepositoryAsync();
@@ -3433,6 +3451,23 @@ public sealed class ReleaseToolTests : IDisposable
     }
 
     [Fact]
+    public async Task PublishRejectsPrereleaseWithGeneratedDocsManifestDigest()
+    {
+        await SeedRepositoryAsync();
+        var docs = (await SeedDocsArchiveAsync("0.1.0-preview.1")) with
+        {
+            ReleaseManifestSha256 = ReleaseEvidence.DocsArchiveGeneratedDigest
+        };
+
+        var result = await RunAsync(
+            ["publish", "--version", "0.1.0-preview.1", "--tag", "v0.1.0-preview.1", "--dry-run"],
+            CreateSuccessfulPublishRunner(docs));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Code: release-evidence-docs-manifest-digest-mismatch", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PublishEmitsStructuredOutputsForAnnotatedPrereleaseTag()
     {
         await SeedRepositoryAsync();
@@ -5010,7 +5045,7 @@ public sealed class ReleaseToolTests : IDisposable
             TimeSpan.FromMilliseconds(50));
     }
 
-    private static FakeCommandRunner CreateSuccessfulPublishRunner()
+    private static FakeCommandRunner CreateSuccessfulPublishRunner(DocsArchiveFixture? docs = null)
     {
         var runner = new FakeCommandRunner();
         var releaseManifest = CreateReleaseManifestJson();
@@ -5022,7 +5057,17 @@ public sealed class ReleaseToolTests : IDisposable
         runner.Add("git show v0.1.0-preview.1:releases/v0.1.0-preview.1.md", new CommandResult(0, TaggedReleaseNoteContent, ""));
         runner.Add("git show v0.1.0-preview.1:releases/v0.1.0-preview.1.md.yml", new CommandResult(0, TaggedReleaseSidecarContent, ""));
         runner.Add("git show v0.1.0-preview.1:releases/v0.1.0-preview.1.release.json", new CommandResult(0, releaseManifest, ""));
-        runner.Add("git show v0.1.0-preview.1:releases/v0.1.0-preview.1.evidence.json", new CommandResult(0, CreateReleaseEvidenceJson(releaseManifest), ""));
+        runner.Add(
+            "git show v0.1.0-preview.1:releases/v0.1.0-preview.1.evidence.json",
+            new CommandResult(
+                0,
+                CreateReleaseEvidenceJson(
+                    releaseManifest,
+                    "0.1.0-preview.1",
+                    docs?.ExactTreePath,
+                    docs?.ReleaseManifestSha256,
+                    docs?.FileCount),
+                ""));
         return runner;
     }
 

--- a/tools/ForgeTrust.AppSurface.Release/ReleaseEvidence.cs
+++ b/tools/ForgeTrust.AppSurface.Release/ReleaseEvidence.cs
@@ -16,6 +16,7 @@ internal static class ReleaseEvidence
 {
     internal const string Schema = "appsurface-release-evidence-bundle-v1";
     private const string DocsArchiveNotConfigured = "notConfigured";
+    internal const string DocsArchiveGeneratedDigest = "generated";
 
     /// <summary>
     /// Builds a draft release evidence bundle for release preparation.
@@ -582,6 +583,7 @@ internal static class ReleaseEvidence
         List<ReleaseDiagnostic> diagnostics,
         string docsPath)
     {
+        var isStableRelease = string.Equals(releaseClassification, "stable", StringComparison.Ordinal);
         var docs = bundle.DocsArchive;
         if (docs.CatalogEntry is not null
             && (!string.Equals(docs.CatalogEntry.ExactTreePath, docs.ExactTreePath, StringComparison.Ordinal)
@@ -599,7 +601,7 @@ internal static class ReleaseEvidence
             && string.IsNullOrWhiteSpace(docs.ExactTreePath)
             && string.IsNullOrWhiteSpace(docs.ReleaseManifestSha256))
         {
-            if (string.Equals(releaseClassification, "stable", StringComparison.Ordinal))
+            if (isStableRelease)
             {
                 diagnostics.Add(ReleaseDiagnostic.Error(
                     "release-evidence-docs-archive-required",
@@ -612,8 +614,7 @@ internal static class ReleaseEvidence
             return;
         }
 
-        if (string.Equals(releaseClassification, "stable", StringComparison.Ordinal)
-            && docs.CatalogEntry is null)
+        if (isStableRelease && docs.CatalogEntry is null)
         {
             diagnostics.Add(ReleaseDiagnostic.Error(
                 "release-evidence-docs-archive-incomplete",
@@ -646,13 +647,15 @@ internal static class ReleaseEvidence
                 docsPath));
         }
 
-        if (!IsSha256Hex(docs.ReleaseManifestSha256!))
+        var isGeneratedDigest = string.Equals(docs.ReleaseManifestSha256, DocsArchiveGeneratedDigest, StringComparison.Ordinal);
+        if (!(isStableRelease && isGeneratedDigest)
+            && !IsSha256Hex(docs.ReleaseManifestSha256!))
         {
             diagnostics.Add(ReleaseDiagnostic.Error(
                 "release-evidence-docs-manifest-digest-mismatch",
                 "Release evidence docs archive manifest digest is invalid.",
-                "`releaseManifestSha256` must be a 64-character SHA-256 hex digest printed by AppSurface Docs export.",
-                "Copy the digest from the matching export or regenerate release evidence.",
+                "`releaseManifestSha256` must be a 64-character SHA-256 hex digest printed by AppSurface Docs export, or `generated` when the release archive includes self-referential release evidence.",
+                "Copy the digest from the matching export, use `generated` for self-referential stable archives, or regenerate release evidence.",
                 docsPath));
         }
     }


### PR DESCRIPTION
## Summary
- allow stable docs evidence to use the `generated` release-manifest digest sentinel during tag-bound publish validation
- keep invalid digest diagnostics for all non-sentinel values
- add a publish dry-run regression test for the release-publish validation path

## Verification
- `dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj -c Release --no-restore`
- `git diff --check`
- `dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes --no-restore`

## Release note
This unblocks running the v0.1.0 GitHub Release workflow from `main` while validating tag-bound release evidence from `release/0.1.0`.