### PR TITLE
fix: verify release assets without checkout

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -393,7 +393,7 @@ jobs:
             echo "Expected manifest ${EXPECTED_MANIFEST_SHA256}; got ${actual_manifest_sha256}." >&2
             exit 1
           fi
-          gh release download "${TAG}" --pattern "${ARCHIVE_ASSET_NAME}" --dir "${asset_dir}" --clobber
+          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --pattern "${ARCHIVE_ASSET_NAME}" --dir "${asset_dir}" --clobber
           actual_archive_sha256="$(sha256sum "${asset_dir}/${ARCHIVE_ASSET_NAME}" | awk '{print $1}')"
           if [[ "${actual_archive_sha256}" != "${EXPECTED_ARCHIVE_SHA256}" ]]; then
             echo "Expected archive ${EXPECTED_ARCHIVE_SHA256}; got ${actual_archive_sha256}." >&2
@@ -407,9 +407,9 @@ jobs:
             echo "- Release manifest SHA-256: ${EXPECTED_MANIFEST_SHA256}"
             echo "- Release asset: ${ARCHIVE_ASSET_NAME}"
             echo "- Archive SHA-256: ${EXPECTED_ARCHIVE_SHA256}"
-            echo "- Resume draft: \`gh release view ${TAG} --json isDraft,url\`"
-            echo "- Publish draft: \`gh release edit ${TAG} --draft=false\`"
-            echo "- Abort draft: \`gh release delete ${TAG} --cleanup-tag=false\`"
+            echo "- Resume draft: \`gh release view ${TAG} --repo ${GITHUB_REPOSITORY} --json isDraft,url\`"
+            echo "- Publish draft: \`gh release edit ${TAG} --repo ${GITHUB_REPOSITORY} --draft=false\`"
+            echo "- Abort draft: \`gh release delete ${TAG} --repo ${GITHUB_REPOSITORY} --cleanup-tag=false\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   publish-github-release:

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -106,10 +106,11 @@ public sealed class ReleaseWorkflowPolicyTests
         Assert.Contains("PROMOTE_RECOMMENDED: ${{ inputs.promote-recommended }}", publish, StringComparison.Ordinal);
         Assert.Contains("--arg promoteRecommended \"${PROMOTE_RECOMMENDED}\"", publish, StringComparison.Ordinal);
         Assert.Contains("$promoteRecommended != \"true\" or .recommendedVersion == $version", publish, StringComparison.Ordinal);
-        Assert.Contains("gh release download \"${TAG}\" --pattern \"${ARCHIVE_ASSET_NAME}\"", publish, StringComparison.Ordinal);
-        Assert.Contains("gh release edit ${TAG} --draft=false", publish, StringComparison.Ordinal);
+        Assert.Contains("gh release download \"${TAG}\" --repo \"${GITHUB_REPOSITORY}\" --pattern \"${ARCHIVE_ASSET_NAME}\"", publish, StringComparison.Ordinal);
+        Assert.Contains("gh release edit ${TAG} --repo ${GITHUB_REPOSITORY} --draft=false", publish, StringComparison.Ordinal);
+        Assert.Contains("gh release view ${TAG} --repo ${GITHUB_REPOSITORY} --json isDraft,url", publish, StringComparison.Ordinal);
         Assert.Contains("args=(release edit \"${TAG}\" --draft=false)", publish, StringComparison.Ordinal);
-        Assert.Contains("gh release delete ${TAG} --cleanup-tag=false", publish, StringComparison.Ordinal);
+        Assert.Contains("gh release delete ${TAG} --repo ${GITHUB_REPOSITORY} --cleanup-tag=false", publish, StringComparison.Ordinal);
         Assert.Contains("tar -tzf \"${asset_dir}/${asset_name}\"", publish, StringComparison.Ordinal);
         Assert.Contains("unsafe absolute or parent-relative entry", publish, StringComparison.Ordinal);
         Assert.Contains("tar -tzvf \"${asset_dir}/${asset_name}\"", publish, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- pass --repo to release asset verification so no-checkout release jobs do not depend on a local .git directory
- update release workflow recovery hints and policy assertions for repo-qualified gh release commands

## Verification
- dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj -c Release --no-restore --filter ReleaseWorkflowPolicyTests
- git diff --check