### PR TITLE
test(dev-auth): stabilize repeated signal verification

### DIFF
--- a/examples/auth-aspnetcore-dev-auth.tests/VerifierContractTests.cs
+++ b/examples/auth-aspnetcore-dev-auth.tests/VerifierContractTests.cs
@@ -698,7 +698,15 @@ public sealed class VerifierContractTests
             {
                 await Task.WhenAll(standardOutput, standardError).WaitAsync(cancellation.Token);
             }
-            catch
+            catch (OperationCanceledException)
+            {
+                // Preserve the exception that triggered cleanup.
+            }
+            catch (IOException)
+            {
+                // Preserve the exception that triggered cleanup.
+            }
+            catch (ObjectDisposedException)
             {
                 // Preserve the exception that triggered cleanup.
             }

--- a/examples/auth-aspnetcore-dev-auth.tests/VerifierContractTests.cs
+++ b/examples/auth-aspnetcore-dev-auth.tests/VerifierContractTests.cs
@@ -232,9 +232,7 @@ public sealed class VerifierContractTests
 
         var result = await fixture.RunAndSignalAsync(signal);
 
-        Assert.True(
-            result.ExitCode == expectedExitCode,
-            $"Expected verifier exit code {expectedExitCode}, but received {result.ExitCode}.{Environment.NewLine}{result.CombinedOutput}");
+        AssertExpectedExitCode(result, expectedExitCode);
         fixture.AssertStageSummaryReason(expectedReason);
         fixture.AssertNoChildrenRemain();
         fixture.AssertFailureEvidenceIsSafe();
@@ -252,13 +250,49 @@ public sealed class VerifierContractTests
 
         var result = await fixture.RunAndSignalTwiceAsync(signal, TimeSpan.FromSeconds(12));
 
-        Assert.True(
-            result.ExitCode == expectedExitCode,
-            $"Expected verifier exit code {expectedExitCode}, but received {result.ExitCode}.{Environment.NewLine}{result.CombinedOutput}");
+        AssertExpectedExitCode(result, expectedExitCode);
         Assert.Contains("[stage=CLEANUP reason=TERM_ESCALATED_TO_KILL]", result.CombinedOutput, StringComparison.Ordinal);
         fixture.AssertStageSummaryReason(expectedReason);
         fixture.AssertNoChildrenRemain();
         fixture.AssertFailureEvidenceIsSafe();
+    }
+
+    [Fact]
+    public async Task RepeatedSignal_CleanupHandlerTimeout_ReapsTheVerifierAndChild()
+    {
+        await using var fixture = await VerifierFixture.CreateAsync("resistant-child");
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => fixture.RunAndSignalTwiceWithSimulatedCleanupHandlerTimeoutAsync(
+                "TERM",
+                TimeSpan.FromSeconds(12),
+                TimeSpan.FromMilliseconds(100)));
+
+        fixture.AssertNoChildrenRemain();
+    }
+
+    public static IEnumerable<object[]> CleanupSignalHandlerStartedMarkerSplitPositions =>
+        Enumerable.Range(1, VerifierFixture.CleanupSignalHandlerStartedMarker.Length - 1)
+            .Select(static splitPosition => new object[] { splitPosition });
+
+    [Theory]
+    [MemberData(nameof(CleanupSignalHandlerStartedMarkerSplitPositions))]
+    public void CleanupSignalHandlerMarker_IsDetectedAcrossEveryReadBoundary(int splitPosition)
+    {
+        var marker = VerifierFixture.CleanupSignalHandlerStartedMarker;
+        var output = new System.Text.StringBuilder().Append(marker[..splitPosition]);
+        var outputLengthBeforeAppend = output.Length;
+
+        output.Append(marker[splitPosition..]);
+
+        Assert.True(VerifierFixture.ContainsCleanupSignalHandlerStartedMarker(output, outputLengthBeforeAppend));
+    }
+
+    private static void AssertExpectedExitCode(VerifierResult result, int expectedExitCode)
+    {
+        Assert.True(
+            result.ExitCode == expectedExitCode,
+            $"Expected verifier exit code {expectedExitCode}, but received {result.ExitCode}.{Environment.NewLine}{result.CombinedOutput}");
     }
 
     [Fact]
@@ -304,6 +338,7 @@ public sealed class VerifierContractTests
 
     private sealed class VerifierFixture : IAsyncDisposable
     {
+        internal const string CleanupSignalHandlerStartedMarker = "[stage=CLEANUP] Received ";
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
 
         private VerifierFixture(string root, string mode)
@@ -395,14 +430,34 @@ public sealed class VerifierContractTests
             return RunCoreAsync(port: null, timeout: "30", signal, processTimeout ?? DefaultTimeout);
         }
 
-        internal async Task<VerifierResult> RunAndSignalTwiceAsync(string signal, TimeSpan processTimeout)
+        internal Task<VerifierResult> RunAndSignalTwiceAsync(string signal, TimeSpan processTimeout)
         {
-            return await RunCoreAsync(
+            return RunAndSignalTwiceCore(signal, processTimeout, cleanupSignalHandlerTimeout: null, secondSignalReadinessOverride: null);
+        }
+
+        internal Task<VerifierResult> RunAndSignalTwiceWithSimulatedCleanupHandlerTimeoutAsync(
+            string signal,
+            TimeSpan processTimeout,
+            TimeSpan cleanupSignalHandlerTimeout)
+        {
+            var neverReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return RunAndSignalTwiceCore(signal, processTimeout, cleanupSignalHandlerTimeout, neverReady.Task);
+        }
+
+        private Task<VerifierResult> RunAndSignalTwiceCore(
+            string signal,
+            TimeSpan processTimeout,
+            TimeSpan? cleanupSignalHandlerTimeout,
+            Task? secondSignalReadinessOverride)
+        {
+            return RunCoreAsync(
                 port: null,
                 timeout: "30",
                 signal: signal,
                 processTimeout: processTimeout,
-                sendSecondSignal: true);
+                sendSecondSignal: true,
+                cleanupSignalHandlerTimeout: cleanupSignalHandlerTimeout,
+                secondSignalReadinessOverride: secondSignalReadinessOverride);
         }
 
         internal string ReadEvents()
@@ -504,7 +559,9 @@ public sealed class VerifierContractTests
             string? timeout,
             string? signal,
             TimeSpan processTimeout,
-            bool sendSecondSignal = false)
+            bool sendSecondSignal = false,
+            TimeSpan? cleanupSignalHandlerTimeout = null,
+            Task? secondSignalReadinessOverride = null)
         {
             var startInfo = new ProcessStartInfo
             {
@@ -535,32 +592,42 @@ public sealed class VerifierContractTests
             var standardOutput = process.StandardOutput.ReadToEndAsync();
             var standardError = ReadStandardErrorAsync(process.StandardError, cleanupSignalHandlerStarted);
 
-            if (signal is not null)
-            {
-                await WaitForChildLaunchAsync(processTimeout);
-                await SendSignalAsync(process.Id, signal);
-                if (sendSecondSignal)
-                {
-                    await cleanupSignalHandlerStarted!.Task.WaitAsync(processTimeout);
-                    await SendSignalAsync(process.Id, signal, requireSuccess: false);
-                }
-            }
-
-            using var cancellation = new CancellationTokenSource(processTimeout);
             try
             {
-                await process.WaitForExitAsync(cancellation.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                process.Kill(entireProcessTree: true);
-                throw new TimeoutException($"Verifier fixture '{Mode}' exceeded {processTimeout}.");
-            }
+                if (signal is not null)
+                {
+                    await WaitForChildLaunchAsync(processTimeout);
+                    await SendSignalAsync(process.Id, signal);
+                    if (sendSecondSignal)
+                    {
+                        await (secondSignalReadinessOverride ?? cleanupSignalHandlerStarted!.Task)
+                            .WaitAsync(cleanupSignalHandlerTimeout ?? processTimeout);
+                        await SendSignalAsync(process.Id, signal, requireSuccess: false);
+                    }
+                }
 
-            return new VerifierResult(
-                process.ExitCode,
-                await standardOutput,
-                await standardError);
+                using var cancellation = new CancellationTokenSource(processTimeout);
+                try
+                {
+                    await process.WaitForExitAsync(cancellation.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new TimeoutException($"Verifier fixture '{Mode}' exceeded {processTimeout}.");
+                }
+
+                return new VerifierResult(
+                    process.ExitCode,
+                    await standardOutput,
+                    await standardError);
+            }
+            catch
+            {
+                var cleanupDeadline = DateTime.UtcNow + processTimeout;
+                await TerminateProcessTreeAsync(process, cleanupDeadline);
+                await DrainOutputAsync(standardOutput, standardError, cleanupDeadline);
+                throw;
+            }
         }
 
         private static async Task<string> ReadStandardErrorAsync(
@@ -578,14 +645,69 @@ public sealed class VerifierContractTests
                     return output.ToString();
                 }
 
+                var outputLengthBeforeAppend = output.Length;
                 output.Append(buffer, 0, count);
                 if (waitingForCleanupSignalHandler
-                    && output.ToString().Contains("[stage=CLEANUP] Received ", StringComparison.Ordinal))
+                    && ContainsCleanupSignalHandlerStartedMarker(output, outputLengthBeforeAppend))
                 {
                     cleanupSignalHandlerStarted!.TrySetResult();
                     waitingForCleanupSignalHandler = false;
                 }
             }
+        }
+
+        internal static bool ContainsCleanupSignalHandlerStartedMarker(
+            System.Text.StringBuilder output,
+            int outputLengthBeforeAppend)
+        {
+            var searchStart = Math.Max(0, outputLengthBeforeAppend - CleanupSignalHandlerStartedMarker.Length + 1);
+            return output
+                .ToString(searchStart, output.Length - searchStart)
+                .Contains(CleanupSignalHandlerStartedMarker, StringComparison.Ordinal);
+        }
+
+        private static async Task TerminateProcessTreeAsync(Process process, DateTime cleanupDeadline)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited after HasExited was checked.
+            }
+
+            using var cancellation = new CancellationTokenSource(GetRemainingCleanupTime(cleanupDeadline));
+            try
+            {
+                await process.WaitForExitAsync(cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Preserve the exception that triggered cleanup.
+            }
+        }
+
+        private static async Task DrainOutputAsync(Task<string> standardOutput, Task<string> standardError, DateTime cleanupDeadline)
+        {
+            using var cancellation = new CancellationTokenSource(GetRemainingCleanupTime(cleanupDeadline));
+            try
+            {
+                await Task.WhenAll(standardOutput, standardError).WaitAsync(cancellation.Token);
+            }
+            catch
+            {
+                // Preserve the exception that triggered cleanup.
+            }
+        }
+
+        private static TimeSpan GetRemainingCleanupTime(DateTime cleanupDeadline)
+        {
+            var remaining = cleanupDeadline - DateTime.UtcNow;
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
         }
 
         private async Task WaitForChildLaunchAsync(TimeSpan timeout)

--- a/examples/auth-aspnetcore-dev-auth.tests/VerifierContractTests.cs
+++ b/examples/auth-aspnetcore-dev-auth.tests/VerifierContractTests.cs
@@ -232,7 +232,9 @@ public sealed class VerifierContractTests
 
         var result = await fixture.RunAndSignalAsync(signal);
 
-        Assert.Equal(expectedExitCode, result.ExitCode);
+        Assert.True(
+            result.ExitCode == expectedExitCode,
+            $"Expected verifier exit code {expectedExitCode}, but received {result.ExitCode}.{Environment.NewLine}{result.CombinedOutput}");
         fixture.AssertStageSummaryReason(expectedReason);
         fixture.AssertNoChildrenRemain();
         fixture.AssertFailureEvidenceIsSafe();
@@ -250,7 +252,9 @@ public sealed class VerifierContractTests
 
         var result = await fixture.RunAndSignalTwiceAsync(signal, TimeSpan.FromSeconds(12));
 
-        Assert.Equal(expectedExitCode, result.ExitCode);
+        Assert.True(
+            result.ExitCode == expectedExitCode,
+            $"Expected verifier exit code {expectedExitCode}, but received {result.ExitCode}.{Environment.NewLine}{result.CombinedOutput}");
         Assert.Contains("[stage=CLEANUP reason=TERM_ESCALATED_TO_KILL]", result.CombinedOutput, StringComparison.Ordinal);
         fixture.AssertStageSummaryReason(expectedReason);
         fixture.AssertNoChildrenRemain();
@@ -525,8 +529,11 @@ public sealed class VerifierContractTests
 
             using var process = Process.Start(startInfo);
             Assert.NotNull(process);
+            var cleanupSignalHandlerStarted = sendSecondSignal
+                ? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+                : null;
             var standardOutput = process.StandardOutput.ReadToEndAsync();
-            var standardError = process.StandardError.ReadToEndAsync();
+            var standardError = ReadStandardErrorAsync(process.StandardError, cleanupSignalHandlerStarted);
 
             if (signal is not null)
             {
@@ -534,7 +541,7 @@ public sealed class VerifierContractTests
                 await SendSignalAsync(process.Id, signal);
                 if (sendSecondSignal)
                 {
-                    await Task.Delay(100);
+                    await cleanupSignalHandlerStarted!.Task.WaitAsync(processTimeout);
                     await SendSignalAsync(process.Id, signal, requireSuccess: false);
                 }
             }
@@ -554,6 +561,31 @@ public sealed class VerifierContractTests
                 process.ExitCode,
                 await standardOutput,
                 await standardError);
+        }
+
+        private static async Task<string> ReadStandardErrorAsync(
+            StreamReader standardError,
+            TaskCompletionSource? cleanupSignalHandlerStarted)
+        {
+            var output = new System.Text.StringBuilder();
+            var buffer = new char[1024];
+            var waitingForCleanupSignalHandler = cleanupSignalHandlerStarted is not null;
+            while (true)
+            {
+                var count = await standardError.ReadAsync(buffer.AsMemory());
+                if (count == 0)
+                {
+                    return output.ToString();
+                }
+
+                output.Append(buffer, 0, count);
+                if (waitingForCleanupSignalHandler
+                    && output.ToString().Contains("[stage=CLEANUP] Received ", StringComparison.Ordinal))
+                {
+                    cleanupSignalHandlerStarted!.TrySetResult();
+                    waitingForCleanupSignalHandler = false;
+                }
+            }
         }
 
         private async Task WaitForChildLaunchAsync(TimeSpan timeout)


### PR DESCRIPTION
## Summary

- Replace the repeated-signal test's fixed delay with an observation that the verifier's cleanup signal handler is active.
- Reap the verifier process tree and drain its output readers on every fixture failure path, within one cleanup deadline.
- Include captured verifier output when signal-exit assertions fail, and cover every cleanup-marker read boundary.

## Test Coverage

Test-only diff: no application code paths changed. The DevAuth verifier contract tests cover the affected signal, cleanup, timeout, and marker-boundary behavior.

## Pre-Landing Review

Four local feedback-review cycles resolved the valid process-cleanup, output-draining, timing, and maintainability findings. The canonical Codex review checklist was applied; no unresolved local findings remain.

## Design Review

No frontend files changed — design review skipped.

## Plan Completion

No plan file detected.

## Verification Results

- `dotnet test examples/auth-aspnetcore-dev-auth.tests/AuthAspNetCoreDevAuthExample.Tests.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~Signal_UsesFixedExitStatusAndReapsTheChild|FullyQualifiedName~RepeatedSignal|FullyQualifiedName~CleanupSignalHandlerMarker' --logger 'console;verbosity=normal'` — 29 passed
- `dotnet format examples/auth-aspnetcore-dev-auth.tests/AuthAspNetCoreDevAuthExample.Tests.csproj --verify-no-changes --no-restore`
- `git diff --check`

## Notes since opening

- Addressed the two Copilot review threads in `dff01fc6` with regression coverage for cleanup-handler timeout and all marker read boundaries.
- Narrowed `DrainOutputAsync` to expected cancellation and stream-teardown exceptions in `367d1e3f`.
- No production behavior, public API, documentation, or release metadata changed.

## TODOS

No TODO items completed or introduced in this PR.

## Test plan

- [x] Run direct- and repeated-signal verifier regressions in Release
- [x] Force cleanup-handler readiness timeout and verify child reaping
- [x] Check every cleanup-marker read-boundary split
