### PR TITLE
fix: publish hidden docs manifest to pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,6 +321,7 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ${{ runner.temp }}/appsurface-docs-pages
+          include-hidden-files: true
 
   deploy-appsurface-docs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -313,6 +313,7 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ${{ steps.docs.outputs.pages_staging_root }}
+          include-hidden-files: true
 
   deploy-docs-pages:
     if: ${{ github.repository == 'forge-trust/AppSurface' }}

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -100,6 +100,7 @@ public sealed class ReleaseWorkflowPolicyTests
         Assert.Contains("gh release edit \"${TAG}\" --title \"${TITLE}\" --notes-file \"${notes_file}\"", publish, StringComparison.Ordinal);
         Assert.Contains("gh release upload \"${TAG}\" \"${ARCHIVE_PATH}\" \"${SHA256_PATH}\" --clobber", publish, StringComparison.Ordinal);
         Assert.Contains("actions/upload-pages-artifact", publish, StringComparison.Ordinal);
+        Assert.Contains("include-hidden-files: true", publish, StringComparison.Ordinal);
         Assert.Contains("actions/deploy-pages", publish, StringComparison.Ordinal);
         Assert.Contains("curl -fsSL \"${root}/versions.json\"", publish, StringComparison.Ordinal);
         Assert.Contains("PROMOTE_RECOMMENDED: ${{ inputs.promote-recommended }}", publish, StringComparison.Ordinal);
@@ -190,6 +191,7 @@ public sealed class ReleaseWorkflowPolicyTests
         var uploadIndex = workflow.IndexOf("Upload Pages artifact", StringComparison.Ordinal);
         Assert.True(hydrateIndex >= 0, "Main docs deploy must hydrate published release docs archives.");
         Assert.True(uploadIndex > hydrateIndex, "Release archive hydration must happen before Pages artifact upload.");
+        Assert.Contains("include-hidden-files: true", workflow, StringComparison.Ordinal);
         Assert.Contains("gh api --paginate \"repos/${GITHUB_REPOSITORY}/releases\"", workflow, StringComparison.Ordinal);
         Assert.Contains("select(.draft | not)", workflow, StringComparison.Ordinal);
         Assert.Contains("mapfile -t release_rows", workflow, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- include hidden files in the release publish Pages artifact so the exact-tree docs manifest is deployed
- pin the release workflow policy test to require that upload behavior

## Verification
- dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj -c Release --no-restore --filter ReleaseWorkflowPolicyTests
- git diff --check