### PR TITLE
docs: strengthen release note guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ These guidelines apply to all changes made in this repository.
 - Include decision content that explains why an API exists, when it should be used, and when a different approach is the better choice.
 - Include pitfall content that calls out sharp edges, ordering requirements, surprising behavior, and common mistakes.
 - Update package-level and repository-level documentation when a change affects discoverability or adoption, not just inline XML comments.
+- Link named concepts to their canonical documentation instead of only mentioning them. When prose names a package, guide, example, workflow, policy, diagnostic family, CLI command, or cross-package concept, add a nearby link to the best start-here or reference page unless the same paragraph already defines it completely.
+- Prefer a small set of useful cross-links over scattered repeats. Link the first meaningful mention in a section, and link again only when the reader is likely to need the destination without scrolling back.
 
 ### Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,23 @@ Literal expected paths and tests intentionally exercising `Path.Join` or `Path.C
 - Update [`releases/unreleased.md`](./releases/unreleased.md) whenever a pull request changes behavior, usage guidance, release policy, examples, or docs consumers would care about in release notes.
 - Maintainers may apply the `no-unreleased-entry` label only for changes that do not belong in the public release story, such as repo administration or workflow-only cleanup.
 
+## Writing documentation
+
+- Link named concepts to their canonical documentation instead of only mentioning them. When prose names a package, guide, example, workflow, policy, diagnostic family, CLI command, or cross-package concept, add a nearby link to the best start-here or reference page unless the same paragraph already defines it completely.
+- Prefer useful cross-links over link noise. Link the first meaningful mention in a section, and link again only when the reader is likely to need the destination without scrolling back.
+- Use links to connect concepts, not just files. For example, a release note that mentions [PWA install support](./Web/ForgeTrust.AppSurface.Web/Docs/pwa-install.md) should link to the Web package PWA guide and [runnable PWA example](./examples/web-pwa-install/README.md); a note that mentions [RazorWire auth projection](./Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md) should link to the RazorWire auth package README or [auth proof example](./examples/auth-web-razorwire-proof/README.md).
+- Keep link targets durable. Prefer package READMEs, guides, examples, release notes, and public docs routes over transient PRs, local scratch notes, or maintainer-only recovery material.
+
 ## Writing release notes
 
 - Start from the public [release hub](./releases/README.md).
 - Keep [`CHANGELOG.md`](./CHANGELOG.md) compact. It is the ledger, not the full story.
 - Put detailed adoption notes in the current unreleased page or a tagged release page under [`releases/`](./releases/README.md).
 - Capture breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
+- Write for package consumers before maintainers. Start each notable entry with the adopter outcome, the package or app shape it applies to, and the next action a reader can take.
+- Link every substantial feature, named concept, workflow, diagnostic family, or package boundary to its best start-here material, such as the package README, guide, runnable example, or CLI proof. Do not leave readers to search the repository after a release note names a capability.
+- Define internal phrases in plain language before using them as labels. Prefer "[RazorWire can render allowed, forbidden, and anonymous UI from your existing ASP.NET Core policies](./Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md)" over opaque shorthand such as "passive auth projection" by itself.
+- Keep maintainer evidence, warning IDs, diagnostics, and generated-artifact details after the consumer path unless those details change adoption risk.
 
 ## Maintainer workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Literal expected paths and tests intentionally exercising `Path.Join` or `Path.C
 
 - Link named concepts to their canonical documentation instead of only mentioning them. When prose names a package, guide, example, workflow, policy, diagnostic family, CLI command, or cross-package concept, add a nearby link to the best start-here or reference page unless the same paragraph already defines it completely.
 - Prefer useful cross-links over link noise. Link the first meaningful mention in a section, and link again only when the reader is likely to need the destination without scrolling back.
-- Use links to connect concepts, not just files. For example, a release note that mentions [PWA install support](./Web/ForgeTrust.AppSurface.Web/Docs/pwa-install.md) should link to the Web package PWA guide and [runnable PWA example](./examples/web-pwa-install/README.md); a note that mentions [RazorWire auth projection](./Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md) should link to the RazorWire auth package README or [auth proof example](./examples/auth-web-razorwire-proof/README.md).
+- Use links to connect concepts, not just files. For example, a release note that mentions [PWA install support](./Web/ForgeTrust.AppSurface.Web/Docs/pwa-install.md) should link to the Web package PWA guide and [PWA example](./examples/web-pwa-install/README.md); a note that mentions [RazorWire auth projection](./Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md) should link to the RazorWire auth package README or [auth proof example](./examples/auth-web-razorwire-proof/README.md).
 - Keep link targets durable. Prefer package READMEs, guides, examples, release notes, and public docs routes over transient PRs, local scratch notes, or maintainer-only recovery material.
 
 ## Writing release notes
@@ -67,7 +67,7 @@ Literal expected paths and tests intentionally exercising `Path.Join` or `Path.C
 - Put detailed adoption notes in the current unreleased page or a tagged release page under [`releases/`](./releases/README.md).
 - Capture breaking or behavior-changing updates in the unreleased page even before `v0.1.0`. Finalized migration guidance moves into the tagged release page when the version ships.
 - Write for package consumers before maintainers. Start each notable entry with the adopter outcome, the package or app shape it applies to, and the next action a reader can take.
-- Link every substantial feature, named concept, workflow, diagnostic family, or package boundary to its best start-here material, such as the package README, guide, runnable example, or CLI proof. Do not leave readers to search the repository after a release note names a capability.
+- Link every substantial feature, named concept, workflow, diagnostic family, or package boundary to its best start-here material, such as the package README, guide, example, or CLI proof. Do not leave readers to search the repository after a release note names a capability.
 - Define internal phrases in plain language before using them as labels. Prefer "[RazorWire can render allowed, forbidden, and anonymous UI from your existing ASP.NET Core policies](./Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md)" over opaque shorthand such as "passive auth projection" by itself.
 - Keep maintainer evidence, warning IDs, diagnostics, and generated-artifact details after the consumer path unless those details change adoption risk.
 

--- a/releases/README.md
+++ b/releases/README.md
@@ -36,6 +36,19 @@ The release evidence bundle is not a signature or hosted-build attestation. It i
 
 Each release note should open with the narrative that matters to evaluators and adopters. Explain what changed, why it matters, and which parts of the product surface are affected before dropping into mechanical lists.
 
+### Consumer path next
+
+Each major item should answer the reader's next question without making them inspect the repository:
+
+- Who should care?
+- What can they now do?
+- Which package, guide, example, or CLI command should they start with?
+- What boundary or pitfall should they know before adopting it?
+
+Use internal feature names only after the reader-facing behavior is clear. For example, introduce [RazorWire auth projection](../Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md) as rendering allowed, forbidden, and anonymous UI from host-owned ASP.NET Core policies before relying on the phrase "passive auth projection." When a change ships with a guide or runnable example, link that path from the release note next to the feature summary.
+
+Release notes should also connect related concepts instead of only naming them. If an item mentions a package, guide, example, workflow, policy, diagnostic family, CLI command, or cross-package concept, link the first meaningful mention to the canonical page a consumer should read next. Prefer durable start-here links, package READMEs, guides, examples, and public docs routes over transient PRs or maintainer-only notes.
+
 ### Safety second
 
 Every release note should make upgrade risk obvious near the top. Call out whether the note is unreleased or tagged, which surfaces are affected, how fresh the information is, and where migration guidance lives.

--- a/releases/README.md
+++ b/releases/README.md
@@ -45,7 +45,7 @@ Each major item should answer the reader's next question without making them ins
 - Which package, guide, example, or CLI command should they start with?
 - What boundary or pitfall should they know before adopting it?
 
-Use internal feature names only after the reader-facing behavior is clear. For example, introduce [RazorWire auth projection](../Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md) as rendering allowed, forbidden, and anonymous UI from host-owned ASP.NET Core policies before relying on the phrase "passive auth projection." When a change ships with a guide or runnable example, link that path from the release note next to the feature summary.
+Use internal feature names only after the reader-facing behavior is clear. For example, introduce [RazorWire auth projection](../Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md) as rendering allowed, forbidden, and anonymous UI from host-owned ASP.NET Core policies before relying on the phrase "passive auth projection." When a change ships with a guide or example, link that path from the release note next to the feature summary.
 
 Release notes should also connect related concepts instead of only naming them. If an item mentions a package, guide, example, workflow, policy, diagnostic family, CLI command, or cross-package concept, link the first meaningful mention to the canonical page a consumer should read next. Prefer durable start-here links, package READMEs, guides, examples, and public docs routes over transient PRs or maintainer-only notes.
 

--- a/releases/release-authoring-checklist.md
+++ b/releases/release-authoring-checklist.md
@@ -7,6 +7,9 @@ Use this checklist when turning the living unreleased story into a tagged AppSur
 - run `./eng/release check --version x.y.z` to validate the release inputs, package policy, generated targets, and warning IDs
 - make sure the pull request queue has updated [`unreleased.md`](./unreleased.md)
 - regroup the story so the opening narrative explains what changed and why it matters
+- rewrite maintainer-led bullets into consumer-led entries for every prerelease, release-candidate, and stable note: outcome first, affected package or app shape second, maintainer evidence last
+- replace opaque shorthand with a plain-language explanation before the label, especially for cross-package concepts such as [auth projection](../Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md), [static export safety](../Web/ForgeTrust.RazorWire/README.md), or [release evidence](./README.md)
+- link every substantial feature, named concept, package boundary, workflow, diagnostic family, and CLI command to its best start-here material: package README, guide, runnable example, CLI command reference, or migration section
 - confirm every breaking or behavior-changing update has migration guidance
 - for stable releases, stage the AppSurface Docs exact archive and run `appsurface docs verify-archive --catalog <staging>/versions.json --version x.y.z --trusted-release-root <staging>` before asking the release tool to validate docs evidence
 - for stable releases, confirm the checked-in evidence fields describe the same staged docs archive that `nuget-stable-publish.yml` will export and verify before `publish-nuget`
@@ -19,6 +22,7 @@ Use this checklist when turning the living unreleased story into a tagged AppSur
 - for stable releases, confirm `releases/vx.y.z.evidence.json` records `docsArchive.exactTreePath`, `docsArchive.releaseManifestSha256`, and matching `docsArchive.catalogEntry` fields from the staged docs catalog
 - confirm the generated package path updates described in the [package registry](../packages/README.md) point every `classification: public` plus `publish_decision: publish` package at the tagged note
 - review the generated [package readiness evidence](../packages/readiness.md) and resolve or explicitly track package-index blockers before asking maintainers to approve package artifacts; this package-index evidence is separate from the per-version release evidence bundle
+- check that the tagged note gives adopters direct paths to related guides, examples, package docs, and command references instead of only naming the capability
 - when a tagged or release-candidate note supersedes a preview page, remove the preview source file and carry its browser routes as `redirect_aliases` on the new canonical note
 - keep the trust bar accurate for the release state and archive location
 - link the tagged note from [`CHANGELOG.md`](../CHANGELOG.md)

--- a/releases/release-authoring-checklist.md
+++ b/releases/release-authoring-checklist.md
@@ -9,7 +9,7 @@ Use this checklist when turning the living unreleased story into a tagged AppSur
 - regroup the story so the opening narrative explains what changed and why it matters
 - rewrite maintainer-led bullets into consumer-led entries for every prerelease, release-candidate, and stable note: outcome first, affected package or app shape second, maintainer evidence last
 - replace opaque shorthand with a plain-language explanation before the label, especially for cross-package concepts such as [auth projection](../Web/ForgeTrust.RazorWire.Auth.AspNetCore/README.md), [static export safety](../Web/ForgeTrust.RazorWire/README.md), or [release evidence](./README.md)
-- link every substantial feature, named concept, package boundary, workflow, diagnostic family, and CLI command to its best start-here material: package README, guide, runnable example, CLI command reference, or migration section
+- link every substantial feature, named concept, package boundary, workflow, diagnostic family, and CLI command to its best start-here material: package README, guide, example, CLI command reference, or migration section
 - confirm every breaking or behavior-changing update has migration guidance
 - for stable releases, stage the AppSurface Docs exact archive and run `appsurface docs verify-archive --catalog <staging>/versions.json --version x.y.z --trusted-release-root <staging>` before asking the release tool to validate docs evidence
 - for stable releases, confirm the checked-in evidence fields describe the same staged docs archive that `nuget-stable-publish.yml` will export and verify before `publish-nuget`

--- a/releases/release-authoring-checklist.md.yml
+++ b/releases/release-authoring-checklist.md.yml
@@ -1,5 +1,5 @@
 title: Release authoring checklist
-summary: Maintainer workflow for turning the unreleased proof artifact into a tagged release note.
+summary: Maintainer workflow for turning the unreleased proof artifact into a consumer-led tagged release note.
 page_type: how-to
 nav_group: Releases
 order: 40

--- a/releases/templates/tagged-release-template.md
+++ b/releases/templates/tagged-release-template.md
@@ -16,7 +16,7 @@ Write the short story first. Explain what adopters can do now, who should care, 
 
 - Package chooser or package README:
 - Guide:
-- Runnable example:
+- Example:
 - CLI or verification command:
 
 ## What shipped
@@ -31,7 +31,7 @@ Write the short story first. Explain what adopters can do now, who should care, 
 
 ### Docs and examples
 
-- Describe docs-facing and example changes here. Link guides and runnable examples beside the feature they explain, and connect adjacent concepts readers are likely to need next.
+- Describe docs-facing and example changes here. Link guides and examples beside the feature they explain, and connect adjacent concepts readers are likely to need next.
 
 ### Boundaries and pitfalls
 

--- a/releases/templates/tagged-release-template.md
+++ b/releases/templates/tagged-release-template.md
@@ -4,27 +4,38 @@ Replace every placeholder in this template before publishing a tagged AppSurface
 
 ## Why this release matters
 
-Write the short story first. Explain what changed, who should care, and which parts of the AppSurface surface moved in this version.
+Write the short story first. Explain what adopters can do now, who should care, which packages or app shapes are affected, and why the change matters. Avoid opening with internal feature labels unless the surrounding sentence already explains the consumer outcome.
 
 ## Highlights
 
-- Highlight one
-- Highlight two
-- Highlight three
+- Consumer outcome one, with the affected package and start-here link.
+- Consumer outcome two, with the affected package and start-here link.
+- Consumer outcome three, with the affected package and start-here link.
+
+## Start Here
+
+- Package chooser or package README:
+- Guide:
+- Runnable example:
+- CLI or verification command:
 
 ## What shipped
 
 ### Packages and APIs
 
-- Describe package-level changes here.
+- Describe package-level changes here. Lead with the reader-facing behavior before naming internal abstractions, and link named packages, cross-package concepts, and companion guides on first meaningful mention.
 
 ### CLI and tooling
 
-- Describe CLI and developer workflow changes here.
+- Describe CLI and developer workflow changes here. Include the command a consumer should run when the release adds a verifier, migration helper, or proof workflow, and link the command reference or guide.
 
 ### Docs and examples
 
-- Describe docs-facing and example changes here.
+- Describe docs-facing and example changes here. Link guides and runnable examples beside the feature they explain, and connect adjacent concepts readers are likely to need next.
+
+### Boundaries and pitfalls
+
+- State what this release does not own, what stays host-owned, and which ordering or configuration mistakes adopters should avoid.
 
 ## Migration guidance
 

--- a/releases/templates/tagged-release-template.md.yml
+++ b/releases/templates/tagged-release-template.md.yml
@@ -1,5 +1,5 @@
 title: Tagged release template
-summary: Maintainer template for future versioned AppSurface release notes.
+summary: Consumer-led template for future versioned AppSurface release notes.
 page_type: guide
 nav_group: Releases
 order: 50

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -10,6 +10,7 @@ This is the living release note for the next coordinated AppSurface version afte
 
 ### Release and docs surface
 
+- Documentation and release authoring guidance now require concept links instead of mention-only prose: start with adopter outcomes, explain internal feature labels in plain language, link named packages, concepts, workflows, diagnostics, guides, examples, and CLI commands to their canonical docs, and keep maintainer evidence after the adoption path.
 - AppSurface DevAuth now centralizes its environment activation policy. DevAuth remains Development-by-default, but
   package consumers can explicitly add local/proof environment names through `AllowedEnvironmentNames`; the marker
   self-suppresses outside allowed environments and mapped control/mutation endpoints stay fail-closed.


### PR DESCRIPTION
## Summary
- Make repo documentation guidance require links from named concepts to canonical docs, examples, workflows, commands, and package references.
- Make release-note guidance consumer-led, including explicit coverage for prerelease, release-candidate, and stable notes.
- Update the release checklist and tagged-release template so authors point readers to guides, examples, package docs, and proof paths instead of only naming internal concepts.

## Test plan
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] Verified linked guide and example targets exist
- [ ] `./eng/release check --version 0.2.0-preview.3` was not rerun; earlier attempt hung after a macOS CSSM warning, and this PR is docs-guidance only

## Notes
- This intentionally does not bump `VERSION` or rewrite release notes for a tagged ship, because the branch only changes repo authoring guidance and the requested PR is a draft.