### PR TITLE
feat(release): classify Dependabot release evidence

### DIFF
--- a/.github/release-ops.md
+++ b/.github/release-ops.md
@@ -2,6 +2,45 @@
 
 This file lives under `.github/` on purpose so AppSurface Docs does not publish it as public documentation.
 
+<a id="release-contract-check"></a>
+
+## Dormant automatic release-contract classifier
+
+The versioned classifier in [`.github/scripts/release-contract-v1.mjs`](scripts/release-contract-v1.mjs)
+is base-owned maintainer tooling for a proposed, syntactic classification of pinned
+external-action updates. It is deliberately dormant in this change: the live
+release-contract workflow does not import it, and **no third release-evidence path
+is active yet**. The only active evidence paths remain an authored
+[`releases/unreleased.md`](../releases/unreleased.md) entry or the exact,
+case-sensitive `no-unreleased-entry` label described below.
+
+The classifier decides only whether public release prose is required. It does not
+approve action compatibility, supply-chain safety, CI health, review sufficiency,
+or merge safety. Conventional-title validation and ordinary branch protection are
+independent. A future integration change must activate the classifier from the
+trusted base revision and update this document before automatic evidence can pass
+the live check.
+
+Maintainers can reproduce a normalized input locally with Node.js 24. The command
+accepts a JSON file path, or reads the same JSON from standard input. A document may
+contain the classifier fields directly or wrap them as `{ "input": ..., "context": ... }`.
+It prints the same Markdown summary renderer intended for CI, exits 0 for a passing
+contract, 1 for a blocking contract diagnostic, and 2 for unreadable or invalid JSON.
+
+```bash
+node .github/scripts/release-contract-diagnose.mjs normalized-release-contract.json
+```
+
+Run the complete fail-closed parser and renderer suite with its exact coverage gate:
+
+```bash
+node --experimental-test-coverage \
+  --test-coverage-lines=100 \
+  --test-coverage-functions=100 \
+  --test-coverage-branches=100 \
+  --test .github/scripts/release-contract-v1.test.mjs
+```
+
 ## `no-unreleased-entry` label
 
 Use `no-unreleased-entry` only when a pull request does not belong in the public release story, such as:

--- a/.github/release-ops.md
+++ b/.github/release-ops.md
@@ -4,34 +4,92 @@ This file lives under `.github/` on purpose so AppSurface Docs does not publish 
 
 <a id="release-contract-check"></a>
 
-## Dormant automatic release-contract classifier
+## Release contract check
 
-The versioned classifier in [`.github/scripts/release-contract-v1.mjs`](scripts/release-contract-v1.mjs)
-is base-owned maintainer tooling for a proposed, syntactic classification of pinned
-external-action updates. It is deliberately dormant in this change: the live
-release-contract workflow does not import it, and **no third release-evidence path
-is active yet**. The only active evidence paths remain an authored
-[`releases/unreleased.md`](../releases/unreleased.md) entry or the exact,
-case-sensitive `no-unreleased-entry` label described below.
+The [release-contract workflow](workflows/release-contract.yml) accepts three
+release-evidence paths. It evaluates them in this order, while Conventional Commits
+title validation remains an independent requirement:
 
-The classifier decides only whether public release prose is required. It does not
-approve action compatibility, supply-chain safety, CI health, review sufficiency,
-or merge safety. Conventional-title validation and ordinary branch protection are
-independent. A future integration change must activate the classifier from the
-trusted base revision and update this document before automatic evidence can pass
-the live check.
+| Priority | Evidence | When to use it | Review consequence |
+| --- | --- | --- | --- |
+| 1 | Authored [`releases/unreleased.md`](../releases/unreleased.md) entry | The change is part of the adopter-visible release story. | Review the prose for accuracy. It takes precedence over both exemptions. |
+| 2 | Exact, case-sensitive `no-unreleased-entry` label | A maintainer has determined the change is outside the public release story. | Follow the [override runbook](#no-unreleased-entry-label) and remove the label if impact is later found. |
+| 3 | Automatic Dependabot classification | The exact bot identity and labels are present and every complete, bounded patch is syntactically limited to same-position pinned external-action references. | Release-note exemption only; all ordinary checks and review remain required. |
 
-Maintainers can reproduce a normalized input locally with Node.js 24. The command
-accepts a JSON file path, or reads the same JSON from standard input. A document may
-contain the classifier fields directly or wrap them as `{ "input": ..., "context": ... }`.
-It prints the same Markdown summary renderer intended for CI, exits 0 for a passing
-contract, 1 for a blocking contract diagnostic, and 2 for unreadable or invalid JSON.
+The automatic path decides only whether public release prose is required. It does
+not approve action compatibility, action behavior, supply-chain safety, CI health,
+review sufficiency, or merge safety. It is a textual, fail-closed classification of
+base-owned normalized evidence, not a YAML validity or semantic safety proof.
+Conventional-title validation, branch protection, CI, and ordinary human review are
+independent. There is no force-fail label: when a reviewer identifies adopter-visible
+impact, request an authored unreleased entry and remove any stale maintainer label.
+The authored entry then wins by evidence precedence.
+
+### Trusted-base and read-only boundary
+
+The workflow remains on `pull_request` with only `contents: read` and
+`pull-requests: read`. It checks out `github.event.pull_request.base.sha` into the
+isolated `.release-contract-policy` path, restricts sparse checkout to
+`.github/scripts`, disables persisted credentials, imports the module with
+`pathToFileURL()`, and requires `contractVersion === 1`. Pull-request code never
+supplies the policy executable. The job has no secrets, mutation, comments, label
+writes, `pull_request_target`, or write permission.
+
+The v1 classifier requires complete file enumeration and valid GitHub counts. It
+accepts at most 3,000 unique modified workflow YAML files, 128 KiB per patch,
+1 MiB aggregate patch data, and 8 KiB per patch line. Its linear unified-diff parser
+validates paired file headers when present, every hunk range and consumed line count,
+legal prefixes, complete input, and API addition/deletion totals. It rejects omitted,
+binary, combined, truncated, malformed, over-limit, CR, newline-marker, movement,
+reordering, input, permission, action-substitution, local, Docker, quoted, tag, and
+reusable-workflow evidence. Automatic rejection is informational when an earlier
+evidence path passes.
+
+### Override runbook
+
+Repository maintainers may apply `no-unreleased-entry` only after reviewing the
+actual diff and confirming that it is outside the adopter-facing release story.
+Apply it in the pull request Labels control or with:
+
+```bash
+gh pr edit <number> --add-label no-unreleased-entry
+```
+
+Record the rationale in normal review discussion when it is not self-evident. The
+label comparison is exact and case-sensitive. Remove it when scope changes, public
+impact is discovered, or an authored entry is requested:
+
+```bash
+gh pr edit <number> --remove-label no-unreleased-entry
+```
+
+An authored entry has higher precedence if both appear, but stale labels should still
+be removed so the audit trail matches the decision.
+
+### Troubleshooting and local reproduction
+
+Use the stable diagnostic leaf code in the check summary. Eligibility codes mean the
+evidence is outside the deliberately narrow automatic grammar; they do not mean the
+dependency update is unsafe. Add public prose or use the maintainer runbook after
+review. `infrastructure-event-invalid`, `infrastructure-api-failure`, `infrastructure-import-failure`,
+`infrastructure-version-mismatch`, `infrastructure-runtime-failure`, and
+`infrastructure-checkout-failure` fail the job rather than changing release evidence.
+Re-run once to distinguish a transient GitHub failure, then inspect the named checkout,
+API, import, or runtime boundary. Platform action-resolution failures remain in the
+standard step failure details because no repository script can run before the action
+resolves.
+
+Maintainers can reproduce normalized evidence with Node.js 24. The command accepts a
+JSON file path or standard input. A document may contain classifier fields directly or
+wrap them as `{ "input": ..., "context": ... }`. It prints the same bounded Markdown
+summary as CI, never renders patches, and exits 0 for pass, 1 for contract blockers,
+or 2 for unreadable or invalid JSON:
 
 ```bash
 node .github/scripts/release-contract-diagnose.mjs normalized-release-contract.json
 ```
 
-Run the complete fail-closed parser and renderer suite with its exact coverage gate:
+Run the classifier, renderer, and diagnostic-command suite with the ordinary-build gate:
 
 ```bash
 node --experimental-test-coverage \
@@ -40,6 +98,30 @@ node --experimental-test-coverage \
   --test-coverage-branches=100 \
   --test .github/scripts/release-contract-v1.test.mjs
 ```
+
+### Rollback and versioning
+
+Rollback triggers are any false exemption, classifier runtime failure, unexplained
+required-check result, or incompatible v1 output. Revert or disable the workflow
+integration first while retaining the v1 module. Use an authored entry for the
+rollback pull request, verify both manual evidence paths after the workflow can run,
+and remove dormant code only in a later change. A maintainer may temporarily adjust
+branch protection only when the required workflow cannot execute at all.
+
+Breaking classifier contracts must use a new module and contract version through the
+same bootstrap-then-integration sequence. Do not replace v1 and its importer in one
+pull request.
+
+### 6–8 week effectiveness checkpoint
+
+Six to eight weeks after activation, the AppSurface release maintainer reviews every
+GitHub Actions Dependabot pull request in the window. Record automatic exemption rate,
+leaf rejection codes, manual-label use, public-prose cases, false or misleading
+exemptions, missed release notes, runtime failures, and maintainer effort. Retain the
+classifier only with zero false or misleading exemptions, zero missed release notes,
+zero runtime failures, and at least a 50% exemption rate among syntactically eligible
+candidates. If fewer than three eligible candidates occur, extend observation by four
+weeks. End with an explicit **retain**, **narrow**, **expand**, or **remove** decision.
 
 ## `no-unreleased-entry` label
 

--- a/.github/scripts/release-contract-diagnose.mjs
+++ b/.github/scripts/release-contract-diagnose.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+import {
+  evaluateReleaseContractV1,
+  renderReleaseContractSummaryV1
+} from "./release-contract-v1.mjs";
+
+async function readInput() {
+  const path = process.argv[2];
+  if (path) {
+    return readFile(path, "utf8");
+  }
+
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+try {
+  const document = JSON.parse(await readInput());
+  const input = document?.input ?? document;
+  const context = document?.context ?? {};
+  const result = evaluateReleaseContractV1(input);
+  process.stdout.write(renderReleaseContractSummaryV1(result, context));
+  process.exitCode = result.diagnostics.some(item => item.blocking) ? 1 : 0;
+} catch (error) {
+  process.stderr.write(`release-contract-diagnose: ${error.message}\n`);
+  process.exitCode = 2;
+}

--- a/.github/scripts/release-contract-v1.mjs
+++ b/.github/scripts/release-contract-v1.mjs
@@ -1,0 +1,853 @@
+import { Buffer } from "node:buffer";
+
+/**
+ * Dormant v1 release-prose classifier for normalized pull-request evidence.
+ *
+ * This module is intentionally pure and read-only. It classifies only whether a
+ * pull request has accepted release evidence; it makes no compatibility,
+ * supply-chain, review, CI-health, or merge-safety judgment. Invalid JSON-shaped
+ * evidence returns deterministic diagnostics instead of throwing.
+ *
+ * @typedef {object} ReleaseContractFileV1
+ * @property {string} filename Repository-relative path returned by GitHub.
+ * @property {string} status GitHub file status; automatic classification accepts only `modified`.
+ * @property {number} additions Non-negative GitHub additions count.
+ * @property {number} deletions Non-negative GitHub deletions count.
+ * @property {number} changes Sum of additions and deletions.
+ * @property {string} patch Complete GitHub unified-diff patch.
+ *
+ * @typedef {object} ReleaseContractInputV1
+ * @property {string} title Pull-request title.
+ * @property {string} authorLogin Exact pull-request author login.
+ * @property {string[]} labels Exact, case-sensitive pull-request label names.
+ * @property {number} changedFiles Authoritative pull-request `changed_files` value.
+ * @property {ReleaseContractFileV1[]} files Complete, uniquely named file enumeration.
+ */
+
+/** Version checked by trusted-base workflow integration before evaluation. */
+export const contractVersion = 1;
+
+export const MaximumPullRequestFiles = 3000;
+export const MaximumPatchBytesPerFile = 128 * 1024;
+export const MaximumAggregatePatchBytes = 1024 * 1024;
+export const MaximumPatchLineBytes = 8 * 1024;
+
+const ConventionalTitlePattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+/;
+const WorkflowPathPattern = /^\.github\/workflows\/.+\.ya?ml$/;
+const UsesLinePattern = /^([ \t]*(?:-[ \t]+)?uses:[ \t]+)([A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)+)@([0-9a-f]{40})((?:[ \t]+#.*)?[ \t]*)$/;
+const HunkHeaderPattern = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$/;
+const DocumentationPath = ".github/release-ops.md#release-contract-check";
+const MaximumLocationLength = 256;
+
+function boundedText(value, maximumLength = MaximumLocationLength) {
+  return [...value].slice(0, maximumLength).join("");
+}
+
+function boundedLocation(location) {
+  return {
+    file: boundedText(location.file),
+    ...(location.hunk ? { hunk: location.hunk } : {})
+  };
+}
+
+function diagnostic(code, category, problem, cause, remediation, blocking = false, location = undefined) {
+  return {
+    code,
+    category,
+    problem,
+    cause,
+    remediation,
+    docsUrl: DocumentationPath,
+    blocking,
+    ...(location ? { location: boundedLocation(location) } : {})
+  };
+}
+
+function automaticDiagnostic(code, problem, cause, remediation, location = undefined) {
+  return diagnostic(code, "automatic-eligibility", problem, cause, remediation, false, location);
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonNegativeSafeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function isWorkflowPath(value) {
+  if (!WorkflowPathPattern.test(value) || value.includes("\0")) {
+    return false;
+  }
+
+  return value.slice(".github/workflows/".length).split("/").every(segment => segment !== "" && segment !== "." && segment !== "..");
+}
+
+function firstArrayProblem(value, itemPredicate) {
+  if (!Array.isArray(value)) {
+    return "not-array";
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (!(index in value) || !itemPredicate(value[index])) {
+      return "invalid-item";
+    }
+  }
+
+  if (new Set(value).size !== value.length) {
+    return "duplicate-item";
+  }
+
+  return null;
+}
+
+function parseHunkCount(value, omittedDefault) {
+  if (value === undefined) {
+    return omittedDefault;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function parseUsesLine(line) {
+  const match = UsesLinePattern.exec(line);
+  if (!match) {
+    return null;
+  }
+
+  const [, prefix, locator] = match;
+  const components = locator.split("/");
+  if (components.length < 2 || components.some(component => component === "." || component === "..")) {
+    return null;
+  }
+
+  for (let index = 2; index < components.length - 1; index += 1) {
+    if (components[index] === ".github" && components[index + 1] === "workflows") {
+      return null;
+    }
+  }
+
+  return `${prefix}${locator}@<PINNED-SHA>`;
+}
+
+function parsePatch(patch, filename) {
+  if (patch.includes("\r")) {
+    return {
+      error: automaticDiagnostic(
+        "patch-carriage-return",
+        "Patch evidence uses unsupported line endings.",
+        "The GitHub patch contains a carriage-return character, so its line structure is ambiguous.",
+        "Ask a maintainer to classify the pull request manually.",
+        { file: filename })
+    };
+  }
+
+  let lines = patch.split("\n");
+  if (lines.at(-1) === "") {
+    lines = lines.slice(0, -1);
+  }
+
+  if (lines.length === 0 || lines.some(line => Buffer.byteLength(line, "utf8") > MaximumPatchLineBytes)) {
+    return {
+      error: automaticDiagnostic(
+        "patch-line-limit",
+        "Patch evidence is empty or exceeds the supported line length.",
+        `Every patch line must be at most ${MaximumPatchLineBytes} UTF-8 bytes.`,
+        "Ask a maintainer to classify the pull request manually.",
+        { file: filename })
+    };
+  }
+
+  let index = 0;
+  if (lines[index]?.startsWith("--- ")) {
+    if (lines[index] !== `--- a/${filename}` || lines[index + 1] !== `+++ b/${filename}`) {
+      return {
+        error: automaticDiagnostic(
+          "patch-file-header-invalid",
+          "Patch file headers are incomplete.",
+          "A removed-file header was not followed by an added-file header.",
+          "Ask a maintainer to classify the pull request manually.",
+          { file: filename })
+      };
+    }
+
+    index += 2;
+  } else if (lines[index]?.startsWith("+++ ")) {
+    return {
+      error: automaticDiagnostic(
+        "patch-file-header-invalid",
+        "Patch file headers are incomplete.",
+        "An added-file header appeared without a preceding removed-file header.",
+        "Ask a maintainer to classify the pull request manually.",
+        { file: filename })
+    };
+  }
+
+  let additions = 0;
+  let deletions = 0;
+  let hunkIndex = 0;
+  const hunks = [];
+
+  while (index < lines.length) {
+    const header = HunkHeaderPattern.exec(lines[index]);
+    if (!header) {
+      return {
+        error: automaticDiagnostic(
+          "patch-hunk-header-invalid",
+          "Patch evidence contains unsupported metadata or a malformed hunk header.",
+          `Expected a unified-diff hunk header at line ${index + 1}.`,
+          "Ask a maintainer to classify the pull request manually.",
+          { file: filename, hunk: hunkIndex + 1 })
+      };
+    }
+
+    const oldStart = Number(header[1]);
+    const oldCount = parseHunkCount(header[2], 1);
+    const newStart = Number(header[3]);
+    const newCount = parseHunkCount(header[4], 1);
+    if (![oldStart, oldCount, newStart, newCount].every(Number.isSafeInteger)
+        || oldStart < 0
+        || oldCount < 0
+        || newStart < 0
+        || newCount < 0
+        || (oldStart === 0) !== (oldCount === 0)
+        || (newStart === 0) !== (newCount === 0)) {
+      return {
+        error: automaticDiagnostic(
+          "patch-hunk-range-invalid",
+          "Patch hunk ranges are invalid.",
+          "A hunk range is negative or larger than JavaScript can represent safely.",
+          "Ask a maintainer to classify the pull request manually.",
+          { file: filename, hunk: hunkIndex + 1 })
+      };
+    }
+
+    if (oldStart !== newStart || oldCount !== newCount) {
+      return {
+        error: automaticDiagnostic(
+          "patch-position-changed",
+          "The workflow reference did not remain in the same hunk position.",
+          "The old and new hunk ranges differ.",
+          "Review the workflow change and classify its release impact manually.",
+          { file: filename, hunk: hunkIndex + 1 })
+      };
+    }
+
+    index += 1;
+    hunkIndex += 1;
+    let consumedOld = 0;
+    let consumedNew = 0;
+    let hunkAdditions = 0;
+    let hunkDeletions = 0;
+    const oldLines = [];
+    const newLines = [];
+
+    while (index < lines.length && !lines[index].startsWith("@@ ")) {
+      const line = lines[index];
+      const prefix = line[0];
+      const content = line.slice(1);
+
+      if (prefix === " ") {
+        consumedOld += 1;
+        consumedNew += 1;
+        oldLines.push({ content, changed: false });
+        newLines.push({ content, changed: false });
+      } else if (prefix === "-") {
+        consumedOld += 1;
+        hunkDeletions += 1;
+        deletions += 1;
+        oldLines.push({ content, changed: true });
+      } else if (prefix === "+") {
+        consumedNew += 1;
+        hunkAdditions += 1;
+        additions += 1;
+        newLines.push({ content, changed: true });
+      } else {
+        return {
+          error: automaticDiagnostic(
+            prefix === "\\" ? "patch-newline-marker" : "patch-line-prefix-invalid",
+            "Patch evidence contains an unsupported line.",
+            prefix === "\\"
+              ? "Terminal newline markers are outside the automatic classifier contract."
+              : `Line ${index + 1} does not use a unified-diff prefix.`,
+            "Ask a maintainer to classify the pull request manually.",
+            { file: filename, hunk: hunkIndex })
+        };
+      }
+
+      index += 1;
+    }
+
+    if (consumedOld !== oldCount || consumedNew !== newCount) {
+      return {
+        error: automaticDiagnostic(
+          "patch-hunk-count-mismatch",
+          "Patch hunk evidence is incomplete.",
+          `The hunk header declares ${oldCount} old and ${newCount} new lines, but the patch contains ${consumedOld} old and ${consumedNew} new lines.`,
+          "Ask a maintainer to classify the pull request manually.",
+          { file: filename, hunk: hunkIndex })
+      };
+    }
+
+    if (hunkAdditions === 0 || hunkDeletions === 0) {
+      return {
+        error: automaticDiagnostic(
+          "patch-hunk-unpaired",
+          "A changed hunk does not contain a paired replacement.",
+          "Automatic exemption requires at least one removal and one addition in every hunk.",
+          "Review the workflow change and classify its release impact manually.",
+          { file: filename, hunk: hunkIndex })
+      };
+    }
+
+    hunks.push({ oldLines, newLines, hunk: hunkIndex });
+  }
+
+  if (hunkIndex === 0) {
+    return {
+      error: automaticDiagnostic(
+        "patch-hunk-missing",
+        "Patch evidence contains no changed hunks.",
+        "The pull-request files API did not return a usable unified diff.",
+        "Ask a maintainer to classify the pull request manually.",
+        { file: filename })
+    };
+  }
+
+  return { additions, deletions, hunks };
+}
+
+function indentation(line) {
+  return /^[ \t]*/.exec(line)[0].length;
+}
+
+function isBlockScalarContent(lines, changedIndex) {
+  const changedIndent = indentation(lines[changedIndex].content);
+  for (let index = changedIndex - 1; index >= 0; index -= 1) {
+    const candidate = lines[index].content;
+    if (candidate.trim().length === 0) {
+      continue;
+    }
+
+    const candidateIndent = indentation(candidate);
+    if (candidateIndent >= changedIndent) {
+      continue;
+    }
+
+    return /:\s*[|>](?:[+-]?\d?|\d?[+-])?\s*(?:#.*)?$/.test(candidate);
+  }
+
+  return false;
+}
+
+function precedingLowerIndentIndex(lines, startIndex, upperIndent) {
+  for (let index = startIndex - 1; index >= 0; index -= 1) {
+    if (lines[index].content.trim().length > 0 && indentation(lines[index].content) < upperIndent) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function isEligibleUsesPosition(lines, changedIndex) {
+  const changed = lines[changedIndex].content;
+  const changedIndent = indentation(changed);
+  const parentIndex = precedingLowerIndentIndex(lines, changedIndex, changedIndent);
+  if (parentIndex < 0) {
+    return false;
+  }
+
+  const parent = lines[parentIndex].content.trim();
+  if (changed.trimStart().startsWith("- ")) {
+    return parent === "steps:";
+  }
+
+  const parentIndent = indentation(lines[parentIndex].content);
+  const grandparentIndex = precedingLowerIndentIndex(lines, parentIndex, parentIndent);
+  if (grandparentIndex < 0) {
+    return false;
+  }
+
+  const grandparent = lines[grandparentIndex].content.trim();
+  return (parent.startsWith("- ") && grandparent === "steps:")
+    || (/^[A-Za-z0-9_.-]+:\s*(?:#.*)?$/.test(parent) && grandparent === "jobs:");
+}
+
+function validateChangedLines(parsed, filename) {
+  for (const hunk of parsed.hunks) {
+    const normalizedSides = [];
+    for (const [side, lines] of [["removal", hunk.oldLines], ["addition", hunk.newLines]]) {
+      const normalized = [];
+      for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (!line.changed) {
+          normalized.push(line.content);
+          continue;
+        }
+
+        const normalizedLine = parseUsesLine(line.content);
+        if (normalizedLine === null || isBlockScalarContent(lines, index) || !isEligibleUsesPosition(lines, index)) {
+          return automaticDiagnostic(
+            `uses-${side}-ineligible`,
+            `A ${side === "removal" ? "removed" : "added"} line is not an eligible pinned external-action reference.`,
+            "The line is quoted, unpinned, local, Docker-based, a reusable workflow, block-scalar content, or changes workflow semantics beyond the supported grammar.",
+            "Review the workflow change and classify its release impact manually.",
+            { file: filename, hunk: hunk.hunk });
+        }
+
+        normalized.push(normalizedLine);
+      }
+
+      normalizedSides.push(normalized);
+    }
+
+    const [normalizedOld, normalizedNew] = normalizedSides;
+    if (normalizedOld.length !== normalizedNew.length
+        || normalizedOld.some((line, lineIndex) => line !== normalizedNew[lineIndex])) {
+      return automaticDiagnostic(
+        "patch-normalized-content-changed",
+        "The workflow hunk changes more than pinned action versions or comments.",
+        "After normalizing eligible pins, the complete old and new hunk sequences differ.",
+        "Review the workflow change and classify its release impact manually.",
+        { file: filename, hunk: hunk.hunk });
+    }
+  }
+
+  return null;
+}
+
+function evaluateAutomaticExemption(input, labels, files) {
+  if (input.authorLogin !== "dependabot[bot]") {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "identity-not-dependabot",
+        "The pull request is not eligible for automatic release-note exemption.",
+        "The author is not exactly dependabot[bot].",
+        "Add release prose or ask a maintainer to apply no-unreleased-entry when appropriate.")
+    };
+  }
+
+  const labelsProblem = firstArrayProblem(labels, label => typeof label === "string" && label.length > 0);
+  if (labelsProblem !== null) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        `labels-${labelsProblem}`,
+        "Pull-request labels are malformed.",
+        "Labels must be a unique array of non-empty strings.",
+        "Retry the check or classify the pull request manually.")
+    };
+  }
+
+  if (!labels.includes("dependencies")) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "label-dependencies-missing",
+        "The Dependabot dependency label is missing.",
+        "Automatic exemption requires the exact dependencies label.",
+        "Restore the expected Dependabot labels or classify the pull request manually.")
+    };
+  }
+
+  if (!labels.includes("github_actions")) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "label-github-actions-missing",
+        "The GitHub Actions ecosystem label is missing.",
+        "Automatic exemption requires the exact github_actions label.",
+        "Restore the expected Dependabot labels or classify the pull request manually.")
+    };
+  }
+
+  if (!Number.isSafeInteger(input.changedFiles) || input.changedFiles <= 0) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "changed-files-invalid",
+        "The authoritative changed-file count is invalid.",
+        "changedFiles must be a positive safe integer.",
+        "Retry the check or classify the pull request manually.")
+    };
+  }
+
+  if (input.changedFiles > MaximumPullRequestFiles) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "changed-files-over-limit",
+        "The pull request is too large for complete file enumeration.",
+        `GitHub returns at most ${MaximumPullRequestFiles} pull-request files.`,
+        "Split the pull request or classify it manually.")
+    };
+  }
+
+  if (!Array.isArray(files)) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "files-not-array",
+        "Pull-request file evidence is malformed.",
+        "files must be an array.",
+        "Retry the check or classify the pull request manually.")
+    };
+  }
+
+  if (files.length !== input.changedFiles) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "changed-files-count-mismatch",
+        "Pull-request file enumeration is incomplete.",
+        `The event reports ${input.changedFiles} changed files, but the API returned ${files.length}.`,
+        "Retry the check or classify the pull request manually.")
+    };
+  }
+
+  for (let index = 0; index < files.length; index += 1) {
+    if (!(index in files) || !isRecord(files[index]) || typeof files[index].filename !== "string" || files[index].filename.length === 0) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: automaticDiagnostic(
+          "file-entry-invalid",
+          "Pull-request file evidence contains an invalid entry.",
+          "Every file must be an object with a non-empty filename.",
+          "Retry the check or classify the pull request manually.")
+      };
+    }
+  }
+
+  const filenames = files.map(file => file.filename);
+  if (new Set(filenames).size !== filenames.length) {
+    return {
+      automaticExemption: false,
+      automaticClassification: null,
+      automaticDiagnostic: automaticDiagnostic(
+        "file-duplicate",
+        "Pull-request file evidence contains duplicate filenames.",
+        "Complete API enumeration must contain each file exactly once.",
+        "Retry the check or classify the pull request manually.")
+    };
+  }
+
+  const sortedFiles = [...files].sort((left, right) => left.filename < right.filename ? -1 : 1);
+  for (const file of sortedFiles) {
+    if (file.status !== "modified") {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: automaticDiagnostic(
+          "file-status-ineligible",
+          "A changed file is not a modification.",
+          `Automatic exemption does not support the ${String(file.status)} file status.`,
+          "Review the file set and classify the pull request manually.",
+          { file: file.filename })
+      };
+    }
+
+    if (!isWorkflowPath(file.filename)) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: automaticDiagnostic(
+          "file-path-ineligible",
+          "A changed file is outside the supported workflow path.",
+          "Automatic exemption only supports YAML descendants of .github/workflows/.",
+          "Add release prose or ask a maintainer to classify the pull request.",
+          { file: file.filename })
+      };
+    }
+
+    if (![file.additions, file.deletions, file.changes].every(isNonNegativeSafeInteger)
+        || file.changes !== file.additions + file.deletions) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: automaticDiagnostic(
+          "file-counts-invalid",
+          "A workflow file has invalid change counts.",
+          "additions, deletions, and changes must be non-negative safe integers and changes must equal additions plus deletions.",
+          "Retry the check or classify the pull request manually.",
+          { file: file.filename })
+      };
+    }
+
+  }
+
+  let aggregatePatchBytes = 0;
+  for (const file of sortedFiles) {
+    if (typeof file.patch !== "string" || file.patch.length === 0) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: automaticDiagnostic(
+          "patch-missing",
+          "A workflow file has no complete patch evidence.",
+          "GitHub omitted or returned an empty unified patch.",
+          "Retry the check or classify the pull request manually.",
+          { file: file.filename })
+      };
+    }
+
+    const patchBytes = Buffer.byteLength(file.patch, "utf8");
+    aggregatePatchBytes += patchBytes;
+    if (patchBytes > MaximumPatchBytesPerFile || aggregatePatchBytes > MaximumAggregatePatchBytes) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: automaticDiagnostic(
+          patchBytes > MaximumPatchBytesPerFile ? "patch-file-size-limit" : "patch-aggregate-size-limit",
+          "Patch evidence exceeds the automatic classifier size limit.",
+          patchBytes > MaximumPatchBytesPerFile
+            ? `One patch exceeds ${MaximumPatchBytesPerFile} UTF-8 bytes.`
+            : `Aggregate patches exceed ${MaximumAggregatePatchBytes} UTF-8 bytes.`,
+          "Split the pull request or classify it manually.",
+          { file: file.filename })
+      };
+    }
+
+  }
+
+  const parsedFiles = [];
+  for (const file of sortedFiles) {
+    const parsed = parsePatch(file.patch, file.filename);
+    if (parsed.error) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: parsed.error
+      };
+    }
+
+    parsedFiles.push({ file, parsed });
+  }
+
+  for (const { file, parsed } of parsedFiles) {
+    if (parsed.additions !== file.additions || parsed.deletions !== file.deletions) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: automaticDiagnostic(
+          "patch-api-count-mismatch",
+          "Patch evidence does not match GitHub's file counts.",
+          `The patch contains ${parsed.additions} additions and ${parsed.deletions} deletions; the API reports ${file.additions} and ${file.deletions}.`,
+          "Retry the check or classify the pull request manually.",
+          { file: file.filename })
+      };
+    }
+  }
+
+  for (const { file, parsed } of parsedFiles) {
+    const semanticDiagnostic = validateChangedLines(parsed, file.filename);
+    if (semanticDiagnostic !== null) {
+      return {
+        automaticExemption: false,
+        automaticClassification: null,
+        automaticDiagnostic: semanticDiagnostic
+      };
+    }
+  }
+
+  return {
+    automaticExemption: true,
+    automaticClassification: "dependabot-github-actions-reference-only",
+    automaticDiagnostic: null
+  };
+}
+
+/**
+ * Evaluates authored, maintainer-label, and syntactic Dependabot release evidence.
+ * Evidence precedence is unreleased entry, exact maintainer label, then automatic
+ * classification. Conventional-title validation remains an independent blocker.
+ *
+ * @param {ReleaseContractInputV1 | unknown} input Normalized JSON-shaped evidence.
+ * @returns {object} Stable v1 result with evidence, classification, and structured diagnostics.
+ */
+export function evaluateReleaseContractV1(input) {
+  const normalizedInput = isRecord(input) ? input : {};
+  const title = typeof normalizedInput.title === "string" ? normalizedInput.title.trim() : "";
+  const labels = normalizedInput.labels;
+  const files = normalizedInput.files;
+  const conventionalTitleValid = ConventionalTitlePattern.test(title);
+  const labelsValid = firstArrayProblem(labels, label => typeof label === "string" && label.length > 0) === null;
+  const fileEntriesValid = Array.isArray(files)
+    && firstArrayProblem(files, file => isRecord(file) && typeof file.filename === "string" && file.filename.length > 0) === null
+    && new Set(files.map(file => file.filename)).size === files.length;
+  const hasUnreleasedEntry = fileEntriesValid && files.some(file => file.filename === "releases/unreleased.md");
+  const hasMaintainerExemptionLabel = labelsValid && labels.includes("no-unreleased-entry");
+  const automatic = evaluateAutomaticExemption(normalizedInput, labels, files);
+
+  let releaseEvidenceKind = "none";
+  if (hasUnreleasedEntry) {
+    releaseEvidenceKind = "unreleased-entry";
+  } else if (hasMaintainerExemptionLabel) {
+    releaseEvidenceKind = "maintainer-label";
+  } else if (automatic.automaticExemption) {
+    releaseEvidenceKind = "automatic-dependabot";
+  }
+
+  const diagnostics = [];
+  if (!conventionalTitleValid) {
+    diagnostics.push(diagnostic(
+      "conventional-title-invalid",
+      "title",
+      "The pull-request title does not follow Conventional Commits.",
+      "The title is missing an accepted type, optional scope, colon, or description.",
+      "Rename the pull request, for example: build(deps): update pinned GitHub Actions.",
+      true));
+  }
+
+  if (automatic.automaticDiagnostic !== null) {
+    diagnostics.push(automatic.automaticDiagnostic);
+  }
+
+  if (releaseEvidenceKind === "none") {
+    diagnostics.push(diagnostic(
+      "release-evidence-missing",
+      "release-evidence",
+      "The pull request has no accepted release evidence.",
+      "It does not update releases/unreleased.md, carry no-unreleased-entry, or qualify for automatic release-note exemption.",
+      "Add adopter-facing release prose, or ask a maintainer to apply no-unreleased-entry when the change is outside the public release story.",
+      true));
+  }
+
+  return {
+    contractVersion,
+    conventionalTitleValid,
+    hasUnreleasedEntry,
+    hasMaintainerExemptionLabel,
+    automaticExemption: automatic.automaticExemption,
+    automaticClassification: automatic.automaticClassification,
+    automaticDiagnostic: automatic.automaticDiagnostic,
+    releaseEvidenceKind,
+    diagnostics,
+    evidence: {
+      authorLogin: typeof normalizedInput.authorLogin === "string" ? normalizedInput.authorLogin : "",
+      labels: labelsValid ? [...labels] : [],
+      expectedChangedFiles: Number.isSafeInteger(normalizedInput.changedFiles) ? normalizedInput.changedFiles : null,
+      returnedChangedFiles: Array.isArray(files) ? files.length : null
+    }
+  };
+}
+
+function escapeMarkdown(value, maximumLength = 200) {
+  const text = String(value ?? "").slice(0, maximumLength);
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("|", "&#124;")
+    .replaceAll("`", "&#96;")
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ");
+}
+
+function documentationUrl(context) {
+  if (typeof context?.docsUrl === "string" && context.docsUrl.length > 0) {
+    return context.docsUrl;
+  }
+
+  const owner = escapeMarkdown(context?.owner ?? "OWNER");
+  const repo = escapeMarkdown(context?.repo ?? "REPOSITORY");
+  const ref = escapeMarkdown(context?.baseSha ?? "main");
+  return `https://github.com/${owner}/${repo}/blob/${ref}/.github/release-ops.md#release-contract-check`;
+}
+
+/**
+ * Renders the bounded, Markdown-escaped decision summary used by CI and local diagnostics.
+ * Patch content is never included.
+ *
+ * @param {ReturnType<typeof evaluateReleaseContractV1>} result Evaluated v1 result.
+ * @param {{owner?: string, repo?: string, baseSha?: string, docsUrl?: string}} context Trusted link context.
+ * @returns {string} Markdown beginning with Decision, Why, and What to do next.
+ */
+export function renderReleaseContractSummaryV1(result, context = {}) {
+  const blocking = result.diagnostics.filter(item => item.blocking);
+  const passed = blocking.length === 0;
+  const docsUrl = documentationUrl(context);
+  let why;
+  let next;
+
+  if (!passed) {
+    why = blocking.map(item => item.problem).join(" ");
+    next = blocking.map(item => item.remediation).join(" ");
+  } else if (result.releaseEvidenceKind === "unreleased-entry") {
+    why = "An authored releases/unreleased.md entry is present.";
+    next = "Review the release prose and all ordinary checks before merging.";
+  } else if (result.releaseEvidenceKind === "maintainer-label") {
+    why = "A maintainer applied the no-unreleased-entry exemption label.";
+    next = "Confirm the label remains appropriate and review all ordinary checks before merging.";
+  } else {
+    why = "The Dependabot change is syntactically limited to paired pinned external-action references.";
+    next = "Review compatibility and all ordinary checks; add releases/unreleased.md if behavior is adopter-visible.";
+  }
+
+  const lines = [
+    "## Decision",
+    "",
+    `**${passed ? "PASS" : "FAIL"}**`,
+    "",
+    "## Why",
+    "",
+    escapeMarkdown(why, 1000),
+    "",
+    "## What to do next",
+    "",
+    escapeMarkdown(next, 1000)
+  ];
+
+  if (result.releaseEvidenceKind === "automatic-dependabot") {
+    lines.push(
+      "",
+      "> **Release-note exemption only; all ordinary checks and review remain required.**");
+  }
+
+  lines.push(
+    "",
+    `<details><summary>Evidence and diagnostics</summary>`,
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    `| Contract version | ${escapeMarkdown(result.contractVersion)} |`,
+    `| Conventional title valid | ${escapeMarkdown(result.conventionalTitleValid)} |`,
+    `| Release evidence | ${escapeMarkdown(result.releaseEvidenceKind)} |`,
+    `| Automatic exemption | ${escapeMarkdown(result.automaticExemption)} |`,
+    `| Automatic classification | ${escapeMarkdown(result.automaticClassification ?? "none")} |`,
+    `| Author | ${escapeMarkdown(result.evidence.authorLogin || "unknown")} |`,
+    `| Labels | ${escapeMarkdown(result.evidence.labels.join(", ") || "none")} |`,
+    `| Expected files | ${escapeMarkdown(result.evidence.expectedChangedFiles ?? "unknown")} |`,
+    `| Returned files | ${escapeMarkdown(result.evidence.returnedChangedFiles ?? "unknown")} |`,
+    "");
+
+  if (result.diagnostics.length === 0) {
+    lines.push("No diagnostics.");
+  } else {
+    lines.push(
+      "| Code | Blocking | Problem | Cause | Remediation | Location |",
+      "| --- | --- | --- | --- | --- | --- |");
+    for (const item of result.diagnostics) {
+      const location = item.location
+        ? [item.location.file, item.location.hunk ? `hunk ${item.location.hunk}` : null, item.location.field]
+          .filter(Boolean)
+          .join(", ")
+        : "none";
+      lines.push(`| ${escapeMarkdown(item.code)} | ${escapeMarkdown(item.blocking)} | ${escapeMarkdown(item.problem)} | ${escapeMarkdown(item.cause)} | ${escapeMarkdown(item.remediation)} | ${escapeMarkdown(location)} |`);
+    }
+  }
+
+  lines.push("", `See [release-contract maintainer guidance](${escapeMarkdown(docsUrl, 500)}).`, "", "</details>");
+  return `${lines.join("\n")}\n`;
+}

--- a/.github/scripts/release-contract-v1.test.mjs
+++ b/.github/scripts/release-contract-v1.test.mjs
@@ -384,7 +384,7 @@ test("summary bounds and escapes all raw evidence and supports explicit docs URL
     labels: ["dependencies", "github_actions", hostile]
   }));
   const summary = renderReleaseContractSummaryV1(result, { docsUrl: "https://example.test/docs?a=1&b=2" });
-  assert.doesNotMatch(summary, /<script>/);
+  assert.equal(summary.includes("<script>"), false);
   assert.match(summary, /&lt;script&gt;&#124;&#96;x&#96;/);
   assert.match(summary, /https:\/\/example\.test\/docs\?a=1&amp;b=2/);
   assert.ok(summary.length < 10_000);

--- a/.github/scripts/release-contract-v1.test.mjs
+++ b/.github/scripts/release-contract-v1.test.mjs
@@ -1,0 +1,443 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  MaximumAggregatePatchBytes,
+  MaximumPatchBytesPerFile,
+  MaximumPatchLineBytes,
+  MaximumPullRequestFiles,
+  contractVersion,
+  evaluateReleaseContractV1,
+  renderReleaseContractSummaryV1
+} from "./release-contract-v1.mjs";
+
+const oldPin = "1111111111111111111111111111111111111111";
+const newPin = "2222222222222222222222222222222222222222";
+
+function patch(oldReference = `actions/checkout@${oldPin}`, newReference = `actions/checkout@${newPin}`, options = {}) {
+  const indent = options.indent ?? "      ";
+  const suffixOld = options.suffixOld ?? "";
+  const suffixNew = options.suffixNew ?? "";
+  const context = options.context ?? ["jobs:", "  build:"];
+  const oldLines = [...context, `${indent}uses: ${oldReference}${suffixOld}`];
+  const newLines = [...context, `${indent}uses: ${newReference}${suffixNew}`];
+  const body = [
+    ...context.map(line => ` ${line}`),
+    `-${indent}uses: ${oldReference}${suffixOld}`,
+    `+${indent}uses: ${newReference}${suffixNew}`
+  ];
+  return `@@ -1,${oldLines.length} +1,${newLines.length} @@\n${body.join("\n")}`;
+}
+
+function file(overrides = {}) {
+  return {
+    filename: ".github/workflows/build.yml",
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    changes: 2,
+    patch: patch(),
+    ...overrides
+  };
+}
+
+function input(overrides = {}) {
+  const files = overrides.files ?? [file()];
+  return {
+    title: "build(deps): bump actions/checkout",
+    authorLogin: "dependabot[bot]",
+    labels: ["dependencies", "github_actions"],
+    changedFiles: files.length,
+    files,
+    ...overrides
+  };
+}
+
+function codeFor(overrides) {
+  return evaluateReleaseContractV1(input(overrides)).automaticDiagnostic?.code ?? null;
+}
+
+function summaryDigest(result, context) {
+  return createHash("sha256").update(renderReleaseContractSummaryV1(result, context)).digest("hex");
+}
+
+test("exports the v1 public constants", () => {
+  assert.equal(contractVersion, 1);
+  assert.equal(MaximumPullRequestFiles, 3000);
+  assert.equal(MaximumPatchBytesPerFile, 128 * 1024);
+  assert.equal(MaximumAggregatePatchBytes, 1024 * 1024);
+  assert.equal(MaximumPatchLineBytes, 8 * 1024);
+});
+
+test("accepts the documented 3,000-file boundary and an exact per-patch byte limit", () => {
+  const files = Array.from({ length: MaximumPullRequestFiles }, (_, index) => file({
+    filename: `.github/workflows/generated/${String(index).padStart(4, "0")}.yml`
+  }));
+  assert.equal(evaluateReleaseContractV1(input({ files, changedFiles: files.length })).automaticExemption, true);
+
+  const hunkCount = 20;
+  const makeSizedPatch = fillers => Array.from({ length: hunkCount }, (_, index) => [
+    `@@ -${index * 3 + 1},3 +${index * 3 + 1},3 @@`,
+    " jobs:",
+    "   generated:",
+    `-    uses: owner/action@${oldPin} # ${"x".repeat(fillers[index * 2])}`,
+    `+    uses: owner/action@${newPin} # ${"x".repeat(fillers[index * 2 + 1])}`
+  ].join("\n")).join("\n");
+  const fillers = Array(hunkCount * 2).fill(0);
+  const remaining = MaximumPatchBytesPerFile - Buffer.byteLength(makeSizedPatch(fillers));
+  for (let index = 0; index < remaining; index += 1) {
+    fillers[index % fillers.length] += 1;
+  }
+  const maximumPatch = makeSizedPatch(fillers);
+  assert.equal(Buffer.byteLength(maximumPatch), MaximumPatchBytesPerFile);
+  assert.equal(codeFor({
+    files: [file({ additions: hunkCount, deletions: hunkCount, changes: hunkCount * 2, patch: maximumPatch })]
+  }), null);
+});
+
+test("classifies the PR 622 shape and preserves independent title validation", () => {
+  const result = evaluateReleaseContractV1(input());
+  assert.deepEqual(
+    {
+      title: result.conventionalTitleValid,
+      note: result.hasUnreleasedEntry,
+      label: result.hasMaintainerExemptionLabel,
+      automatic: result.automaticExemption,
+      classification: result.automaticClassification,
+      diagnostic: result.automaticDiagnostic,
+      evidence: result.releaseEvidenceKind,
+      diagnostics: result.diagnostics
+    },
+    {
+      title: true,
+      note: false,
+      label: false,
+      automatic: true,
+      classification: "dependabot-github-actions-reference-only",
+      diagnostic: null,
+      evidence: "automatic-dependabot",
+      diagnostics: []
+    });
+
+  const invalid = evaluateReleaseContractV1(input({ title: "Bump checkout" }));
+  assert.equal(invalid.automaticExemption, true);
+  assert.equal(invalid.releaseEvidenceKind, "automatic-dependabot");
+  assert.deepEqual(invalid.diagnostics.map(item => [item.code, item.blocking]), [["conventional-title-invalid", true]]);
+});
+
+test("supports grouped files, multiple hunks, YAML extensions, list syntax, and comment-only pin changes", () => {
+  const firstPatch = [
+    "--- a/.github/workflows/a.yml",
+    "+++ b/.github/workflows/a.yml",
+    `@@ -1,2 +1,2 @@ task`,
+    "  steps:",
+    `-    - uses: owner/action/sub@${oldPin} # v1`,
+    `+    - uses: owner/action/sub@${newPin} # v2`,
+    "@@ -20,3 +20,3 @@",
+    " jobs:",
+    "   other:",
+    `-    uses: owner/other@${oldPin} # old release`,
+    `+    uses: owner/other@${newPin} # new release`
+  ].join("\n");
+  const files = [
+    file({ filename: ".github/workflows/nested/b.yaml" }),
+    file({ filename: ".github/workflows/a.yml", additions: 2, deletions: 2, changes: 4, patch: firstPatch })
+  ];
+  const result = evaluateReleaseContractV1(input({ files, changedFiles: 2 }));
+  assert.equal(result.automaticExemption, true);
+});
+
+test("authored entry and exact maintainer label take precedence over automatic classification", () => {
+  const releaseFile = file({
+    filename: "releases/unreleased.md",
+    status: "modified",
+    patch: "not relevant because earlier evidence is independently detected"
+  });
+  const authored = evaluateReleaseContractV1(input({ authorLogin: "human", files: [releaseFile], changedFiles: 1 }));
+  assert.equal(authored.releaseEvidenceKind, "unreleased-entry");
+  assert.equal(authored.hasUnreleasedEntry, true);
+  assert.equal(authored.automaticDiagnostic.code, "identity-not-dependabot");
+  assert.equal(authored.diagnostics.some(item => item.blocking), false);
+
+  const labeled = evaluateReleaseContractV1(input({
+    authorLogin: "human",
+    labels: ["dependencies", "github_actions", "no-unreleased-entry"]
+  }));
+  assert.equal(labeled.releaseEvidenceKind, "maintainer-label");
+  assert.equal(labeled.hasMaintainerExemptionLabel, true);
+  assert.equal(labeled.diagnostics.some(item => item.blocking), false);
+
+  const wrongCase = evaluateReleaseContractV1(input({
+    authorLogin: "human",
+    labels: ["dependencies", "github_actions", "No-Unreleased-Entry"]
+  }));
+  assert.equal(wrongCase.releaseEvidenceKind, "none");
+  assert.deepEqual(wrongCase.diagnostics.map(item => item.code), ["identity-not-dependabot", "release-evidence-missing"]);
+});
+
+test("validation precedence is identity, labels, aggregate schema, sorted files, patch, then changed lines", () => {
+  assert.equal(codeFor({ authorLogin: "dependabot", labels: null, changedFiles: 0, files: null }), "identity-not-dependabot");
+  assert.equal(codeFor({ labels: null, changedFiles: 0, files: null }), "labels-not-array");
+  assert.equal(codeFor({ labels: ["dependencies", 2], changedFiles: 0, files: null }), "labels-invalid-item");
+  assert.equal(codeFor({ labels: ["dependencies", "dependencies"], changedFiles: 0, files: null }), "labels-duplicate-item");
+  assert.equal(codeFor({ labels: ["github_actions"], changedFiles: 0, files: null }), "label-dependencies-missing");
+  assert.equal(codeFor({ labels: ["dependencies"], changedFiles: 0, files: null }), "label-github-actions-missing");
+  assert.equal(codeFor({ changedFiles: 0, files: null }), "changed-files-invalid");
+  assert.equal(codeFor({ changedFiles: MaximumPullRequestFiles + 1, files: [] }), "changed-files-over-limit");
+  assert.equal(codeFor({ changedFiles: 1, files: null }), "files-not-array");
+  assert.equal(codeFor({ changedFiles: 2, files: [file()] }), "changed-files-count-mismatch");
+  assert.equal(codeFor({ changedFiles: 1, files: [null] }), "file-entry-invalid");
+  assert.equal(codeFor({ changedFiles: 1, files: [{ filename: "" }] }), "file-entry-invalid");
+  assert.equal(codeFor({ changedFiles: 2, files: [file(), file()] }), "file-duplicate");
+
+  const lateBad = file({ filename: ".github/workflows/z.yml", status: "added", patch: "bad" });
+  const earlyBad = file({ filename: ".github/workflows/a.yml", status: "removed", patch: "bad" });
+  assert.equal(codeFor({ changedFiles: 2, files: [lateBad, earlyBad] }), "file-status-ineligible");
+  assert.equal(evaluateReleaseContractV1(input({ changedFiles: 2, files: [lateBad, earlyBad] })).automaticDiagnostic.location.file, earlyBad.filename);
+});
+
+test("rejects ineligible status, paths, counts, missing patches, and exact size boundaries", () => {
+  assert.equal(codeFor({ files: [file({ status: "renamed" })] }), "file-status-ineligible");
+  assert.equal(codeFor({ files: [file({ filename: ".github/workflows.yml" })] }), "file-path-ineligible");
+  assert.equal(codeFor({ files: [file({ filename: ".github/workflows/build.json" })] }), "file-path-ineligible");
+  assert.equal(codeFor({ files: [file({ additions: -1 })] }), "file-counts-invalid");
+  assert.equal(codeFor({ files: [file({ additions: 1.5 })] }), "file-counts-invalid");
+  assert.equal(codeFor({ files: [file({ changes: 99 })] }), "file-counts-invalid");
+  assert.equal(codeFor({ files: [file({ patch: null })] }), "patch-missing");
+  assert.equal(codeFor({ files: [file({ patch: "" })] }), "patch-missing");
+
+  const tooLarge = `@@ -1 +1 @@\n-${"a".repeat(MaximumPatchBytesPerFile)}\n+${"a".repeat(MaximumPatchBytesPerFile)}`;
+  assert.equal(codeFor({ files: [file({ patch: tooLarge })] }), "patch-file-size-limit");
+
+  const largePatch = Array.from({ length: 700 }, (_, index) => [
+    `@@ -${index + 1} +${index + 1} @@`,
+    `-uses: owner/action@${oldPin} # ${"a".repeat(20)}`,
+    `+uses: owner/action@${newPin} # ${"a".repeat(20)}`
+  ].join("\n")).join("\n");
+  assert.ok(Buffer.byteLength(largePatch) < MaximumPatchBytesPerFile);
+  const files = Array.from({ length: 10 }, (_, index) => file({
+    filename: `.github/workflows/${index}.yml`,
+    additions: 700,
+    deletions: 700,
+    changes: 1400,
+    patch: largePatch
+  }));
+  assert.equal(codeFor({ files, changedFiles: files.length }), "patch-aggregate-size-limit");
+});
+
+test("rejects malformed unified diffs with stable structural leaf codes", () => {
+  const cases = [
+    ["patch-carriage-return", `${patch()}\r`],
+    ["patch-line-limit", `@@ -1 +1 @@\n-${"x".repeat(MaximumPatchLineBytes + 1)}\n+x`],
+    ["patch-file-header-invalid", "--- a/x\n@@ -1 +1 @@\n-a\n+b"],
+    ["patch-file-header-invalid", "+++ b/x\n@@ -1 +1 @@\n-a\n+b"],
+    ["patch-hunk-header-invalid", "diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b"],
+    ["patch-hunk-header-invalid", "@@@ -1 +1 @@@\n-a\n+b"],
+    ["patch-hunk-range-invalid", "@@ -9007199254740992 +9007199254740992 @@\n-a\n+b"],
+    ["patch-hunk-range-invalid", "@@ -1,9007199254740992 +1,9007199254740992 @@\n-a\n+b"],
+    ["patch-hunk-range-invalid", "@@ -0,1 +0,1 @@\n-a\n+b"],
+    ["patch-position-changed", "@@ -1 +2 @@\n-a\n+b"],
+    ["patch-hunk-count-mismatch", "@@ -1,2 +1,2 @@\n-a\n+b"],
+    ["patch-newline-marker", "@@ -1,2 +1,2 @@\n-a\n+b\n\\ No newline at end of file"],
+    ["patch-line-prefix-invalid", "@@ -1 +1 @@\n?a\n+b"],
+    ["patch-hunk-unpaired", "@@ -1 +1 @@\n a"],
+    ["patch-hunk-missing", "--- a/.github/workflows/build.yml\n+++ b/.github/workflows/build.yml"]
+  ];
+  for (const [expected, malformed] of cases) {
+    assert.equal(codeFor({ files: [file({ patch: malformed })] }), expected, expected);
+  }
+});
+
+test("rejects every unsupported uses shape and semantic substitution", () => {
+  const eligible = [
+    [`owner/action@${oldPin}`, `owner/action@${newPin}`],
+    [`owner/action/sub@${oldPin}`, `owner/action/sub@${newPin}`]
+  ];
+  for (const [oldReference, newReference] of eligible) {
+    assert.equal(codeFor({ files: [file({ patch: patch(oldReference, newReference) })] }), null);
+  }
+  assert.equal(codeFor({ files: [file({ patch: patch(`owner/./action@${oldPin}`, `owner/action@${newPin}`) })] }), "uses-removal-ineligible");
+
+  const rejected = [
+    ["tag", "owner/action@v4"],
+    ["uppercase SHA", `owner/action@${"A".repeat(40)}`],
+    ["short SHA", `owner/action@${oldPin.slice(1)}`],
+    ["non-comment suffix", `owner/action@${oldPin}#suffix`],
+    ["quoted", `\"owner/action@${oldPin}\"`],
+    ["local", `./action@${oldPin}`],
+    ["Docker", `docker://alpine@${oldPin}`],
+    ["reusable workflow", `owner/repo/.github/workflows/build.yml@${oldPin}`]
+  ];
+  for (const [name, reference] of rejected) {
+    assert.equal(codeFor({ files: [file({ patch: patch(reference, `owner/action@${newPin}`) })] }), "uses-removal-ineligible", name);
+    assert.equal(codeFor({ files: [file({ patch: patch(`owner/action@${oldPin}`, reference) })] }), "uses-addition-ineligible", name);
+  }
+
+  assert.equal(codeFor({ files: [file({ patch: patch(`owner/action@${oldPin}`, `other/action@${newPin}`) })] }), "patch-normalized-content-changed");
+  const moved = `@@ -1,3 +1,3 @@\n jobs:\n   build:\n-    uses: owner/action@${oldPin}\n+      uses: owner/action@${newPin}`;
+  assert.equal(codeFor({ files: [file({ patch: moved })] }), "patch-normalized-content-changed");
+  assert.equal(codeFor({ files: [file({ patch: patch(`owner/action@${oldPin}`, `owner/action@${newPin}`, { suffixNew: " # changed" }) })] }), null);
+
+  const scalar = `@@ -1,2 +1,2 @@\n run: |\n-  uses: owner/action@${oldPin}\n+  uses: owner/action@${newPin}`;
+  assert.equal(codeFor({ files: [file({ patch: scalar })] }), "uses-removal-ineligible");
+  const scalarWithBlank = `@@ -1,3 +1,3 @@\n run: >-\n \n-  uses: owner/action@${oldPin}\n+  uses: owner/action@${newPin}`;
+  assert.equal(codeFor({ files: [file({ patch: scalarWithBlank })] }), "uses-removal-ineligible");
+
+  for (const mapping of ["with", "env", "permissions"]) {
+    const lookalike = `@@ -1,4 +1,4 @@\n jobs:\n   build:\n     ${mapping}:\n-      uses: owner/action@${oldPin}\n+      uses: owner/action@${newPin}`;
+    assert.equal(codeFor({ files: [file({ patch: lookalike })] }), "uses-removal-ineligible", mapping);
+  }
+
+  const step = `@@ -1,4 +1,4 @@\n jobs:\n   build:\n     steps:\n-      - uses: owner/action@${oldPin}\n+      - uses: owner/action@${newPin}`;
+  assert.equal(codeFor({ files: [file({ patch: step })] }), null);
+
+  const namedStep = `@@ -1,5 +1,5 @@\n jobs:\n   build:\n     steps:\n       - name: Build\n-        uses: owner/action@${oldPin}\n+        uses: owner/action@${newPin}`;
+  assert.equal(codeFor({ files: [file({ patch: namedStep })] }), null);
+
+  const noParent = `@@ -1 +1 @@\n-uses: owner/action@${oldPin}\n+uses: owner/action@${newPin}`;
+  assert.equal(codeFor({ files: [file({ patch: noParent })] }), "uses-removal-ineligible");
+  const noGrandparent = `@@ -1,2 +1,2 @@\n build:\n-  uses: owner/action@${oldPin}\n+  uses: owner/action@${newPin}`;
+  assert.equal(codeFor({ files: [file({ patch: noGrandparent })] }), "uses-removal-ineligible");
+});
+
+test("rejects movement, reordering, unequal pairs, mixed changes, and API count mismatch", () => {
+  const reordered = [
+    "@@ -1,4 +1,4 @@",
+    " jobs:",
+    "   build:",
+    `-    uses: one/action@${oldPin}`,
+    `-    uses: two/action@${oldPin}`,
+    `+    uses: two/action@${newPin}`,
+    `+    uses: one/action@${newPin}`
+  ].join("\n");
+  assert.equal(codeFor({ files: [file({ additions: 2, deletions: 2, changes: 4, patch: reordered })] }), "patch-normalized-content-changed");
+  assert.equal(codeFor({ files: [file({ patch: patch(), additions: 2, changes: 3 })] }), "patch-api-count-mismatch");
+  assert.equal(codeFor({ files: [file({ patch: "@@ -1,3 +1,3 @@\n jobs:\n   build:\n-    uses: x/action@1111111111111111111111111111111111111111\n+    permissions: write" })] }), "uses-addition-ineligible");
+});
+
+test("is total for JSON-shaped null, missing, sparse, duplicate, and wrong-typed values", () => {
+  for (const value of [null, undefined, true, 12, "input", [], {}]) {
+    const result = evaluateReleaseContractV1(value);
+    assert.equal(result.conventionalTitleValid, false);
+    assert.equal(result.releaseEvidenceKind, "none");
+    assert.ok(result.diagnostics.some(item => item.blocking));
+  }
+
+  const sparseLabels = [];
+  sparseLabels.length = 1;
+  assert.equal(evaluateReleaseContractV1(input({ labels: sparseLabels })).automaticDiagnostic.code, "labels-invalid-item");
+  const sparseFiles = [];
+  sparseFiles.length = 1;
+  assert.equal(evaluateReleaseContractV1(input({ files: sparseFiles, changedFiles: 1 })).automaticDiagnostic.code, "file-entry-invalid");
+  assert.equal(codeFor({ changedFiles: Number.MAX_SAFE_INTEGER + 1 }), "changed-files-invalid");
+});
+
+test("title grammar matches the live conventional-title policy", () => {
+  for (const title of ["feat: x", "fix(ui): x", "chore!: x", "ci(scope)!: x", "revert: x"]) {
+    assert.equal(evaluateReleaseContractV1(input({ title })).conventionalTitleValid, true, title);
+  }
+  for (const title of ["", "feature: x", "feat x", " feat: x ", "feat(): x", "feat:"]) {
+    assert.equal(evaluateReleaseContractV1(input({ title })).conventionalTitleValid, title === " feat: x ", title);
+  }
+});
+
+test("renders exact golden summaries for automatic, authored, label, title failure, and rejection", () => {
+  const context = { owner: "forge-trust", repo: "AppSurface", baseSha: "abc123" };
+  const automatic = renderReleaseContractSummaryV1(evaluateReleaseContractV1(input()), context);
+  assert.match(automatic, /^## Decision\n\n\*\*PASS\*\*\n\n## Why\n/);
+  assert.match(automatic, /Release-note exemption only; all ordinary checks and review remain required\./);
+  assert.match(automatic, /blob\/abc123\/\.github\/release-ops\.md#release-contract-check/);
+  assert.doesNotMatch(automatic, /1111111111111111111111111111111111111111/);
+
+  const authored = evaluateReleaseContractV1(input({ authorLogin: "human", files: [file({ filename: "releases/unreleased.md" })], changedFiles: 1 }));
+  assert.match(renderReleaseContractSummaryV1(authored, context), /An authored releases\/unreleased\.md entry is present\./);
+  const labeled = evaluateReleaseContractV1(input({ authorLogin: "human", labels: ["no-unreleased-entry", "dependencies", "github_actions"] }));
+  assert.match(renderReleaseContractSummaryV1(labeled, context), /A maintainer applied the no-unreleased-entry exemption label\./);
+  assert.match(renderReleaseContractSummaryV1(evaluateReleaseContractV1(input({ title: "bad" })), context), /## Decision\n\n\*\*FAIL\*\*/);
+  assert.match(renderReleaseContractSummaryV1(evaluateReleaseContractV1(input({ authorLogin: "human" })), context), /identity-not-dependabot/);
+
+  assert.deepEqual([
+    summaryDigest(evaluateReleaseContractV1(input()), context),
+    summaryDigest(authored, context),
+    summaryDigest(labeled, context),
+    summaryDigest(evaluateReleaseContractV1(input({ title: "bad" })), context),
+    summaryDigest(evaluateReleaseContractV1(input({ authorLogin: "human" })), context)
+  ], [
+    "b97350a5e5b1baae072db45ebface5cb72740e37abaa53510c64d790c3eeb1f6",
+    "448fca479a020008da8e8659219ccf90bc54877e9f2ca6b79acb2c25a6abd718",
+    "52a0e538c4a817ae23794d398b97cbf5d402a36626d43e49f76553ca6a4bd35a",
+    "0191d39af2f715bd52f45431c9b7e00d3726a00e426206773598571224ffbae2",
+    "b750cc348c5c73240a443e438f2f8302f095a10908a00a3b037f8c7bf94e5bf5"
+  ]);
+});
+
+test("summary bounds and escapes all raw evidence and supports explicit docs URLs", () => {
+  const hostile = `<script>|\`x\`\n${"z".repeat(500)}`;
+  const result = evaluateReleaseContractV1(input({
+    authorLogin: hostile,
+    labels: ["dependencies", "github_actions", hostile]
+  }));
+  const summary = renderReleaseContractSummaryV1(result, { docsUrl: "https://example.test/docs?a=1&b=2" });
+  assert.doesNotMatch(summary, /<script>/);
+  assert.match(summary, /&lt;script&gt;&#124;&#96;x&#96;/);
+  assert.match(summary, /https:\/\/example\.test\/docs\?a=1&amp;b=2/);
+  assert.ok(summary.length < 10_000);
+
+  const emptyResult = evaluateReleaseContractV1(null);
+  const defaults = renderReleaseContractSummaryV1(emptyResult);
+  assert.match(defaults, /github\.com\/OWNER\/REPOSITORY\/blob\/main/);
+  assert.match(defaults, /\| Author \| unknown \|/);
+  assert.match(defaults, /\| Labels \| none \|/);
+  assert.match(defaults, /\| Expected files \| unknown \|/);
+  assert.match(defaults, /\| Returned files \| unknown \|/);
+
+  const located = renderReleaseContractSummaryV1(
+    evaluateReleaseContractV1(input({ files: [file({ patch: `${patch()}\n` })] })),
+    { owner: "o", repo: "r", baseSha: "s" });
+  assert.match(located, /No diagnostics\./);
+
+  const malformed = renderReleaseContractSummaryV1(
+    evaluateReleaseContractV1(input({ files: [file({ patch: "@@ -1 +1 @@\n-x\n+y" })] })),
+    { owner: "o", repo: "r", baseSha: "s" });
+  assert.match(malformed, /\.github\/workflows\/build\.yml, hunk 1/);
+
+  const missingPatch = renderReleaseContractSummaryV1(
+    evaluateReleaseContractV1(input({ files: [file({ patch: null })] })),
+    { owner: "o", repo: "r", baseSha: "s" });
+  assert.match(missingPatch, /\.github\/workflows\/build\.yml \|/);
+
+  const nullContract = { ...emptyResult, contractVersion: null };
+  assert.match(renderReleaseContractSummaryV1(nullContract), /\| Contract version \|  \|/);
+});
+
+test("diagnostic CLI supports stdin, wrapper files, renderer parity, and stable exit statuses", () => {
+  const cli = fileURLToPath(new URL("./release-contract-diagnose.mjs", import.meta.url));
+  const validInput = input();
+  const stdinRun = spawnSync(process.execPath, [cli], { input: JSON.stringify(validInput), encoding: "utf8" });
+  assert.equal(stdinRun.status, 0);
+  assert.equal(stdinRun.stdout, renderReleaseContractSummaryV1(evaluateReleaseContractV1(validInput)));
+  assert.equal(stdinRun.stderr, "");
+
+  const directory = mkdtempSync(join(tmpdir(), "release-contract-v1-"));
+  const inputPath = join(directory, "input.json");
+  const context = { owner: "forge-trust", repo: "AppSurface", baseSha: "base" };
+  writeFileSync(inputPath, JSON.stringify({ input: validInput, context }));
+  const fileRun = spawnSync(process.execPath, [cli, inputPath], { encoding: "utf8" });
+  assert.equal(fileRun.status, 0);
+  assert.equal(fileRun.stdout, renderReleaseContractSummaryV1(evaluateReleaseContractV1(validInput), context));
+
+  const blockingRun = spawnSync(process.execPath, [cli], { input: "{}", encoding: "utf8" });
+  assert.equal(blockingRun.status, 1);
+  assert.match(blockingRun.stdout, /\*\*FAIL\*\*/);
+
+  const invalidRun = spawnSync(process.execPath, [cli], { input: "not-json", encoding: "utf8" });
+  assert.equal(invalidRun.status, 2);
+  assert.match(invalidRun.stderr, /^release-contract-diagnose:/);
+  rmSync(directory, { recursive: true });
+});

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: Web/pnpm-lock.yaml
 
+      - name: Test dormant release-contract classifier
+        run: node --experimental-test-coverage --test-coverage-lines=100 --test-coverage-functions=100 --test-coverage-branches=100 --test .github/scripts/release-contract-v1.test.mjs
+
       - name: Verify generated package chooser
         run: |
           dotnet run --project tools/ForgeTrust.AppSurface.PackageIndex/ForgeTrust.AppSurface.PackageIndex.csproj --configuration Release --no-restore -- verify

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -20,57 +20,184 @@ permissions:
 jobs:
   enforce:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Validate PR title and unreleased entry
+      - name: Checkout trusted base release policy
+        id: policy-checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .release-contract-policy
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Evaluate trusted release contract
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
+            const { pathToFileURL } = await import("node:url");
             const pr = context.payload.pull_request;
 
-            if (!pr) {
-              core.setFailed("This workflow only supports pull_request events.");
+            const escape = value => String(value ?? "")
+              .slice(0, 500)
+              .replaceAll("&", "&amp;")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;")
+              .replaceAll("|", "&#124;")
+              .replaceAll("`", "&#96;")
+              .replaceAll("\r", " ")
+              .replaceAll("\n", " ");
+
+            const writeInfrastructureFailure = async (code, problem, cause, remediation) => {
+              const baseSha = typeof pr?.base?.sha === "string" ? pr.base.sha : "main";
+              const docsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${baseSha}/.github/release-ops.md#release-contract-check`;
+              const summary = [
+                "## Decision",
+                "",
+                "**FAIL**",
+                "",
+                "## Why",
+                "",
+                escape(problem),
+                "",
+                "## What to do next",
+                "",
+                escape(remediation),
+                "",
+                "<details><summary>Infrastructure diagnostic</summary>",
+                "",
+                "| Code | Cause |",
+                "| --- | --- |",
+                `| ${escape(code)} | ${escape(cause)} |`,
+                "",
+                `See [release-contract maintainer guidance](${docsUrl}).`,
+                "",
+                "</details>",
+                ""
+              ].join("\n");
+              await core.summary.addRaw(summary).write();
+              core.setFailed(`${code}: ${problem}`);
+            };
+
+            if (!pr || typeof pr.number !== "number" || typeof pr.base?.sha !== "string") {
+              await writeInfrastructureFailure(
+                "infrastructure-event-invalid",
+                "The pull-request event payload is unavailable or malformed.",
+                "Trusted base identity and pull-request number could not be acquired.",
+                "Re-run the pull_request workflow; if the event remains malformed, ask a repository administrator to inspect the event.");
               return;
             }
 
-            const title = (pr.title || "").trim();
-            const conventionalCommitTitle = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+/;
-            const labels = (pr.labels || [])
-              .map(label => label && typeof label.name === "string" ? label.name : "")
-              .filter(Boolean);
-            const skipUnreleasedEntry = labels.includes("no-unreleased-entry");
-            const files = await github.paginate(
-              github.rest.pulls.listFiles,
-              {
+            const modulePath = `${process.env.GITHUB_WORKSPACE}/.release-contract-policy/.github/scripts/release-contract-v1.mjs`;
+            let policy;
+            try {
+              policy = await import(pathToFileURL(modulePath).href);
+            } catch (error) {
+              await writeInfrastructureFailure(
+                "infrastructure-import-failure",
+                "The trusted release-contract classifier could not be imported.",
+                error instanceof Error ? error.message : String(error),
+                "Verify the base revision contains release-contract-v1.mjs, then re-run the workflow.");
+              return;
+            }
+
+            if (policy.contractVersion !== 1
+                || typeof policy.evaluateReleaseContractV1 !== "function"
+                || typeof policy.renderReleaseContractSummaryV1 !== "function") {
+              await writeInfrastructureFailure(
+                "infrastructure-version-mismatch",
+                "The trusted release-contract classifier is incompatible with this workflow.",
+                `Expected contractVersion 1 with v1 evaluator and renderer; received ${escape(policy.contractVersion)}.`,
+                "Disable or revert the integration workflow first, then restore a compatible v1 base module.");
+              return;
+            }
+
+            let files;
+            try {
+              files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
                 per_page: 100
               });
-            const changedFiles = files.map(file => file.filename);
-            const touchesUnreleased = changedFiles.includes("releases/unreleased.md");
-
-            const failures = [];
-
-            if (!conventionalCommitTitle.test(title)) {
-              failures.push(
-                "PR titles must follow Conventional Commits, for example `feat(web): add streamed sidebar`.");
+            } catch (error) {
+              await writeInfrastructureFailure(
+                "infrastructure-api-failure",
+                "GitHub pull-request file evidence could not be acquired.",
+                error instanceof Error ? error.message : String(error),
+                "Re-run the workflow; if GitHub still cannot enumerate every file, classify the pull request manually after service recovery.");
+              return;
             }
 
-            if (!skipUnreleasedEntry && !touchesUnreleased) {
-              failures.push(
-                "PRs must update `releases/unreleased.md` unless a maintainer applies the `no-unreleased-entry` label.");
+            try {
+              const input = {
+                title: pr.title,
+                authorLogin: pr.user?.login,
+                labels: Array.isArray(pr.labels) ? pr.labels.map(label => label?.name) : pr.labels,
+                changedFiles: pr.changed_files,
+                files: files.map(file => ({
+                  filename: file.filename,
+                  status: file.status,
+                  additions: file.additions,
+                  deletions: file.deletions,
+                  changes: file.changes,
+                  patch: file.patch
+                }))
+              };
+
+              const result = policy.evaluateReleaseContractV1(input);
+              if (!result || result.contractVersion !== 1 || !Array.isArray(result.diagnostics)) {
+                throw new Error("The v1 evaluator returned an incompatible result shape.");
+              }
+
+              const summary = policy.renderReleaseContractSummaryV1(result, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                baseSha: pr.base.sha
+              });
+              await core.summary.addRaw(summary).write();
+              const blocking = result.diagnostics.filter(item => item?.blocking === true);
+              if (blocking.length > 0) {
+                core.setFailed(blocking.map(item => item.code).join(", "));
+              }
+            } catch (error) {
+              await writeInfrastructureFailure(
+                "infrastructure-runtime-failure",
+                "The trusted release-contract classifier failed unexpectedly.",
+                error instanceof Error ? error.message : String(error),
+                "Disable or revert the integration workflow first and use an authored release entry while the runtime failure is investigated.");
             }
 
-            await core.summary
-              .addHeading("Release contract check")
-              .addTable([
-                [{data: "PR title", header: true}, title || "(empty)"],
-                [{data: "Conventional title", header: true}, conventionalCommitTitle.test(title) ? "yes" : "no"],
-                [{data: "Touched unreleased note", header: true}, touchesUnreleased ? "yes" : "no"],
-                [{data: "Skip label present", header: true}, skipUnreleasedEntry ? "yes" : "no"]
-              ])
-              .write();
-
-            if (failures.length > 0) {
-              core.setFailed(failures.join("\n"));
-            }
+      - name: Summarize trusted-policy checkout failure
+        if: ${{ failure() && steps.policy-checkout.outcome == 'failure' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const baseSha = context.payload.pull_request?.base?.sha || "main";
+            const docsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${baseSha}/.github/release-ops.md#release-contract-check`;
+            await core.summary.addRaw([
+              "## Decision",
+              "",
+              "**FAIL**",
+              "",
+              "## Why",
+              "",
+              "The trusted base release policy could not be checked out.",
+              "",
+              "## What to do next",
+              "",
+              "Re-run the workflow; if checkout still fails, inspect the checkout step and temporarily use an authored release entry after the workflow can execute.",
+              "",
+              "<details><summary>Infrastructure diagnostic</summary>",
+              "",
+              "| Code | Cause |",
+              "| --- | --- |",
+              "| infrastructure-checkout-failure | The isolated trusted-base checkout step failed. |",
+              "",
+              `See [release-contract maintainer guidance](${docsUrl}).`,
+              "",
+              "</details>",
+              ""
+            ].join("\n")).write();

--- a/releases/unreleased.md
+++ b/releases/unreleased.md
@@ -10,6 +10,7 @@ This is the living release note for the next coordinated AppSurface version afte
 
 ### Release and docs surface
 
+- The [release contract](../.github/release-ops.md#release-contract-check) now automatically exempts only release prose for Dependabot GitHub Actions pull requests whose complete, bounded patches are syntactically limited to same-position pinned external-action references. Compatibility, supply-chain review, CI, title validation, and ordinary merge protection remain independent requirements; maintainers can still require an authored entry whenever adopter-visible impact is identified.
 - [`ForgeTrust.AppSurface.Web` health and readiness probes](../Web/ForgeTrust.AppSurface.Web/README.md#health-and-readiness-probes) are now opt-in. New hosts avoid ASP.NET Core health-check registration and `/health` plus `/ready` endpoint mapping unless `WebOptions.Health.Enabled` is explicitly set to `true`; enabled probes also avoid general route-handler binding during startup. Hosts whose deployment or monitoring infrastructure consumes those probes must enable the shared flag; paths, readiness tags, response semantics, validation, and authorization behavior are unchanged.
 
 ## Migration watch

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -3,6 +3,85 @@ namespace ForgeTrust.AppSurface.Release.Tests;
 public sealed class ReleaseWorkflowPolicyTests
 {
     [Fact]
+    public async Task ReleaseContractUsesTrustedBaseReadOnlyClassifier()
+    {
+        var workflow = await ReadRepositoryFileAsync(".github/workflows/release-contract.yml");
+        var buildWorkflow = await ReadRepositoryFileAsync(".github/workflows/build.yml");
+
+        var trigger = SliceBetween(workflow, "on:\n", "\npermissions:");
+        Assert.Contains("  pull_request:\n", trigger, StringComparison.Ordinal);
+        Assert.DoesNotContain("pull_request_target", trigger, StringComparison.Ordinal);
+
+        var permissions = SliceBetween(workflow, "permissions:\n", "\njobs:");
+        Assert.Equal("  contents: read\n  pull-requests: read\n", permissions);
+        Assert.DoesNotContain("write", permissions, StringComparison.Ordinal);
+
+        var enforceJob = workflow[workflow.IndexOf("  enforce:\n", StringComparison.Ordinal)..];
+        Assert.Contains("    timeout-minutes: 5\n", enforceJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("secrets.", enforceJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("pull_request_target", enforceJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("permissions:", enforceJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("issues: write", enforceJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("pull-requests: write", enforceJob, StringComparison.Ordinal);
+
+        var checkout = SliceBetween(
+            enforceJob,
+            "      - name: Checkout trusted base release policy\n",
+            "\n      - name: Evaluate trusted release contract");
+        Assert.Contains("          ref: ${{ github.event.pull_request.base.sha }}\n", checkout, StringComparison.Ordinal);
+        Assert.Contains("          path: .release-contract-policy\n", checkout, StringComparison.Ordinal);
+        Assert.Contains("          persist-credentials: false\n", checkout, StringComparison.Ordinal);
+        Assert.Contains("          sparse-checkout: |\n            .github/scripts\n", checkout, StringComparison.Ordinal);
+        Assert.Contains("          sparse-checkout-cone-mode: false\n", checkout, StringComparison.Ordinal);
+
+        var evaluate = SliceBetween(
+            enforceJob,
+            "      - name: Evaluate trusted release contract\n",
+            "\n      - name: Summarize trusted-policy checkout failure");
+        Assert.Contains("const { pathToFileURL } = await import(\"node:url\");", evaluate, StringComparison.Ordinal);
+        Assert.Contains(".release-contract-policy/.github/scripts/release-contract-v1.mjs", evaluate, StringComparison.Ordinal);
+        Assert.Contains("policy.contractVersion !== 1", evaluate, StringComparison.Ordinal);
+        Assert.Contains("github.rest.pulls.listFiles", evaluate, StringComparison.Ordinal);
+        Assert.Contains("policy.evaluateReleaseContractV1(input)", evaluate, StringComparison.Ordinal);
+        Assert.Contains("policy.renderReleaseContractSummaryV1(result", evaluate, StringComparison.Ordinal);
+        Assert.Contains("infrastructure-api-failure", evaluate, StringComparison.Ordinal);
+        Assert.Contains("infrastructure-import-failure", evaluate, StringComparison.Ordinal);
+        Assert.Contains("infrastructure-runtime-failure", evaluate, StringComparison.Ordinal);
+        Assert.DoesNotContain("github.rest.issues", evaluate, StringComparison.Ordinal);
+        Assert.DoesNotContain("addLabels", evaluate, StringComparison.Ordinal);
+        Assert.DoesNotContain("createComment", evaluate, StringComparison.Ordinal);
+        var infrastructureSummaryGolden = SliceBetween(
+            evaluate,
+            "              const summary = [\n",
+            "              await core.summary.addRaw(summary).write();");
+        Assert.Equal(
+            "01F01D38A82BB2CCA9680DF73B1178BD6C891BCBAFEBC9ECF41AE51B073722E0",
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(infrastructureSummaryGolden))));
+
+        var fallback = enforceJob[enforceJob.IndexOf("      - name: Summarize trusted-policy checkout failure\n", StringComparison.Ordinal)..];
+        Assert.Contains("if: ${{ failure() && steps.policy-checkout.outcome == 'failure' }}", fallback, StringComparison.Ordinal);
+        Assert.Contains("infrastructure-checkout-failure", fallback, StringComparison.Ordinal);
+        Assert.Contains("## Decision", fallback, StringComparison.Ordinal);
+        Assert.Contains("## Why", fallback, StringComparison.Ordinal);
+        Assert.Contains("## What to do next", fallback, StringComparison.Ordinal);
+        var checkoutSummaryGolden = SliceBetween(
+            fallback,
+            "            await core.summary.addRaw([\n",
+            "            ].join(\"\\n\")).write();");
+        Assert.Equal(
+            "5E0291D42478E031BE74686B31BCD7D9441FAA3E7F2DF94BB7EF0EAA2FD321F4",
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(checkoutSummaryGolden))));
+
+        var buildNodeSlice = SliceBetween(
+            buildWorkflow,
+            "      - name: Setup Node.js\n",
+            "\n      - name: Verify generated package chooser");
+        Assert.Contains("          node-version: 24\n", buildNodeSlice, StringComparison.Ordinal);
+        Assert.Contains("      - name: Test dormant release-contract classifier\n", buildNodeSlice, StringComparison.Ordinal);
+        Assert.Contains("node --experimental-test-coverage --test-coverage-lines=100 --test-coverage-functions=100 --test-coverage-branches=100 --test .github/scripts/release-contract-v1.test.mjs", buildNodeSlice, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ReleasePrepReviewUsesReadOnlyPullRequestTriggerWithoutSecrets()
     {
         var workflow = await ReadRepositoryFileAsync(".github/workflows/release-prep.yml");
@@ -238,5 +317,15 @@ public sealed class ReleaseWorkflowPolicyTests
     {
         var root = TestPathUtils.FindRepoRoot(AppContext.BaseDirectory);
         return await File.ReadAllTextAsync(TestPathUtils.PathUnder(root, relativePath));
+    }
+
+    private static string SliceBetween(string source, string start, string end)
+    {
+        var startIndex = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(startIndex >= 0, $"Expected bounded slice start: {start}");
+        startIndex += start.Length;
+        var endIndex = source.IndexOf(end, startIndex, StringComparison.Ordinal);
+        Assert.True(endIndex >= startIndex, $"Expected bounded slice end: {end}");
+        return source[startIndex..endIndex];
     }
 }


### PR DESCRIPTION
## Summary

- activate the v1 classifier through an isolated checkout of the exact pull-request base SHA
- preserve pull_request and read-only contents plus pull-requests permissions with no secrets or mutation
- render bounded contract and infrastructure summaries, including checkout fallback diagnostics
- document the three evidence paths, semantic boundary, override, troubleshooting, rollback, reproduction, and effectiveness checkpoint
- add exact bounded workflow-policy tests and an authored unreleased entry

## Semantic boundary

Automatic classification exempts only public release prose. Compatibility, supply-chain safety, CI health, title validation, review, branch protection, and merge safety remain independent.

## Stack

This is PR B and is intentionally stacked on PR A, #670. Merge #670 first so v1 exists on main, then retarget this PR to main and mark it ready. The trusted-base integration must not activate before that bootstrap lands.

## Verification

- Node classifier and CLI gate: 100% lines/functions/branches
- targeted release tests: 286 passed
- release workflow YAML parse: passed
- embedded evaluation and fallback JavaScript syntax: passed
- dotnet format verify-no-changes: passed
- git diff --check: passed
- solution coverage was attempted but stopped during the solution build on pre-existing duplicate assembly attributes in ForgeTrust.AppSurface.Docs.Tests; the changed targeted suite remains green
