### PR TITLE
fix(auth): preserve DevAuth control-page return URL

### DIFF
--- a/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth.Tests/AppSurfaceDevAuthEndpointTests.cs
+++ b/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth.Tests/AppSurfaceDevAuthEndpointTests.cs
@@ -68,6 +68,139 @@ public sealed class AppSurfaceDevAuthEndpointTests
     }
 
     [Fact]
+    public void BuildMutationUrl_WithoutReturnUrl_ReturnsBareAction()
+    {
+        var action = AppSurfaceDevAuthEndpointRouteBuilderExtensions.BuildMutationUrl(
+            "/_appsurface/dev-auth",
+            "select/admin",
+            returnUrl: null);
+
+        Assert.Equal("/_appsurface/dev-auth/select/admin", action);
+    }
+
+    [Fact]
+    public void BuildMutationUrl_WithReturnUrl_AppendsOneUriEscapedValue()
+    {
+        var action = AppSurfaceDevAuthEndpointRouteBuilderExtensions.BuildMutationUrl(
+            "/_appsurface/dev-auth",
+            "clear",
+            "/protected?tab=auth&mode=full");
+
+        Assert.Equal(
+            "/_appsurface/dev-auth/clear?returnUrl=%2Fprotected%3Ftab%3Dauth%26mode%3Dfull",
+            action);
+    }
+
+    [Fact]
+    public async Task ControlPage_WithSafeReturnUrl_RendersTargetOnEveryMutationAction()
+    {
+        await using var app = BuildApp();
+        var endpoint = FindEndpoint(app, "/_appsurface/dev-auth/", HttpMethods.Get);
+        var context = CreateContext(app.Services);
+        context.Request.QueryString = QueryString.Create("returnUrl", "/protected?tab=auth&mode=full");
+
+        await endpoint.RequestDelegate!(context);
+
+        var html = await ReadBodyAsync(context);
+        const string encodedReturnUrl = "%2Fprotected%3Ftab%3Dauth%26mode%3Dfull";
+        Assert.Contains($"action=\"/_appsurface/dev-auth/select/admin?returnUrl={encodedReturnUrl}\"", html, StringComparison.Ordinal);
+        Assert.Contains($"action=\"/_appsurface/dev-auth/select/viewer?returnUrl={encodedReturnUrl}\"", html, StringComparison.Ordinal);
+        Assert.Contains($"action=\"/_appsurface/dev-auth/clear?returnUrl={encodedReturnUrl}\"", html, StringComparison.Ordinal);
+        Assert.Equal(3, CountOccurrences(html, "returnUrl="));
+    }
+
+    [Fact]
+    public async Task ControlPage_WithRootReturnUrl_PreservesExplicitRoot()
+    {
+        await using var app = BuildApp();
+        var endpoint = FindEndpoint(app, "/_appsurface/dev-auth/", HttpMethods.Get);
+        var context = CreateContext(app.Services);
+        context.Request.QueryString = QueryString.Create("returnUrl", "/");
+
+        await endpoint.RequestDelegate!(context);
+
+        var html = await ReadBodyAsync(context);
+        Assert.Contains("action=\"/_appsurface/dev-auth/select/admin?returnUrl=%2F\"", html, StringComparison.Ordinal);
+        Assert.Contains("action=\"/_appsurface/dev-auth/select/viewer?returnUrl=%2F\"", html, StringComparison.Ordinal);
+        Assert.Contains("action=\"/_appsurface/dev-auth/clear?returnUrl=%2F\"", html, StringComparison.Ordinal);
+        Assert.Equal(3, CountOccurrences(html, "returnUrl=%2F"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("?returnUrl=")]
+    [InlineData("?returnUrl=%20%20")]
+    public async Task ControlPage_WithoutUsableReturnUrl_RendersBareMutationActions(string queryString)
+    {
+        await using var app = BuildApp();
+        var endpoint = FindEndpoint(app, "/_appsurface/dev-auth/", HttpMethods.Get);
+        var context = CreateContext(app.Services);
+        context.Request.QueryString = new QueryString(queryString);
+
+        await endpoint.RequestDelegate!(context);
+
+        var html = await ReadBodyAsync(context);
+        AssertBareMutationActions(html, "/_appsurface/dev-auth");
+    }
+
+    [Theory]
+    [InlineData("?returnUrl=dashboard")]
+    [InlineData("?returnUrl=https%3A%2F%2Fexample.com%2F")]
+    [InlineData("?returnUrl=%2F%2Fexample.com%2F")]
+    [InlineData("?returnUrl=%2F%5Cexample.com")]
+    [InlineData("?returnUrl=%2Fsafe%5Cevil")]
+    [InlineData("?returnUrl=%2Fsafe%0Aevil")]
+    public async Task ControlPage_WithRejectedReturnUrl_RendersBareMutationActions(string queryString)
+    {
+        await using var app = BuildApp();
+        var endpoint = FindEndpoint(app, "/_appsurface/dev-auth/", HttpMethods.Get);
+        var context = CreateContext(app.Services);
+        context.Request.QueryString = new QueryString(queryString);
+
+        await endpoint.RequestDelegate!(context);
+
+        var html = await ReadBodyAsync(context);
+        AssertBareMutationActions(html, "/_appsurface/dev-auth");
+    }
+
+    [Fact]
+    public async Task ControlPage_WithCustomPathPrefixAndSafeReturnUrl_ComposesExactActions()
+    {
+        await using var app = BuildApp(options =>
+        {
+            options.PathPrefix = "/local/personas";
+            AddDefaultPersonas(options);
+        });
+        var endpoint = FindEndpoint(app, "/local/personas/", HttpMethods.Get);
+        var context = CreateContext(app.Services);
+        context.Request.QueryString = QueryString.Create("returnUrl", "/protected");
+
+        await endpoint.RequestDelegate!(context);
+
+        var html = await ReadBodyAsync(context);
+        Assert.Contains("action=\"/local/personas/select/admin?returnUrl=%2Fprotected\"", html, StringComparison.Ordinal);
+        Assert.Contains("action=\"/local/personas/select/viewer?returnUrl=%2Fprotected\"", html, StringComparison.Ordinal);
+        Assert.Contains("action=\"/local/personas/clear?returnUrl=%2Fprotected\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ControlPage_WithHtmlSensitiveSafeReturnUrl_EscapesBeforeEncodingActionAttribute()
+    {
+        await using var app = BuildApp();
+        var endpoint = FindEndpoint(app, "/_appsurface/dev-auth/", HttpMethods.Get);
+        var context = CreateContext(app.Services);
+        context.Request.QueryString = QueryString.Create("returnUrl", "/protected?note=\"<x>&mode=1");
+
+        await endpoint.RequestDelegate!(context);
+
+        var html = await ReadBodyAsync(context);
+        const string encodedReturnUrl = "%2Fprotected%3Fnote%3D%22%3Cx%3E%26mode%3D1";
+        Assert.Contains($"action=\"/_appsurface/dev-auth/select/admin?returnUrl={encodedReturnUrl}\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("note=\"<x>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("%252Fprotected", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Marker_RendersPersistentOverlayControlsWithCurrentReturnUrl()
     {
         using var app = BuildApp();
@@ -88,8 +221,29 @@ public sealed class AppSurfaceDevAuthEndpointTests
         Assert.Contains("<details class=\"appsurface-dev-auth-marker__details\">", html, StringComparison.Ordinal);
         Assert.Contains("<summary class=\"appsurface-dev-auth-marker__summary\">", html, StringComparison.Ordinal);
         Assert.Contains("/_appsurface/dev-auth/select/admin?returnUrl=%2Fdashboard%3Ftab%3Dauth", html, StringComparison.Ordinal);
+        Assert.Contains("/_appsurface/dev-auth/select/viewer?returnUrl=%2Fdashboard%3Ftab%3Dauth", html, StringComparison.Ordinal);
+        Assert.Contains("/_appsurface/dev-auth/clear?returnUrl=%2Fdashboard%3Ftab%3Dauth", html, StringComparison.Ordinal);
         Assert.Contains("Open persona lab", html, StringComparison.Ordinal);
         Assert.Contains("Status JSON", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Marker_WithUnsafeConfiguredReturnUrl_NormalizesMutationActionsToRoot()
+    {
+        using var app = BuildApp();
+        var context = CreateContext(app.Services);
+
+        var html = AppSurfaceDevAuthMarker.Render(
+            context,
+            app.Services.GetRequiredService<IHostEnvironment>(),
+            app.Services.GetRequiredService<IOptions<AppSurfaceDevAuthOptions>>(),
+            app.Services.GetRequiredService<IDataProtectionProvider>(),
+            options => options.ReturnUrl = "https://example.com/");
+
+        Assert.Contains("/_appsurface/dev-auth/select/admin?returnUrl=%2F", html, StringComparison.Ordinal);
+        Assert.Contains("/_appsurface/dev-auth/select/viewer?returnUrl=%2F", html, StringComparison.Ordinal);
+        Assert.Contains("/_appsurface/dev-auth/clear?returnUrl=%2F", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("example.com", html, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -612,6 +766,23 @@ public sealed class AppSurfaceDevAuthEndpointTests
     }
 
     [Fact]
+    public async Task ClearPersona_WithExternalReturnUrl_RendersControlPageInsteadOfRedirecting()
+    {
+        await using var app = BuildApp();
+        var endpoint = FindEndpoint(app, "/_appsurface/dev-auth/clear", HttpMethods.Post);
+        var context = CreateContext(app.Services);
+        context.Request.QueryString = new QueryString("?returnUrl=https%3A%2F%2Fexample.com%2F");
+
+        await endpoint.RequestDelegate!(context);
+
+        var html = await ReadBodyAsync(context);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.True(context.Response.Headers.Location.Count == 0, "External return URLs must not redirect.");
+        Assert.Contains("DEV AUTH: Anonymous (AppSurface.DevAuth)", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("returnUrl=", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ClearPersona_WithCrossSiteFetchMetadata_RejectsWithoutCookieMutation()
     {
         await using var app = BuildApp();
@@ -972,5 +1143,26 @@ public sealed class AppSurfaceDevAuthEndpointTests
         context.Response.Body.Position = 0;
         using var reader = new StreamReader(context.Response.Body, leaveOpen: true);
         return await reader.ReadToEndAsync();
+    }
+
+    private static void AssertBareMutationActions(string html, string pathPrefix)
+    {
+        Assert.Contains($"action=\"{pathPrefix}/select/admin\"", html, StringComparison.Ordinal);
+        Assert.Contains($"action=\"{pathPrefix}/select/viewer\"", html, StringComparison.Ordinal);
+        Assert.Contains($"action=\"{pathPrefix}/clear\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("returnUrl=", html, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string value, string searchValue)
+    {
+        var count = 0;
+        var startIndex = 0;
+        while ((startIndex = value.IndexOf(searchValue, startIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            startIndex += searchValue.Length;
+        }
+
+        return count;
     }
 }

--- a/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/AppSurfaceDevAuthEndpointRouteBuilderExtensions.cs
+++ b/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/AppSurfaceDevAuthEndpointRouteBuilderExtensions.cs
@@ -35,7 +35,9 @@ public static partial class AppSurfaceDevAuthEndpointRouteBuilderExtensions
     /// the same materialized options used by the authentication handler, reserves the configured path prefix, and rejects
     /// existing endpoints whose route templates are equivalent to DevAuth control routes even when parameter names differ.
     /// Control endpoints stay loopback-only by default, honor <see cref="AppSurfaceDevAuthOptions.AllowedEnvironmentNames"/>,
-    /// and set no-store headers on every response.
+    /// and set no-store headers on every response. The control-page GET accepts an optional <c>returnUrl</c> query value.
+    /// A safe rooted local value is propagated to every select and clear form action, and successful mutations return
+    /// through a local redirect. Missing or rejected values are omitted, so mutations render the control page normally.
     /// </remarks>
     public static IEndpointRouteBuilder MapAppSurfaceDevAuth(this IEndpointRouteBuilder endpoints)
     {
@@ -144,7 +146,10 @@ public static partial class AppSurfaceDevAuthEndpointRouteBuilderExtensions
             return Results.NotFound();
         }
 
-        return Results.Content(RenderControlPage(status, options.Value), MediaTypeNames.Text.Html, Encoding.UTF8);
+        var returnUrl = TryGetSafeReturnUrl(httpContext, out var safeReturnUrl)
+            ? safeReturnUrl
+            : null;
+        return Results.Content(RenderControlPage(status, options.Value, returnUrl), MediaTypeNames.Text.Html, Encoding.UTF8);
     }
 
     private static IResult RenderStatusAsync(
@@ -211,7 +216,7 @@ public static partial class AppSurfaceDevAuthEndpointRouteBuilderExtensions
             IsAnonymous: false,
             Warnings: []);
 
-        return Results.Content(RenderControlPage(status, devAuthOptions), MediaTypeNames.Text.Html, Encoding.UTF8);
+        return Results.Content(RenderControlPage(status, devAuthOptions, returnUrl: null), MediaTypeNames.Text.Html, Encoding.UTF8);
     }
 
     private static IResult CreateInvalidPersonaResult()
@@ -261,7 +266,7 @@ public static partial class AppSurfaceDevAuthEndpointRouteBuilderExtensions
             IsAnonymous: true,
             Warnings: []);
 
-        return Results.Content(RenderControlPage(status, devAuthOptions), MediaTypeNames.Text.Html, Encoding.UTF8);
+        return Results.Content(RenderControlPage(status, devAuthOptions, returnUrl: null), MediaTypeNames.Text.Html, Encoding.UTF8);
     }
 
     private static CookieOptions CreatePersonaCookieOptions(HttpRequest request)
@@ -321,7 +326,10 @@ public static partial class AppSurfaceDevAuthEndpointRouteBuilderExtensions
             Warnings: warnings);
     }
 
-    private static string RenderControlPage(AppSurfaceDevAuthStatus status, AppSurfaceDevAuthOptions options)
+    private static string RenderControlPage(
+        AppSurfaceDevAuthStatus status,
+        AppSurfaceDevAuthOptions options,
+        string? returnUrl)
     {
         var html = HtmlEncoder.Default;
         var builder = new StringBuilder();
@@ -351,10 +359,12 @@ public static partial class AppSurfaceDevAuthEndpointRouteBuilderExtensions
         foreach (var persona in options.Users.Personas.Values)
         {
             var selected = string.Equals(status.PersonaId, persona.Id, StringComparison.Ordinal);
-            builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(options.PathPrefix)}/select/{html.Encode(persona.Id)}\"><button class=\"{(selected ? "selected" : string.Empty)}\" aria-current=\"{(selected ? "true" : "false")}\">{html.Encode(DisplayPersonaName(persona))}</button></form>");
+            var action = BuildMutationUrl(options.PathPrefix, "select/" + persona.Id, returnUrl);
+            builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(action)}\"><button class=\"{(selected ? "selected" : string.Empty)}\" aria-current=\"{(selected ? "true" : "false")}\">{html.Encode(DisplayPersonaName(persona))}</button></form>");
         }
 
-        builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(options.PathPrefix)}/clear\"><button>Clear persona</button></form>");
+        var clearAction = BuildMutationUrl(options.PathPrefix, "clear", returnUrl);
+        builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(clearAction)}\"><button>Clear persona</button></form>");
         builder.AppendLine("</div></section>");
         builder.AppendLine("<section class=\"panel\" aria-label=\"Claims preview\"><h2>Claims preview</h2>");
         if (status.PersonaId is not null && options.Users.Personas.TryGetValue(status.PersonaId, out var current))
@@ -510,6 +520,27 @@ public static partial class AppSurfaceDevAuthEndpointRouteBuilderExtensions
         returnUrl = NormalizeLocalReturnUrl(httpContext.Request.Query["returnUrl"].ToString());
         return !string.Equals(returnUrl, "/", StringComparison.Ordinal) ||
             string.Equals(httpContext.Request.Query["returnUrl"].ToString(), "/", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Builds a DevAuth mutation action URL and optionally appends a URI-escaped return URL.
+    /// </summary>
+    /// <param name="pathPrefix">Validated DevAuth path prefix without a trailing slash.</param>
+    /// <param name="action">Mutation action path relative to <paramref name="pathPrefix"/>.</param>
+    /// <param name="returnUrl">
+    /// Optional return URL that the caller has already validated or normalized. This method does not determine whether
+    /// the target is local or safe.
+    /// </param>
+    /// <returns>
+    /// The bare mutation action when <paramref name="returnUrl"/> is <see langword="null"/>; otherwise the mutation
+    /// action with one URI-escaped <c>returnUrl</c> query value.
+    /// </returns>
+    internal static string BuildMutationUrl(string pathPrefix, string action, string? returnUrl)
+    {
+        var mutationUrl = string.Concat(pathPrefix, "/", action);
+        return returnUrl is null
+            ? mutationUrl
+            : string.Concat(mutationUrl, "?returnUrl=", Uri.EscapeDataString(returnUrl));
     }
 
     /// <summary>

--- a/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/AppSurfaceDevAuthMarker.cs
+++ b/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/AppSurfaceDevAuthMarker.cs
@@ -102,10 +102,18 @@ public static class AppSurfaceDevAuthMarker
             foreach (var persona in options.Users.Personas.Values)
             {
                 var selected = string.Equals(status.PersonaId, persona.Id, StringComparison.Ordinal);
-                builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(BuildMutationUrl(options.PathPrefix, "select/" + persona.Id, returnUrl))}\"><button class=\"{classPrefix}__button\" aria-current=\"{(selected ? "true" : "false")}\">{html.Encode(AppSurfaceDevAuthEndpointRouteBuilderExtensions.DisplayPersonaName(persona))}</button></form>");
+                var action = AppSurfaceDevAuthEndpointRouteBuilderExtensions.BuildMutationUrl(
+                    options.PathPrefix,
+                    "select/" + persona.Id,
+                    returnUrl);
+                builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(action)}\"><button class=\"{classPrefix}__button\" aria-current=\"{(selected ? "true" : "false")}\">{html.Encode(AppSurfaceDevAuthEndpointRouteBuilderExtensions.DisplayPersonaName(persona))}</button></form>");
             }
 
-            builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(BuildMutationUrl(options.PathPrefix, "clear", returnUrl))}\"><button class=\"{classPrefix}__button\">Clear</button></form>");
+            var clearAction = AppSurfaceDevAuthEndpointRouteBuilderExtensions.BuildMutationUrl(
+                options.PathPrefix,
+                "clear",
+                returnUrl);
+            builder.AppendLine($"<form method=\"post\" action=\"{html.Encode(clearAction)}\"><button class=\"{classPrefix}__button\">Clear</button></form>");
             builder.AppendLine("</div>");
         }
 
@@ -151,8 +159,4 @@ public static class AppSurfaceDevAuthMarker
         return httpContext.Request.PathBase + httpContext.Request.Path + httpContext.Request.QueryString;
     }
 
-    private static string BuildMutationUrl(string pathPrefix, string action, string returnUrl)
-    {
-        return string.Concat(pathPrefix, "/", action, "?returnUrl=", Uri.EscapeDataString(returnUrl));
-    }
 }

--- a/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/AppSurfaceDevAuthMarkerOptions.cs
+++ b/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/AppSurfaceDevAuthMarkerOptions.cs
@@ -65,8 +65,9 @@ public sealed class AppSurfaceDevAuthMarkerOptions
     /// Gets or sets the local URL to return to after a marker persona mutation.
     /// </summary>
     /// <remarks>
-    /// Leave this unset to return to the current request path and query. External URLs, protocol-relative URLs, and
-    /// backslash-prefixed URLs are ignored by the DevAuth endpoints.
+    /// Leave this unset to return to the current request path and query. The marker normalizes blank, non-rooted,
+    /// external, protocol-relative, backslash-containing, and control-character values to the site root before
+    /// constructing its mutation actions.
     /// </remarks>
     public string? ReturnUrl { get; set; }
 }

--- a/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/README.md
+++ b/Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/README.md
@@ -110,6 +110,16 @@ Open the persona lab:
 /_appsurface/dev-auth
 ```
 
+### Return To The Host Page
+
+To return to a host page after selecting or clearing a persona, open the control page with a URI-encoded local target:
+
+```text
+/_appsurface/dev-auth/?returnUrl=%2Fprotected%3Ftab%3Dauth
+```
+
+DevAuth carries a safe rooted local path through every select and clear form action, then returns through the existing local redirect after the mutation. An explicit `/` is valid. Missing, blank, non-rooted, absolute, protocol-relative, backslash-containing, or control-character values are omitted from the forms; submitting then leaves the browser on the normal updated DevAuth control response. Rejected targets do not produce a diagnostic because omission is the fail-closed fallback.
+
 The control page lets you select a seeded persona, clear the persona cookie, inspect safe local claims, and copy a visible marker such as `DEV AUTH: Local Admin (AppSurface.DevAuth)`. For a persistent in-app indicator, render `AppSurfaceDevAuthMarker` from your local layout or proof page. The renderer returns an empty string when the current environment is not in `AllowedEnvironmentNames`, so layouts do not need their own `environment.IsDevelopment()` guard. With default styles, the marker is a fixed bottom-right overlay above 640 CSS pixels and participates in normal document flow at widths up to and including 640 CSS pixels. It starts collapsed, keeps the active fake persona visible, and expands to POST-only persona controls that return to the current page after selection.
 
 The host must provide `<meta name="viewport" content="width=device-width, initial-scale=1">` so the 640 CSS-pixel breakpoint tracks the device width. Render the marker after persistent application chrome and before `<main>` (or the equivalent primary content container). At narrow widths, that host-owned location becomes the marker's in-flow position, so opening the disclosure pushes following content rather than covering it. The host also owns outer spacing and the containing layout.
@@ -117,7 +127,7 @@ The host must provide `<meta name="viewport" content="width=device-width, initia
 ## API Reference
 
 - `AddAppSurfaceDevAuth(IHostEnvironment environment, Action<AppSurfaceDevAuthOptions> configure)` registers the named DevAuth authentication scheme and startup safety validation. The `configure` callback is evaluated once during registration, and the same validated options are used for both scheme registration and runtime DevAuth behavior.
-- `MapAppSurfaceDevAuth(this IEndpointRouteBuilder endpoints)` maps the local-only control page, status JSON, select persona endpoint, and clear persona endpoint. Control and mutation endpoints return not found when the active environment is not allowed; status remains read-only and reports `enabled: false`. The control page root always includes a static-auditable DevAuth control-page marker attribute so static export audits can reject DevAuth UI before it is written to disk.
+- `MapAppSurfaceDevAuth(this IEndpointRouteBuilder endpoints)` maps the local-only control page, status JSON, select persona endpoint, and clear persona endpoint. The control-page GET accepts an optional safe rooted local `returnUrl`, carries it through every select and clear form action, and returns through a local redirect after successful mutation. Missing or rejected targets are omitted, so mutations render the updated control page normally. Control and mutation endpoints return not found when the active environment is not allowed; status remains read-only and reports `enabled: false`. The control page root always includes a static-auditable DevAuth control-page marker attribute so static export audits can reject DevAuth UI before it is written to disk.
 - `AppSurfaceDevAuthMarker.Render(HttpContext, IHostEnvironment, IOptions<AppSurfaceDevAuthOptions>, IDataProtectionProvider, Action<AppSurfaceDevAuthMarkerOptions>?)` returns safe HTML for an explicit in-app DevAuth state marker. It returns `string.Empty` when the active environment is not allowed. With default styles, the marker is fixed above 640 CSS pixels and in flow at or below 640 CSS pixels. The marker root always includes a static-auditable DevAuth marker attribute so static export audits can reject DevAuth UI even when the CSS class prefix is customized.
 - `AppSurfaceDevAuthDefaults.AuthenticationScheme` is `AppSurface.DevAuth`.
 - `AppSurfaceDevAuthDefaults.PathPrefix` is `/_appsurface/dev-auth`.
@@ -304,6 +314,7 @@ Diagnostics, HTML, and status JSON do not include raw tokens, secrets, passwords
 - Include the standard viewport meta tag and render the marker after persistent application chrome and before main content. The package cannot reserve safe space when a host puts the marker inside a fixed, absolute, clipped, or overlapping container.
 - DevAuth does not automatically inject a marker into arbitrary responses. Add it explicitly to the pages or local layout where the fake-auth state should be visible; the renderer self-suppresses outside allowed environments.
 - If persona selection returns a same-origin 403, make sure custom local UI posts from the same scheme, host, and port as the mapped DevAuth endpoints.
+- If persona selection leaves you in the persona lab, verify that the initial control-page URL contained a URI-encoded, rooted local `returnUrl`. Inspect the rendered form action when debugging; rejected values are intentionally omitted rather than diagnosed or redirected to `/`.
 
 ## Upgrade And Removal
 

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -26,6 +26,7 @@ This is the living release note for the next coordinated AppSurface version afte
 - AppSurface DevAuth now centralizes its environment activation policy. DevAuth remains Development-by-default, but
   package consumers can explicitly add local/proof environment names through `AllowedEnvironmentNames`; the marker
   self-suppresses outside allowed environments and mapped control/mutation endpoints stay fail-closed.
+- [`ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth`](../Auth/ForgeTrust.AppSurface.Auth.AspNetCore.DevAuth/README.md#return-to-the-host-page) control pages now preserve an explicitly supplied safe local `returnUrl` through every select-persona and clear-persona form, returning local proof workflows to the page under test. Missing or rejected targets remain omitted, while endpoint names, options, validation, cookies, loopback and same-origin guards, and local-redirect policy remain unchanged; no consumer migration is required.
 - Split stable and prerelease NuGet publish tag triggers so prerelease tags no longer start the stable publish workflow before the prerelease gate.
 - AppSurface DevAuth marker overlays now start collapsed by default while keeping the active fake persona visible, and
   `AppSurfaceDevAuthMarkerOptions.StartExpanded` lets local proof pages opt back into immediate persona controls.


### PR DESCRIPTION
## Summary

- Preserve a validated local `returnUrl` across every DevAuth control-page select and clear form.
- Reuse one documented mutation-action builder from the control page and persistent marker while retaining the existing validator, cookie behavior, loopback and same-origin guards, and `Results.LocalRedirect` policy.
- Document safe targets, fail-closed omission behavior, troubleshooting, and the linked unreleased note.

Fixes #655

## Test Coverage

All 12 changed code paths and user flows are covered (100% AI-assessed path coverage, 0 gaps, no tests generated during ship).

- Safe local, root, missing, blank, rejected, HTML-sensitive, and custom-prefix control-page targets
- Select and clear cookie mutation plus local redirect behavior
- Unsafe select and clear targets remain on the control response
- Marker select/clear actions, unsafe-target normalization, and hidden-controls behavior

Package coverage: **98.65% line, 90.49% branch, 99.11% method**.

## Pre-Landing Review

No issues found. Fresh ship review quality score: **10/10**.

## Design Review

No visual design behavior changed. Browser QA passed at desktop and 375×812 with no layout or interaction issues.

## Eval Results

No prompt-related files changed; evals were not applicable.

## Scope Drift

**CLEAN.** The draft implements the approved local-return propagation wedge without changing public API signatures, endpoint names, validation policy, cookies, loopback/same-origin protections, or release numbering.

## Plan Completion

- [x] Control-page GET validates the optional target and passes an explicit nullable renderer contract.
- [x] Shared documented mutation builder is used by both control-page and marker forms.
- [x] POST fallbacks, redirect behavior, and marker compatibility are regression-covered.
- [x] XML docs, package guidance, pitfalls, and linked unreleased note are complete.
- [x] Focused tests, full DevAuth tests, Release build, formatting, diff checks, and browser QA passed.
- [x] The full solution coverage runner's unrelated Aspire-host hang was replaced by package-scoped coverage above repository thresholds.

## Verification Results

- `dotnet test` DevAuth package: **119 passed, 0 failed**
- `dotnet build ForgeTrust.AppSurface.slnx --configuration Release --no-restore`: **succeeded, 0 warnings, 0 errors**
- `dotnet format ... --verify-no-changes`: passed
- `git diff --check`: passed
- DevAuth example verifier: passed
- Browser QA: **100 → 100 health, 0 issues**; safe admin redirect, expected viewer authorization result, clear-to-root, rejected external target, nested-query preservation, and mobile layout all passed

## Documentation

Documentation is current. The DevAuth package README documents the encoded local `returnUrl` recipe, endpoint behavior, validation constraints, fail-closed fallback, and troubleshooting. The unreleased note links directly to that guidance. No documentation debt or diagram drift was found.

## Test plan

- [x] Every rendered select and clear action carries one URI-escaped safe local target.
- [x] Missing or rejected targets render bare mutation actions and do not redirect externally.
- [x] Safe select/clear mutations preserve cookies and return through local redirects.
- [x] Custom prefixes, nested queries, HTML-sensitive values, marker compatibility, and narrow viewport behavior are verified.

🤖 Generated with Codex
