### PR TITLE
fix(ci): split stable and prerelease tag triggers

### DIFF
--- a/.github/workflows/nuget-prerelease-publish.yml
+++ b/.github/workflows/nuget-prerelease-publish.yml
@@ -3,7 +3,7 @@ name: NuGet Prerelease Publish
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*-*'
 
 concurrency:
   group: nuget-prerelease-${{ github.ref_name }}

--- a/.github/workflows/nuget-stable-publish.yml
+++ b/.github/workflows/nuget-stable-publish.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'v*.*.*'
       - '!v*.*.*-*'
+      - '!v*.*.*.*'
 
 concurrency:
   group: nuget-stable-${{ github.ref_name }}

--- a/.github/workflows/nuget-stable-publish.yml
+++ b/.github/workflows/nuget-stable-publish.yml
@@ -3,7 +3,8 @@ name: NuGet Stable Publish
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
+      - '!v*.*.*-*'
 
 concurrency:
   group: nuget-stable-${{ github.ref_name }}

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -10,7 +10,7 @@ This is the living release note for the next coordinated AppSurface version afte
 
 ### Release and docs surface
 
-- Add release-facing changes here.
+- Split stable and prerelease NuGet publish tag triggers so prerelease tags no longer start the stable publish workflow before the prerelease gate.
 
 ## Migration watch
 


### PR DESCRIPTION
## Summary
- narrow stable NuGet publish trigger to stable-shaped tags only
- narrow prerelease NuGet publish trigger to prerelease-shaped tags only
- keep strict tag regex validation inside each workflow as the final guard
- record the release-pipeline behavior fix in releases/unreleased.md

## Validation
- git diff --check
- ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"ok #{f}\" }" .github/workflows/nuget-stable-publish.yml .github/workflows/nuget-prerelease-publish.yml

## Notes
- This prevents prerelease tags like v0.2.0-preview.2 from starting the stable publish workflow and failing stable tag validation.
