### PR TITLE
fix: allow draft asset verification

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read # Required to download the draft release asset for public digest verification.
+      contents: write # Required because draft release assets are not downloadable with the workflow token under contents: read.
 
     steps:
       - name: Verify deployed docs and uploaded release assets

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -127,6 +127,7 @@ public sealed class ReleaseWorkflowPolicyTests
         Assert.Contains("Required by deploy-pages to mint the GitHub Pages deployment token.", publish, StringComparison.Ordinal);
         Assert.Contains("Required so release validation can verify the protected NuGet workflow run for the tag.", publish, StringComparison.Ordinal);
         Assert.Contains("Required to create or reuse the draft GitHub Release and upload docs archive assets.", publish, StringComparison.Ordinal);
+        Assert.Contains("contents: write # Required because draft release assets are not downloadable with the workflow token under contents: read.", publish, StringComparison.Ordinal);
         Assert.Contains("Required to promote the verified draft GitHub Release to public.", publish, StringComparison.Ordinal);
         Assert.DoesNotContain("attestations: write", publish, StringComparison.Ordinal);
         Assert.DoesNotContain("supportState:\"Supported\"", publish, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- give the release public-docs verifier contents: write so it can download draft release assets with the workflow token
- pin the draft asset verification permission rationale in the workflow policy test

## Verification
- dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj -c Release --no-restore --filter ReleaseWorkflowPolicyTests
- git diff --check