### PR TITLE
fix(coverage): align patch gate with Codecov

### DIFF
--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/CoverageGateTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/CoverageGateTests.cs
@@ -106,6 +106,7 @@ public sealed class CoverageGateTests
                 DiffBase = "HEAD~1",
                 MinPatchLine = 100,
                 MinPatchBranch = 100,
+                PatchLineModeOption = "CoDeCoV",
                 NoGithubSummary = true
             };
             using var console = new FakeInMemoryConsole();
@@ -115,6 +116,7 @@ public sealed class CoverageGateTests
             var output = console.ReadOutputString();
             Assert.Contains("patch lines 100.00% >= 99.5%", output, StringComparison.Ordinal);
             Assert.Contains("patch branches 100.00% >= 99.5%", output, StringComparison.Ordinal);
+            Assert.Contains("Patch line mode: codecov", File.ReadAllText(Path.Join(temp.Path, "coverage-gate.md")), StringComparison.Ordinal);
         }
         finally
         {
@@ -525,6 +527,214 @@ public sealed class CoverageGateTests
         Assert.Contains("| Patch lines | 66.67% (2/3 measurable, 5 changed) | 49.5% | pass |", markdown, StringComparison.Ordinal);
         Assert.Contains("\"patchLine\": 50", json, StringComparison.Ordinal);
         Assert.Contains("\"measurable\": 3", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_DefaultPatchLineMode_PreservesHitsOnlyCoverage()
+    {
+        using var temp = TempDirectory.Create("appsurface-coverage-gate-");
+        var coverage = temp.WriteCoverage("""
+            <coverage lines-covered="1" lines-valid="1" branches-covered="1" branches-valid="1">
+              <packages>
+                <package name="Example">
+                  <classes>
+                    <class name="Example.Foo" filename="src/Foo.cs">
+                      <lines>
+                        <line number="1" hits="1" branch="true" condition-coverage="50% (1/2)" />
+                      </lines>
+                    </class>
+                  </classes>
+                </package>
+              </packages>
+            </coverage>
+            """);
+        var request = new CoverageGateRequest(
+            coverage,
+            temp.Path,
+            0,
+            0,
+            false,
+            null,
+            new CoveragePatchRequest(temp.Path, "origin/main", 100, _ => Task.FromResult("""
+                diff --git a/src/Foo.cs b/src/Foo.cs
+                index 0000000..1111111 100644
+                --- a/src/Foo.cs
+                +++ b/src/Foo.cs
+                @@ -0,0 +1,1 @@
+                +changed
+                """)));
+
+        var result = await CoverageGateEvaluator.EvaluateAsync(request, CancellationToken.None);
+
+        Assert.Equal(PatchLineMode.Measurable, request.PatchCoverage?.LineMode);
+        Assert.Equal(1, result.PatchLineCoverage?.CoveredLines);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_CodecovMode_CountsPartialConditionLinesAsUncovered()
+    {
+        using var temp = TempDirectory.Create("appsurface-coverage-gate-");
+        var coverage = temp.WriteCoverage("""
+            <coverage lines-covered="1" lines-valid="1" branches-covered="1" branches-valid="1">
+              <packages>
+                <package name="Example">
+                  <classes>
+                    <class name="Example.Foo" filename="src/Foo.cs">
+                      <lines>
+                        <line number="1" hits="1" branch="true" condition-coverage="50% (1/2)" />
+                        <line number="2" hits="1" branch="true" condition-coverage="100% (2/2)" />
+                        <line number="3" hits="1" />
+                        <line number="4" hits="0" branch="true" condition-coverage="100% (2/2)" />
+                      </lines>
+                    </class>
+                  </classes>
+                </package>
+              </packages>
+            </coverage>
+            """);
+        var request = new CoverageGateRequest(
+            coverage,
+            temp.Path,
+            0,
+            0,
+            false,
+            null,
+            new CoveragePatchRequest(
+                temp.Path,
+                "origin/main",
+                50,
+                _ => Task.FromResult("""
+                    diff --git a/src/Foo.cs b/src/Foo.cs
+                    index 0000000..1111111 100644
+                    --- a/src/Foo.cs
+                    +++ b/src/Foo.cs
+                    @@ -0,0 +1,4 @@
+                    +partial
+                    +full
+                    +no branch data
+                    +zero hits
+                    """),
+                LineMode: PatchLineMode.Codecov));
+
+        var result = await CoverageGateEvaluator.EvaluateAsync(request, CancellationToken.None);
+        await CoverageGateReportWriter.WriteAsync(result, request, CancellationToken.None);
+
+        Assert.Equal(2, result.PatchLineCoverage?.CoveredLines);
+        Assert.Equal(50, result.PatchLineCoverage?.Percent);
+        Assert.Contains("\"patchLineMode\": \"codecov\"", File.ReadAllText(result.JsonReportPath), StringComparison.Ordinal);
+        Assert.Contains("Patch line mode: codecov", File.ReadAllText(result.MarkdownReportPath), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("measurable")]
+    [InlineData("codecov")]
+    public async Task EvaluateAsync_ExcludesChangedLinesMissingFromCobertura_InEveryMode(string modeName)
+    {
+        var mode = Enum.Parse<PatchLineMode>(modeName, ignoreCase: true);
+        using var temp = TempDirectory.Create("appsurface-coverage-gate-");
+        var coverage = temp.WriteCoverage("""
+            <coverage lines-covered="1" lines-valid="1" branches-covered="1" branches-valid="1">
+              <packages>
+                <package name="Example">
+                  <classes>
+                    <class name="Example.Foo" filename="src/Foo.cs">
+                      <lines>
+                        <line number="1" hits="1" />
+                      </lines>
+                    </class>
+                  </classes>
+                </package>
+              </packages>
+            </coverage>
+            """);
+        var request = new CoverageGateRequest(
+            coverage,
+            temp.Path,
+            0,
+            0,
+            false,
+            null,
+            new CoveragePatchRequest(
+                temp.Path,
+                "origin/main",
+                100,
+                _ => Task.FromResult("""
+                    diff --git a/src/Foo.cs b/src/Foo.cs
+                    index 0000000..1111111 100644
+                    --- a/src/Foo.cs
+                    +++ b/src/Foo.cs
+                    @@ -0,0 +1,2 @@
+                    +covered
+                    +missing from Cobertura
+                    """),
+                LineMode: mode));
+
+        var result = await CoverageGateEvaluator.EvaluateAsync(request, CancellationToken.None);
+
+        Assert.Equal(2, result.PatchLineCoverage?.ChangedLines);
+        Assert.Equal(1, result.PatchLineCoverage?.MeasurableLines);
+        Assert.Equal(1, result.PatchLineCoverage?.CoveredLines);
+    }
+
+    [Theory]
+    [InlineData("measurable")]
+    [InlineData("codecov")]
+    public async Task EvaluateAsync_PassesWithNoMeasurableChangedLines_InEveryMode(string modeName)
+    {
+        var mode = Enum.Parse<PatchLineMode>(modeName, ignoreCase: true);
+        using var temp = TempDirectory.Create("appsurface-coverage-gate-");
+        var coverage = temp.WriteCoverage("""
+            <coverage lines-covered="1" lines-valid="1" branches-covered="1" branches-valid="1" />
+            """);
+        var request = new CoverageGateRequest(
+            coverage,
+            temp.Path,
+            0,
+            0,
+            false,
+            null,
+            new CoveragePatchRequest(
+                temp.Path,
+                "origin/main",
+                100,
+                _ => Task.FromResult("""
+                    diff --git a/Tests/FooTests.cs b/Tests/FooTests.cs
+                    index 0000000..1111111 100644
+                    --- a/Tests/FooTests.cs
+                    +++ b/Tests/FooTests.cs
+                    @@ -0,0 +1,1 @@
+                    +test-only
+                    """),
+                LineMode: mode));
+
+        var result = await CoverageGateEvaluator.EvaluateAsync(request, CancellationToken.None);
+
+        Assert.True(result.Passed);
+        Assert.Equal(0, result.PatchLineCoverage?.MeasurableLines);
+        Assert.Equal(100, result.PatchLineCoverage?.Percent);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RejectsUnknownPatchLineMode_WithDiagnostic()
+    {
+        using var temp = TempDirectory.Create("appsurface-coverage-gate-");
+        var coverage = temp.WriteCoverage("""
+            <coverage lines-covered="1" lines-valid="1" branches-covered="1" branches-valid="1" />
+            """);
+        var command = new CoverageGateCommand
+        {
+            CoveragePath = coverage,
+            OutputDirectory = temp.Path,
+            PatchLineModeOption = "unknown",
+            NoGithubSummary = true,
+        };
+        using var console = new FakeInMemoryConsole();
+
+        var exception = await Assert.ThrowsAsync<CommandException>(
+            async () => await command.ExecuteAsync(console, CancellationToken.None));
+
+        Assert.Contains("ASCOV017", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("--patch-line-mode", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Cli/ForgeTrust.AppSurface.Cli.Tests/CoverageSolutionScriptTests.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli.Tests/CoverageSolutionScriptTests.cs
@@ -26,6 +26,7 @@ public sealed class CoverageSolutionScriptTests
         Assert.Contains("--diff-base \"$COVERAGE_GATE_DIFF_BASE\"", script, StringComparison.Ordinal);
         Assert.Contains("--min-patch-line 95", script, StringComparison.Ordinal);
         Assert.Contains("--min-patch-branch 85", script, StringComparison.Ordinal);
+        Assert.Contains("--patch-line-mode codecov", script, StringComparison.Ordinal);
         Assert.Equal(3, CountOccurrences(script, "--no-restore"));
         Assert.Contains("if [[ -n \"$COVERAGE_GATE_DIFF_BASE\" ]]; then", script, StringComparison.Ordinal);
     }
@@ -138,7 +139,7 @@ public sealed class CoverageSolutionScriptTests
 
         if (expectsPatchGate)
         {
-            Assert.Contains("--diff-base\norigin/main\n--min-patch-line\n95\n--min-patch-branch\n85", invocations, StringComparison.Ordinal);
+            Assert.Contains("--diff-base\norigin/main\n--min-patch-line\n95\n--min-patch-branch\n85\n--patch-line-mode\ncodecov", invocations, StringComparison.Ordinal);
         }
         else
         {

--- a/Cli/ForgeTrust.AppSurface.Cli/CoverageGate.cs
+++ b/Cli/ForgeTrust.AppSurface.Cli/CoverageGate.cs
@@ -92,6 +92,12 @@ internal sealed partial class CoverageGateCommand : ICommand
     public decimal? MinPatchLine { get; set; }
 
     /// <summary>
+    /// Gets or sets the changed-line coverage calculation mode.
+    /// </summary>
+    [CommandOption("patch-line-mode", Description = "Changed-line calculation mode: measurable or codecov. Defaults to measurable.")]
+    public string PatchLineModeOption { get; set; } = "measurable";
+
+    /// <summary>
     /// Gets or sets the minimum changed-branch coverage percentage from 0 to 100.
     /// </summary>
     [CommandOption("min-patch-branch", Description = "Minimum changed-branch coverage percentage from 0 to 100. Requires one patch source: --diff-base, --diff-file, or --diff-stdin.")]
@@ -156,6 +162,8 @@ internal sealed partial class CoverageGateCommand : ICommand
 
     private CoverageGateRequest CreateRequest()
     {
+        var patchLineMode = ParsePatchLineMode();
+
         if (!CoverageGateEvaluator.IsPercentInRange(MinLine))
         {
             throw new CommandException("ASCOV007 --min-line must be between 0 and 100.");
@@ -216,7 +224,8 @@ internal sealed partial class CoverageGateCommand : ICommand
                 ResolveRepositoryRoot(),
                 CreateDiffSource(),
                 MinPatchLine,
-                MinPatchBranchPercent: MinPatchBranch);
+                MinPatchBranchPercent: MinPatchBranch,
+                LineMode: patchLineMode);
 
         return new CoverageGateRequest(
             coveragePath,
@@ -227,6 +236,21 @@ internal sealed partial class CoverageGateCommand : ICommand
             Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY"),
             patchCoverage,
             Tolerance);
+    }
+
+    private PatchLineMode ParsePatchLineMode()
+    {
+        if (string.Equals(PatchLineModeOption, "measurable", StringComparison.OrdinalIgnoreCase))
+        {
+            return PatchLineMode.Measurable;
+        }
+
+        if (string.Equals(PatchLineModeOption, "codecov", StringComparison.OrdinalIgnoreCase))
+        {
+            return PatchLineMode.Codecov;
+        }
+
+        throw new CommandException("ASCOV017 --patch-line-mode must be measurable or codecov.");
     }
 
     private static string GetFullPathOrThrow(string path, string diagnostic)
@@ -424,11 +448,13 @@ internal sealed record CoverageGateRequest(
 /// <param name="DiffSource">Patch diff source used to acquire unified diff text.</param>
 /// <param name="MinPatchLinePercent">Optional changed-line threshold.</param>
 /// <param name="MinPatchBranchPercent">Optional changed-branch threshold.</param>
+/// <param name="LineMode">Changed-line calculation mode. Defaults to <see cref="PatchLineMode.Measurable"/>.</param>
 internal sealed partial record CoveragePatchRequest(
     string RepositoryRoot,
     PatchDiffSource DiffSource,
     decimal? MinPatchLinePercent,
-    decimal? MinPatchBranchPercent = null);
+    decimal? MinPatchBranchPercent = null,
+    PatchLineMode LineMode = PatchLineMode.Measurable);
 
 internal sealed partial record CoveragePatchRequest
 {
@@ -437,14 +463,32 @@ internal sealed partial record CoveragePatchRequest
         string DiffBase,
         decimal? MinPatchLinePercent,
         Func<CancellationToken, Task<string>>? DiffProvider = null,
-        decimal? MinPatchBranchPercent = null)
+        decimal? MinPatchBranchPercent = null,
+        PatchLineMode LineMode = PatchLineMode.Measurable)
         : this(
             RepositoryRoot,
             PatchDiffSource.ForGitBase(DiffBase, DiffBase, DiffProvider),
             MinPatchLinePercent,
-            MinPatchBranchPercent)
+            MinPatchBranchPercent,
+            LineMode)
     {
     }
+}
+
+/// <summary>
+/// Selects the changed-line coverage calculation.
+/// </summary>
+internal enum PatchLineMode
+{
+    /// <summary>
+    /// Counts a Cobertura line as covered when it has at least one hit.
+    /// </summary>
+    Measurable,
+
+    /// <summary>
+    /// Matches Codecov line semantics when Cobertura includes branch condition data.
+    /// </summary>
+    Codecov,
 }
 
 internal enum PatchDiffSourceKind
@@ -595,6 +639,7 @@ internal sealed record PatchDiffSourceReport(
 /// <param name="PatchBranchCoverage">Optional changed-branch coverage metric.</param>
 /// <param name="PatchDiffSource">Optional patch diff source provenance.</param>
 /// <param name="TolerancePercent">Grace margin subtracted from thresholds before evaluation. Defaults to 0.5.</param>
+/// <param name="PatchLineMode">Selected changed-line calculation mode.</param>
 internal sealed record CoverageGateResult(
     string CoveragePath,
     CoverageMetric LineCoverage,
@@ -609,7 +654,8 @@ internal sealed record CoverageGateResult(
     decimal? MinPatchBranchPercent = null,
     PatchBranchCoverageMetric? PatchBranchCoverage = null,
     PatchDiffSourceReport? PatchDiffSource = null,
-    decimal TolerancePercent = 0.5m);
+    decimal TolerancePercent = 0.5m,
+    PatchLineMode? PatchLineMode = null);
 
 /// <summary>
 /// One Cobertura coverage metric expressed as optional covered/valid counts and a percentage.
@@ -746,7 +792,8 @@ internal static class CoverageGateEvaluator
                     request.PatchCoverage?.MinPatchBranchPercent,
                     patchCoverage?.BranchCoverage,
                     patchCoverage?.SourceReport,
-                    request.TolerancePercent);
+                    request.TolerancePercent,
+                    request.PatchCoverage?.LineMode);
             }
         }
         catch (XmlException ex)
@@ -1052,7 +1099,7 @@ internal static class PatchCoverageEvaluator
                 }
 
                 measurableLineCount++;
-                if (lineCoverage.Covered)
+                if (IsLineCovered(lineCoverage, request.LineMode))
                 {
                     coveredLineCount++;
                 }
@@ -1094,6 +1141,12 @@ internal static class PatchCoverageEvaluator
                 coveredBranchCount,
                 branchPercent));
     }
+
+    private static bool IsLineCovered(PatchLineCoverageData lineCoverage, PatchLineMode mode) =>
+        lineCoverage.Covered
+        && (mode != PatchLineMode.Codecov
+            || lineCoverage.Branches is not { } branches
+            || branches.Covered == branches.Valid);
 
     internal static IReadOnlyDictionary<string, IReadOnlySet<int>> ParseChangedLines(string diffText)
         => ParseChangedLinesDetailed(diffText).ChangedLines;
@@ -1846,6 +1899,7 @@ internal static class CoverageGateReportWriter
                     patchLine = effectivePatchLineThreshold,
                     patchBranch = effectivePatchBranchThreshold,
                 },
+                patchLineMode = result.PatchLineMode?.ToString().ToLowerInvariant(),
                 patchDiffSource = ToJson(result.PatchDiffSource),
                 line = ToJson(result.LineCoverage),
                 branch = ToJson(result.BranchCoverage),
@@ -1879,6 +1933,11 @@ internal static class CoverageGateReportWriter
         builder.AppendLine(FormattableString.Invariant($"Tolerance: {result.TolerancePercent:0.##}%"));
         if (result.PatchDiffSource is { } source)
         {
+            if (result.PatchLineMode is { } patchLineMode)
+            {
+                builder.AppendLine($"Patch line mode: {patchLineMode.ToString().ToLowerInvariant()}");
+            }
+
             builder.AppendLine($"Patch source: {EscapeMarkdownCell(GetKindText(source.Kind))}");
             builder.AppendLine($"Patch label: {EscapeMarkdownCell(source.Label)}");
             if (!string.IsNullOrWhiteSpace(source.DiffBase))

--- a/Cli/ForgeTrust.AppSurface.Cli/README.md
+++ b/Cli/ForgeTrust.AppSurface.Cli/README.md
@@ -58,6 +58,7 @@ dotnet tool run appsurface docs --repo .
 dotnet tool run appsurface coverage run --solution ./MyApp.slnx --dry-run
 dotnet tool run appsurface coverage run --solution ./MyApp.slnx
 dotnet tool run appsurface coverage gate --coverage ./TestResults/coverage-merged/coverage.cobertura.xml --min-line 95 --min-branch 85 --diff-base origin/main --min-patch-line 95 --min-patch-branch 85
+dotnet tool run appsurface coverage gate --coverage ./TestResults/coverage-merged/coverage.cobertura.xml --min-line 95 --min-branch 85 --diff-base origin/main --min-patch-line 95 --patch-line-mode codecov
 ```
 
 Update the repo-scoped tool version with:
@@ -640,6 +641,7 @@ Options:
 - `--diff-label`: Optional display label for the selected patch source in JSON, Markdown, and GitHub summaries.
 - `--repository-root`: Repository root used to normalize Cobertura paths and diff paths. Defaults to the Git worktree root when available, otherwise the current directory.
 - `--min-patch-line`: Minimum changed-line coverage percentage from `0` through `100`. Requires exactly one patch source: `--diff-base`, `--diff-file`, or `--diff-stdin`. Omit it to report changed-line coverage without gating on it.
+- `--patch-line-mode`: Changed-line calculation mode, either `measurable` (the backwards-compatible default) or `codecov`, case-insensitive.
 - `--min-patch-branch`: Minimum changed-branch coverage percentage from `0` through `100`. Requires exactly one patch source. Omit it to report changed-branch coverage without gating on it.
 - `--output`: Directory for `coverage-gate.json` and `coverage-gate.md`. Defaults to the coverage file directory.
 - `--github-summary`: Append Markdown to `$GITHUB_STEP_SUMMARY` when it is set. Enabled by default.
@@ -649,7 +651,7 @@ Use the default tolerance to absorb insignificant coverage-report rounding diffe
 
 The command accepts Cobertura root attributes such as `line-rate`, `branch-rate`, `lines-covered`, `lines-valid`, `branches-covered`, and `branches-valid`. XML parsing disables DTD processing and external resolution. Coverage counts must be non-negative, covered counts cannot exceed valid counts, rates must be from `0` through `1`, and zero valid line or branch counts fail with `ASCOV006` because a quality gate with no measurable denominator is misleading.
 
-Patch coverage counts added or modified diff lines, intersects those lines with Cobertura `<class filename>` and `<line number hits>` entries, and reports covered/measurable lines. Changed lines that do not appear in the Cobertura line map are ignored for the denominator, which keeps docs, project files, generated artifacts, and other non-coverable edits from failing the patch gate. Changed-branch coverage uses Cobertura line-level `condition-coverage` counts on those same changed measurable lines, so ordinary changed statements without branch conditions do not inflate the branch denominator. When a diff has no measurable changed lines or no measurable changed branches, the corresponding patch metric reports `100%` and says so explicitly in Markdown. Empty external diff files or stdin are valid empty patches. Non-empty malformed external artifacts, such as HTML login pages or JSON API errors, fail before coverage is evaluated.
+Patch coverage counts added or modified diff lines, intersects those lines with Cobertura `<class filename>` and `<line number hits>` entries, and reports covered/measurable lines. The default `measurable` mode counts a Cobertura line as covered when `hits > 0`, preserving the original local gate behavior. `codecov` mode retains only changed lines present in Cobertura and counts a line as covered when `hits > 0` and it has no branch data or full condition coverage (`covered == valid`); partial condition coverage therefore counts as an uncovered line, matching Codecov's patch-line calculation. Lines absent from Cobertura remain excluded in both modes, including test-only or otherwise non-instrumented modules that Codecov excludes. The patch-line mode affects only the patch line metric; `--min-patch-branch` remains a separate branch-condition metric and still counts changed Cobertura conditions. When a diff has no measurable changed lines or no measurable changed branches, the corresponding patch metric reports `100%` and says so explicitly in Markdown. Empty external diff files or stdin are valid empty patches. Non-empty malformed external artifacts, such as HTML login pages or JSON API errors, fail before coverage is evaluated.
 
 Reports are private local artifacts:
 

--- a/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/AppSurfaceDurablePostgreSqlRegistrationTests.cs
+++ b/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/AppSurfaceDurablePostgreSqlRegistrationTests.cs
@@ -3,6 +3,7 @@ using ForgeTrust.AppSurface.Core;
 using ForgeTrust.AppSurface.Durable.Provider;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Npgsql;
@@ -137,6 +138,23 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
     }
 
     [Fact]
+    public void TurnScheduler_ContinuesRotationAfterChangingTheSelectedSurfaceSet()
+    {
+        var scheduler = new DurableRuntimeTurnScheduler();
+
+        Assert.Equal(DurableRuntimeSurface.Work, scheduler.Next(DurableRuntimeSurface.All));
+        Assert.Equal(DurableRuntimeSurface.Schedule, scheduler.Next(DurableRuntimeSurface.Schedule | DurableRuntimeSurface.Work));
+        Assert.Equal(DurableRuntimeSurface.Work, scheduler.Next(DurableRuntimeSurface.Work));
+        Assert.Equal(DurableRuntimeSurface.Flow, scheduler.Next(DurableRuntimeSurface.Flow | DurableRuntimeSurface.Schedule));
+    }
+
+    [Fact]
+    public void Builder_RejectsNullServiceCollection()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AppSurfaceDurablePostgreSqlBuilder(null!));
+    }
+
+    [Fact]
     public void HostedWait_UsesEarliestDueTimeAndNeverReturnsZeroDelay()
     {
         var maximum = TimeSpan.FromSeconds(5);
@@ -145,6 +163,7 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
         Assert.Equal(TimeSpan.FromMilliseconds(1), PostgreSqlDurableHostedService.CalculateIdleDelay(DateTimeOffset.UtcNow, maximum));
         var nearDue = PostgreSqlDurableHostedService.CalculateIdleDelay(DateTimeOffset.UtcNow.AddMilliseconds(20), maximum);
         Assert.InRange(nearDue, TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(1));
+        Assert.Equal(maximum, PostgreSqlDurableHostedService.CalculateIdleDelay(DateTimeOffset.UtcNow.AddHours(1), maximum));
     }
 
     [Fact]
@@ -182,9 +201,29 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
     }
 
     [Fact]
+    public async Task HostedWait_RejectsNullDependencies()
+    {
+        var wakeSignals = Channel.CreateBounded<bool>(1);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            PostgreSqlDurableHostedService.WaitForWakeOrPollAsync(
+                null!,
+                TimeSpan.Zero,
+                static (_, _) => Task.CompletedTask,
+                CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            PostgreSqlDurableHostedService.WaitForWakeOrPollAsync(
+                wakeSignals.Reader,
+                TimeSpan.Zero,
+                null!,
+                CancellationToken.None));
+    }
+
+    [Fact]
     public void OptionsValidation_RejectsBoundsAndIdentityEdges()
     {
         Assert.Throws<ArgumentException>(() => new AppSurfaceDurablePostgreSqlOptions { WorkerId = " " }.SnapshotAndValidate());
+        Assert.Throws<ArgumentException>(() => new AppSurfaceDurablePostgreSqlOptions { WorkerId = new string('w', 201) }.SnapshotAndValidate());
         Assert.Throws<ArgumentOutOfRangeException>(() => new AppSurfaceDurablePostgreSqlOptions { MaximumItemsPerPass = 0 }.SnapshotAndValidate());
         Assert.Throws<ArgumentOutOfRangeException>(() => new AppSurfaceDurablePostgreSqlOptions { TimeBudgetPerPass = TimeSpan.Zero }.SnapshotAndValidate());
         Assert.Throws<ArgumentOutOfRangeException>(() => new AppSurfaceDurablePostgreSqlOptions { HostedSurfaces = (DurableRuntimeSurface)8 }.SnapshotAndValidate());
@@ -196,6 +235,48 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
             HeartbeatStaleAfter = TimeSpan.FromMilliseconds(500),
         }.SnapshotAndValidate());
         Assert.Throws<ArgumentOutOfRangeException>(() => new AppSurfaceDurablePostgreSqlOptions { ShutdownReserve = TimeSpan.FromMinutes(5).Add(TimeSpan.FromTicks(1)) }.SnapshotAndValidate());
+    }
+
+    [Fact]
+    public void OptionsValidation_PreservesDefaultsAndAcceptsDocumentedUpperBounds()
+    {
+        var defaults = new AppSurfaceDurablePostgreSqlOptions().SnapshotAndValidate();
+
+        Assert.NotEmpty(defaults.WorkerId);
+        Assert.InRange(defaults.WorkerId.Length, 1, 200);
+        Assert.All(
+            defaults.WorkerId,
+            character => Assert.True(
+                char.IsAsciiLetterOrDigit(character) || character is '-' or '_' or '.' or ':'));
+        Assert.True(defaults.SendWakeNotifications);
+        Assert.Equal(32, defaults.MaximumItemsPerPass);
+        Assert.Equal(TimeSpan.FromSeconds(10), defaults.TimeBudgetPerPass);
+        Assert.Equal(DurableRuntimeSurface.All, defaults.HostedSurfaces);
+
+        var bounded = new AppSurfaceDurablePostgreSqlOptions
+        {
+            WorkerId = new string('a', 200),
+            MaximumItemsPerPass = 10_000,
+            TimeBudgetPerPass = TimeSpan.FromMinutes(5),
+            IdlePollingInterval = TimeSpan.FromMinutes(5),
+            TransientFailureDelay = TimeSpan.FromMinutes(5),
+            HeartbeatStaleAfter = TimeSpan.FromHours(1),
+            ShutdownReserve = TimeSpan.FromMinutes(5),
+        }.SnapshotAndValidate();
+
+        Assert.Equal(200, bounded.WorkerId.Length);
+        Assert.Equal(10_000, bounded.MaximumItemsPerPass);
+        Assert.Equal(TimeSpan.FromMinutes(5), bounded.TimeBudgetPerPass);
+    }
+
+    [Theory]
+    [InlineData("worker id")]
+    [InlineData("worker/id")]
+    [InlineData("worker\nid")]
+    public void OptionsValidation_RejectsUnsafeWorkerIdCharacters(string workerId)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new AppSurfaceDurablePostgreSqlOptions { WorkerId = workerId }.SnapshotAndValidate());
     }
 
     [Theory]
@@ -266,6 +347,47 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
         Assert.False(admission.TryEnter());
         Assert.Equal(1, drain.DrainCount);
         await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public void HostedConstructor_RejectsNullDependencies()
+    {
+        using var dispatcher = CreateDataSource();
+        using var runtime = CreateDataSource();
+        var registration = new PostgreSqlDurableRuntimeRegistration(
+            dispatcher,
+            runtime,
+            new PostgreSqlDurableWorkOptions(Guid.NewGuid(), Guid.NewGuid()),
+            new PostgreSqlDurableScheduleOptions("durable_runtime"),
+            new AppSurfaceDurablePostgreSqlOptions
+            {
+                WorkerId = "hosted-constructor-test",
+            }.SnapshotAndValidate(),
+            Guid.NewGuid());
+        var schema = new NoOpSchemaManager();
+        var pump = new EmptyPump();
+        var drain = new RecordingDrainControl();
+        var admission = new DurableRuntimeAdmissionGate();
+        var lifetime = new TestHostApplicationLifetime();
+        var hostOptions = Options.Create(new HostOptions());
+        var logger = NullLogger<PostgreSqlDurableHostedService>.Instance;
+
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            null!, pump, drain, registration, admission, lifetime, hostOptions, logger));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            schema, null!, drain, registration, admission, lifetime, hostOptions, logger));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            schema, pump, null!, registration, admission, lifetime, hostOptions, logger));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            schema, pump, drain, null!, admission, lifetime, hostOptions, logger));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            schema, pump, drain, registration, null!, lifetime, hostOptions, logger));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            schema, pump, drain, registration, admission, null!, hostOptions, logger));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            schema, pump, drain, registration, admission, lifetime, null!, logger));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableHostedService(
+            schema, pump, drain, registration, admission, lifetime, hostOptions, null!));
     }
 
     [Fact]
@@ -553,6 +675,127 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
         await hosted.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Fact]
+    public async Task HostedLifecycle_RetriesAListenerConnectionFailureBeforeShutdownCancellation()
+    {
+        using var dispatcher = CreateDataSource();
+        using var runtime = NpgsqlDataSource.Create(
+            "Host=127.0.0.1;Port=1;Database=durable_registration;Username=durable;Password=not-opened;Timeout=1");
+        var logger = new ListenerRetryLogger();
+        using var hosted = CreateHostedService(
+            dispatcher,
+            runtime,
+            new NoOpSchemaManager(),
+            new EmptyPump(),
+            new RecordingDrainControl(),
+            new TestHostApplicationLifetime(),
+            "hosted-listener-retry-worker",
+            sendWakeNotifications: true,
+            logger);
+
+        await hosted.StartAsync(CancellationToken.None);
+        await logger.RetryLogged.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<TaskCanceledException>(() => hosted.StopAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HostedLifecycle_RetriesAListenerTimeoutBeforeShutdownCancellation()
+    {
+        using var dispatcher = CreateDataSource();
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(
+            "Host=127.0.0.1;Port=5432;Database=durable_registration;Username=durable");
+        dataSourceBuilder.UsePasswordProvider(
+            static _ => "unused",
+            static (_, _) => ValueTask.FromException<string>(new TimeoutException("Simulated listener timeout.")));
+        using var runtime = dataSourceBuilder.Build();
+        var logger = new ListenerRetryLogger();
+        using var hosted = CreateHostedService(
+            dispatcher,
+            runtime,
+            new NoOpSchemaManager(),
+            new EmptyPump(),
+            new RecordingDrainControl(),
+            new TestHostApplicationLifetime(),
+            "hosted-listener-timeout-worker",
+            sendWakeNotifications: true,
+            logger);
+
+        await hosted.StartAsync(CancellationToken.None);
+        await logger.RetryLogged.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<TaskCanceledException>(() => hosted.StopAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HostedStop_RespectsHostCancellationWhenDrainHasNotCompleted()
+    {
+        using var dispatcher = CreateDataSource();
+        using var runtime = CreateDataSource();
+        var drain = new BlockingDrainControl();
+        using var hosted = CreateHostedService(
+            dispatcher,
+            runtime,
+            new NoOpSchemaManager(),
+            new EmptyPump(),
+            drain,
+            new TestHostApplicationLifetime(),
+            "hosted-canceled-stop-worker");
+
+        await hosted.StartAsync(CancellationToken.None);
+        using var cancellation = new CancellationTokenSource();
+        var stop = hosted.StopAsync(cancellation.Token);
+        try
+        {
+            await drain.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellation.Cancel();
+
+            await stop.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(drain.Started.Task.IsCompletedSuccessfully);
+        }
+        finally
+        {
+            drain.Release.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task HostedLifecycle_ExpiresShutdownDeadlineBeforeStartingAnotherPass()
+    {
+        using var dispatcher = CreateDataSource();
+        using var runtime = CreateDataSource();
+        var lifetime = new TestHostApplicationLifetime();
+        var pump = new CountingPump();
+        var options = new AppSurfaceDurablePostgreSqlOptions
+        {
+            WorkerId = "hosted-expired-deadline-worker",
+            SendWakeNotifications = false,
+            IdlePollingInterval = TimeSpan.FromMilliseconds(200),
+            HeartbeatStaleAfter = TimeSpan.FromSeconds(1),
+            TimeBudgetPerPass = TimeSpan.FromMilliseconds(1),
+            ShutdownReserve = TimeSpan.FromMilliseconds(999),
+        }.SnapshotAndValidate();
+        using var hosted = new PostgreSqlDurableHostedService(
+            new NoOpSchemaManager(),
+            pump,
+            new RecordingDrainControl(),
+            new PostgreSqlDurableRuntimeRegistration(
+                dispatcher,
+                runtime,
+                new PostgreSqlDurableWorkOptions(Guid.NewGuid(), Guid.NewGuid()),
+                new PostgreSqlDurableScheduleOptions("durable_runtime"),
+                options,
+                Guid.NewGuid()),
+            new DurableRuntimeAdmissionGate(),
+            lifetime,
+            Options.Create(new HostOptions { ShutdownTimeout = TimeSpan.FromSeconds(1) }),
+            NullLogger<PostgreSqlDurableHostedService>.Instance);
+
+        await hosted.StartAsync(CancellationToken.None);
+        await pump.FirstPass.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        lifetime.StopApplication();
+        await pump.SecondPass.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
     private static PostgreSqlDurableHostedService CreateHostedService(
         NpgsqlDataSource dispatcher,
         NpgsqlDataSource runtime,
@@ -561,7 +804,8 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
         IDurableRuntimeDrainControl drain,
         IHostApplicationLifetime lifetime,
         string workerId,
-        bool sendWakeNotifications = false)
+        bool sendWakeNotifications = false,
+        ILogger<PostgreSqlDurableHostedService>? logger = null)
     {
         var options = new AppSurfaceDurablePostgreSqlOptions
         {
@@ -591,7 +835,7 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
             new DurableRuntimeAdmissionGate(),
             lifetime,
             Options.Create(new HostOptions { ShutdownTimeout = TimeSpan.FromSeconds(1) }),
-            NullLogger<PostgreSqlDurableHostedService>.Instance);
+            logger ?? NullLogger<PostgreSqlDurableHostedService>.Instance);
     }
 
     private static NpgsqlDataSource CreateDataSource() => NpgsqlDataSource.Create(
@@ -749,6 +993,44 @@ public sealed class AppSurfaceDurablePostgreSqlRegistrationTests
             ValueTask.FromException(new InvalidOperationException("Simulated drain persistence failure."));
 
         public ValueTask ResumeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    }
+
+    private sealed class BlockingDrainControl : IDurableRuntimeDrainControl
+    {
+        internal TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask BeginDrainAsync(CancellationToken cancellationToken = default)
+        {
+            Started.TrySetResult();
+            await Release.Task.ConfigureAwait(false);
+        }
+
+        public ValueTask ResumeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    }
+
+    private sealed class ListenerRetryLogger : ILogger<PostgreSqlDurableHostedService>
+    {
+        internal TaskCompletionSource RetryLogged { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull =>
+            NullLogger.Instance.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (eventId.Id == 4106)
+            {
+                RetryLogged.TrySetResult();
+            }
+        }
     }
 
     private sealed class RecordingDrainControl : IDurableRuntimeDrainControl

--- a/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/PostgreSqlDurableRuntimeHealthTests.cs
+++ b/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/PostgreSqlDurableRuntimeHealthTests.cs
@@ -7,6 +7,22 @@ namespace ForgeTrust.AppSurface.Durable.PostgreSql.Tests;
 public sealed class PostgreSqlDurableRuntimeHealthTests
 {
     [Fact]
+    public void Constructor_RejectsNullRegistrationAndSchemaManager()
+    {
+        using var dataSource = NpgsqlDataSource.Create(
+            "Host=localhost;Port=5432;Database=durable_health;Username=durable;Password=not-opened");
+        var registration = CreateRegistration(
+            dataSource,
+            new PostgreSqlDurableWorkOptions(Guid.NewGuid(), Guid.NewGuid()),
+            CreateOptions("runtime-health-constructor-worker"),
+            Guid.NewGuid());
+        var schema = new StubSchemaManager(_ => ValueTask.FromResult(CreateStatus(DurableRuntimeSchemaCompatibility.Compatible)));
+
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableRuntimeHealth(null!, schema));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableRuntimeHealth(registration, null!));
+    }
+
+    [Fact]
     public async Task HeartbeatDrainAndGenerationTakeover_AreFencedByWorkerInstanceAndEpoch()
     {
         await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
@@ -503,6 +519,342 @@ public sealed class PostgreSqlDurableRuntimeHealthTests
         var epochFailure = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await mismatched.TryBeginPassAsync(CancellationToken.None));
         Assert.StartsWith(DurableProblemCodes.RecoveryEpochRequired, epochFailure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReportsRecoveryEpochRequiredWhenMetadataEpochDisappears()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-health-tests", "missing-active-epoch");
+        var status = await schema.GetStatusAsync();
+        var health = new PostgreSqlDurableRuntimeHealth(
+            CreateRegistration(
+                database.DataSource,
+                new PostgreSqlDurableWorkOptions(epoch, status.StoreId),
+                CreateOptions("runtime-health-missing-active-epoch-worker"),
+                Guid.NewGuid()),
+            new StubSchemaManager(_ => ValueTask.FromResult(CreateStatus(DurableRuntimeSchemaCompatibility.Compatible))));
+
+        await using (var clearEpoch = database.DataSource.CreateCommand(
+            "UPDATE appsurface_durable.store_metadata SET active_runtime_epoch = NULL WHERE singleton;"))
+        {
+            Assert.Equal(1, await clearEpoch.ExecuteNonQueryAsync());
+        }
+
+        var snapshot = await health.GetAsync();
+
+        Assert.Equal(DurableRuntimeHealthState.Incompatible, snapshot.State);
+        Assert.Equal(DurableProblemCodes.RecoveryEpochRequired, snapshot.ProblemCode);
+        Assert.False(snapshot.EpochCompatible);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReportsIdentityConflictWhenOnlyHeartbeatEpochChanges()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-health-tests", "heartbeat-epoch-conflict");
+        var status = await schema.GetStatusAsync();
+        var instanceId = Guid.NewGuid();
+        var workerId = "runtime-health-heartbeat-epoch-conflict-worker";
+        var health = new PostgreSqlDurableRuntimeHealth(
+            CreateRegistration(
+                database.DataSource,
+                new PostgreSqlDurableWorkOptions(epoch, status.StoreId),
+                CreateOptions(workerId),
+                instanceId),
+            schema);
+
+        Assert.True(await health.TryBeginPassAsync(CancellationToken.None));
+        await using (var changeEpoch = database.DataSource.CreateCommand(
+            """
+            UPDATE appsurface_durable.runtime_heartbeat
+            SET runtime_epoch = @runtime_epoch
+            WHERE worker_id = @worker_id;
+            """))
+        {
+            changeEpoch.Parameters.AddWithValue("runtime_epoch", Guid.NewGuid());
+            changeEpoch.Parameters.AddWithValue("worker_id", workerId);
+            Assert.Equal(1, await changeEpoch.ExecuteNonQueryAsync());
+        }
+
+        var snapshot = await health.GetAsync();
+
+        Assert.Equal(DurableRuntimeHealthState.Stale, snapshot.State);
+        Assert.Equal(DurableProblemCodes.WorkerIdentityConflict, snapshot.ProblemCode);
+    }
+
+    [Fact]
+    public async Task TryBeginPassAsync_ReturnsFalseWhenPassActivationLosesItsUpdateRace()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-health-tests", "pass-activation-race");
+        var status = await schema.GetStatusAsync();
+        var workerId = "runtime-health-pass-activation-race-worker";
+
+        await using (var trigger = database.DataSource.CreateCommand(
+            """
+            CREATE OR REPLACE FUNCTION appsurface_durable.test_runtime_health_skip_pass_activation()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF NEW.pass_active AND NOT OLD.pass_active THEN
+                    RETURN NULL;
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+            CREATE TRIGGER test_runtime_health_skip_pass_activation
+            BEFORE UPDATE ON appsurface_durable.runtime_heartbeat
+            FOR EACH ROW
+            EXECUTE FUNCTION appsurface_durable.test_runtime_health_skip_pass_activation();
+            """))
+        {
+            await trigger.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            var health = new PostgreSqlDurableRuntimeHealth(
+                CreateRegistration(
+                    database.DataSource,
+                    new PostgreSqlDurableWorkOptions(epoch, status.StoreId),
+                    CreateOptions(workerId),
+                    Guid.NewGuid()),
+                schema);
+
+            Assert.False(await health.TryBeginPassAsync(CancellationToken.None));
+        }
+        finally
+        {
+            await using var cleanup = database.DataSource.CreateCommand(
+                """
+                DROP TRIGGER IF EXISTS test_runtime_health_skip_pass_activation
+                    ON appsurface_durable.runtime_heartbeat;
+                DROP FUNCTION IF EXISTS appsurface_durable.test_runtime_health_skip_pass_activation();
+                """);
+            await cleanup.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Fact]
+    public async Task RecordHeartbeatAsync_PreservesProcessingFailureWhenRollbackLosesTransport()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-health-tests", "rollback-transport");
+        var status = await schema.GetStatusAsync();
+        var workerId = "runtime-health-rollback-transport-worker";
+        var health = new PostgreSqlDurableRuntimeHealth(
+            CreateRegistration(
+                database.DataSource,
+                new PostgreSqlDurableWorkOptions(epoch, status.StoreId),
+                CreateOptions(workerId),
+                Guid.NewGuid()),
+            schema);
+        Assert.True(await health.TryBeginPassAsync(CancellationToken.None));
+
+        await using (var trigger = database.DataSource.CreateCommand(
+            """
+            CREATE OR REPLACE FUNCTION appsurface_durable.test_runtime_health_terminate_backend()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                PERFORM pg_terminate_backend(pg_backend_pid());
+                RETURN NEW;
+            END;
+            $$;
+            CREATE TRIGGER test_runtime_health_terminate_backend
+            BEFORE UPDATE ON appsurface_durable.runtime_heartbeat
+            FOR EACH ROW
+            EXECUTE FUNCTION appsurface_durable.test_runtime_health_terminate_backend();
+            """))
+        {
+            await trigger.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            await Assert.ThrowsAnyAsync<NpgsqlException>(
+                async () => await health.RecordHeartbeatAsync(CancellationToken.None));
+        }
+        finally
+        {
+            await using var cleanup = database.DataSource.CreateCommand(
+                """
+                DROP TRIGGER IF EXISTS test_runtime_health_terminate_backend
+                    ON appsurface_durable.runtime_heartbeat;
+                DROP FUNCTION IF EXISTS appsurface_durable.test_runtime_health_terminate_backend();
+                """);
+            await cleanup.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GetAsync_ReportsDrainingAndIdentityConflictBeforeLiveness()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-health-tests", "state-order");
+        var status = await schema.GetStatusAsync();
+        var instanceId = Guid.NewGuid();
+        var health = new PostgreSqlDurableRuntimeHealth(
+            CreateRegistration(
+                database.DataSource,
+                new PostgreSqlDurableWorkOptions(epoch, status.StoreId),
+                CreateOptions("runtime-health-state-order-worker"),
+                instanceId),
+            schema);
+
+        Assert.True(await health.TryBeginPassAsync(CancellationToken.None));
+        var active = await health.GetAsync();
+        Assert.Equal(DurableRuntimeHealthState.Healthy, active.State);
+        Assert.True(active.IsPassActive);
+
+        await health.BeginDrainAsync();
+        var draining = await health.GetAsync();
+        Assert.Equal(DurableRuntimeHealthState.Draining, draining.State);
+        Assert.Null(draining.ProblemCode);
+        Assert.True(draining.IsDraining);
+
+        await using (var identity = database.DataSource.CreateCommand(
+            """
+            UPDATE appsurface_durable.runtime_heartbeat
+            SET worker_instance_id = @worker_instance_id
+            WHERE worker_id = @worker_id;
+            """))
+        {
+            identity.Parameters.AddWithValue("worker_instance_id", Guid.NewGuid());
+            identity.Parameters.AddWithValue("worker_id", "runtime-health-state-order-worker");
+            Assert.Equal(1, await identity.ExecuteNonQueryAsync());
+        }
+
+        var conflict = await health.GetAsync();
+        Assert.Equal(DurableRuntimeHealthState.Stale, conflict.State);
+        Assert.Equal(DurableProblemCodes.WorkerIdentityConflict, conflict.ProblemCode);
+    }
+
+    [Fact]
+    public async Task RuntimeMutations_RejectLostPassOwnershipAndPreserveFailedPassSemantics()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-health-tests", "mutation-ownership");
+        var status = await schema.GetStatusAsync();
+        var workerId = "runtime-health-mutation-ownership-worker";
+        var health = new PostgreSqlDurableRuntimeHealth(
+            CreateRegistration(
+                database.DataSource,
+                new PostgreSqlDurableWorkOptions(epoch, status.StoreId),
+                CreateOptions(workerId),
+                Guid.NewGuid()),
+            schema);
+
+        Assert.True(await health.TryBeginPassAsync(CancellationToken.None));
+        await health.RecordHeartbeatAsync(CancellationToken.None);
+        await using (var losePass = database.DataSource.CreateCommand(
+            """
+            UPDATE appsurface_durable.runtime_heartbeat
+            SET pass_active = false, pass_started_at = NULL
+            WHERE worker_id = @worker_id;
+            """))
+        {
+            losePass.Parameters.AddWithValue("worker_id", workerId);
+            Assert.Equal(1, await losePass.ExecuteNonQueryAsync());
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await health.RecordFailedPassAsync(CancellationToken.None));
+
+        Assert.True(await health.TryBeginPassAsync(CancellationToken.None));
+        await using (var changeIdentity = database.DataSource.CreateCommand(
+            """
+            UPDATE appsurface_durable.runtime_heartbeat
+            SET worker_instance_id = @worker_instance_id
+            WHERE worker_id = @worker_id;
+            """))
+        {
+            changeIdentity.Parameters.AddWithValue("worker_instance_id", Guid.NewGuid());
+            changeIdentity.Parameters.AddWithValue("worker_id", workerId);
+            Assert.Equal(1, await changeIdentity.ExecuteNonQueryAsync());
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await health.RecordSuccessfulSweepAsync(
+                new DurableRuntimePumpResult(3, 2, 1, 0, 0, false, null, TimeSpan.FromMilliseconds(4)),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task TryBeginPassAsync_ReportsMissingHeartbeatAfterRegistrationIsDiscarded()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-health-tests", "missing-heartbeat-row");
+        var status = await schema.GetStatusAsync();
+        var workerId = "runtime-health-missing-heartbeat-row-worker";
+
+        await using (var trigger = database.DataSource.CreateCommand(
+            """
+            CREATE OR REPLACE FUNCTION appsurface_durable.test_runtime_health_skip_heartbeat_insert()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RETURN NULL;
+            END;
+            $$;
+            CREATE TRIGGER test_runtime_health_skip_heartbeat_insert
+            BEFORE INSERT ON appsurface_durable.runtime_heartbeat
+            FOR EACH ROW
+            EXECUTE FUNCTION appsurface_durable.test_runtime_health_skip_heartbeat_insert();
+            """))
+        {
+            await trigger.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            var health = new PostgreSqlDurableRuntimeHealth(
+                CreateRegistration(
+                    database.DataSource,
+                    new PostgreSqlDurableWorkOptions(epoch, status.StoreId),
+                    CreateOptions(workerId),
+                    Guid.NewGuid()),
+                schema);
+
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                async () => await health.TryBeginPassAsync(CancellationToken.None));
+            Assert.Contains("heartbeat could not be registered", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await using var cleanup = database.DataSource.CreateCommand(
+                """
+                DROP TRIGGER IF EXISTS test_runtime_health_skip_heartbeat_insert
+                    ON appsurface_durable.runtime_heartbeat;
+                DROP FUNCTION IF EXISTS appsurface_durable.test_runtime_health_skip_heartbeat_insert();
+                """);
+            await cleanup.ExecuteNonQueryAsync();
+        }
     }
 
     private static AppSurfaceDurablePostgreSqlOptions CreateOptions(string workerId)

--- a/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/PostgreSqlDurableRuntimePumpTests.cs
+++ b/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/PostgreSqlDurableRuntimePumpTests.cs
@@ -423,6 +423,87 @@ public sealed class PostgreSqlDurableRuntimePumpTests
     }
 
     [Fact]
+    public async Task RunOnceAsync_ReturnsAnEmptyResultWhenAdmissionIsClosed()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "admission-closed");
+        var services = new ServiceCollection();
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-admission-closed-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<DurableRuntimeAdmissionGate>().Close();
+
+        var result = await provider.GetRequiredService<IDurableRuntimePump>().RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.All));
+
+        Assert.Equal(0, result.Discovered);
+        Assert.Equal(0, result.Claimed);
+        Assert.Equal(0, result.Processed);
+        Assert.Equal(0, result.Deferred);
+        Assert.Equal(0, result.Failed);
+        Assert.False(result.HasMore);
+        Assert.Equal(TimeSpan.Zero, result.Elapsed);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_SetsHasMoreWhenTheItemBudgetStopsBeforeRemainingWork()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "budget");
+        var registration = new SuccessfulWorkRegistration();
+        var services = new ServiceCollection();
+        services.AddSingleton<DurableWorkRegistration>(registration);
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-budget-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IDurableWorkClient>();
+        for (var index = 0; index < 2; index++)
+        {
+            var accepted = await client.EnqueueAsync(new DurableWorkRequest(
+                new DurableScopeId($"runtime-pump-budget-scope-{index}"),
+                new DurableCommandId($"runtime-pump-budget-command-{index}"),
+                $"runtime-pump-budget-key-{index}",
+                SuccessfulWorkRegistration.Name,
+                "v1",
+                registration.InputCodec.EncodeObject(Encoding.UTF8.GetBytes("input")),
+                DurableProviderSafety.Idempotent));
+            Assert.True(accepted.IsSuccess);
+        }
+
+        var result = await provider.GetRequiredService<IDurableRuntimePump>().RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Work));
+
+        Assert.Equal(1, result.Discovered);
+        Assert.Equal(1, result.Claimed);
+        Assert.Equal(1, result.Processed);
+        Assert.Equal(0, result.Deferred);
+        Assert.Equal(0, result.Failed);
+        Assert.True(result.HasMore);
+    }
+
+    [Fact]
     public async Task RunOnceAsync_PreservesAmbiguityWhenAPermittedProviderFails()
     {
         await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
@@ -774,6 +855,7 @@ public sealed class PostgreSqlDurableRuntimePumpTests
     [InlineData(RenewalBehavior.Expired)]
     [InlineData(RenewalBehavior.Missing)]
     [InlineData(RenewalBehavior.Fails)]
+    [InlineData(RenewalBehavior.CancellationRequested)]
     public async Task RunOnceAsync_StopsTheInvocationWhenLeaseRenewalCannotContinue(RenewalBehavior behavior)
     {
         await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
@@ -1010,6 +1092,64 @@ public sealed class PostgreSqlDurableRuntimePumpTests
     }
 
     [Fact]
+    public async Task RunOnceAsync_CountsAClaimCanceledBeforePermitAsProcessed()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "canceled-before-permit");
+        var registration = new PreparationGatedWorkRegistration();
+        var services = new ServiceCollection();
+        services.AddSingleton<DurableWorkRegistration>(registration);
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-canceled-before-permit-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        var scope = new DurableScopeId("runtime-pump-canceled-before-permit-scope");
+        var accepted = await provider.GetRequiredService<IDurableWorkClient>().EnqueueAsync(new DurableWorkRequest(
+            scope,
+            new DurableCommandId("runtime-pump-canceled-before-permit-command"),
+            "runtime-pump-canceled-before-permit-key",
+            PreparationGatedWorkRegistration.Name,
+            "v1",
+            registration.InputCodec.EncodeObject(Encoding.UTF8.GetBytes("input")),
+            DurableProviderSafety.Idempotent));
+        Assert.True(accepted.IsSuccess);
+
+        var running = provider.GetRequiredService<IDurableRuntimePump>().RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Work)).AsTask();
+        await registration.PreparationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await using (var cancel = database.DataSource.CreateCommand(
+            "UPDATE appsurface_durable.work SET cancellation_requested_at = clock_timestamp() WHERE scope_id = @scope_id AND work_id = @work_id;"))
+        {
+            cancel.Parameters.AddWithValue("scope_id", scope.Value);
+            cancel.Parameters.AddWithValue("work_id", accepted.Value!.WorkId.Value);
+            Assert.Equal(1, await cancel.ExecuteNonQueryAsync());
+        }
+
+        registration.AllowPreparation.Set();
+        var result = await running;
+
+        Assert.Equal(1, result.Discovered);
+        Assert.Equal(1, result.Claimed);
+        Assert.Equal(1, result.Processed);
+        Assert.Equal(0, result.Deferred);
+        Assert.Equal(0, result.Failed);
+        var snapshot = await provider.GetRequiredService<IDurableWorkControlClient>().GetAsync(
+            new DurableWorkGetRequest(scope, accepted.Value.WorkId));
+        Assert.True(snapshot.IsSuccess);
+        Assert.Equal(DurableWorkState.CanceledBeforeEffect, snapshot.Value!.State);
+    }
+
+    [Fact]
     public async Task RunOnceAsync_FailsClosedWhenAProviderKeyedEffectCannotReportTerminalTruth()
     {
         await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
@@ -1050,6 +1190,266 @@ public sealed class PostgreSqlDurableRuntimePumpTests
             new DurableWorkGetRequest(scope, accepted.Value!.WorkId));
         Assert.True(snapshot.IsSuccess);
         Assert.Equal(DurableWorkState.Suspended, snapshot.Value!.State);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_ReturnsAnEmptyResultWhenTheRuntimeHealthPassIsAlreadyActive()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "health-pass-active");
+        var registration = new BlockingWorkRegistration();
+        var services = new ServiceCollection();
+        services.AddSingleton<DurableWorkRegistration>(registration);
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-health-pass-active-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        var scope = new DurableScopeId("runtime-pump-health-pass-active-scope");
+        var accepted = await provider.GetRequiredService<IDurableWorkClient>().EnqueueAsync(new DurableWorkRequest(
+            scope,
+            new DurableCommandId("runtime-pump-health-pass-active-command"),
+            "runtime-pump-health-pass-active-key",
+            BlockingWorkRegistration.Name,
+            "v1",
+            registration.InputCodec.EncodeObject(Encoding.UTF8.GetBytes("input")),
+            DurableProviderSafety.Idempotent));
+        Assert.True(accepted.IsSuccess);
+
+        var firstPump = provider.GetRequiredService<IDurableRuntimePump>();
+        var firstPass = firstPump.RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Work)).AsTask();
+        await registration.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var secondPump = CreatePump(provider, new PostgreSqlDurableWorkStore(database.DataSource, epoch));
+        var secondResult = await secondPump.RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Work));
+
+        Assert.Equal(0, secondResult.Discovered);
+        Assert.Equal(0, secondResult.Claimed);
+        Assert.Equal(0, secondResult.Processed);
+        Assert.Equal(0, secondResult.Deferred);
+        Assert.Equal(0, secondResult.Failed);
+        Assert.False(secondResult.HasMore);
+        Assert.Equal(TimeSpan.Zero, secondResult.Elapsed);
+
+        registration.Complete.TrySetResult(registration.CompletionResult);
+        Assert.Equal(1, (await firstPass).Processed);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_CountsWorkExhaustedBeforeClaimAsProcessed()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "exhausted-before-claim");
+        var registration = new SuccessfulWorkRegistration();
+        var services = new ServiceCollection();
+        services.AddSingleton<DurableWorkRegistration>(registration);
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-exhausted-before-claim-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        var scope = new DurableScopeId("runtime-pump-exhausted-before-claim-scope");
+        var accepted = await provider.GetRequiredService<IDurableWorkClient>().EnqueueAsync(new DurableWorkRequest(
+            scope,
+            new DurableCommandId("runtime-pump-exhausted-before-claim-command"),
+            "runtime-pump-exhausted-before-claim-key",
+            SuccessfulWorkRegistration.Name,
+            "v1",
+            registration.InputCodec.EncodeObject(Encoding.UTF8.GetBytes("input")),
+            DurableProviderSafety.Idempotent));
+        Assert.True(accepted.IsSuccess);
+
+        await using (var exhaust = database.DataSource.CreateCommand(
+            "UPDATE appsurface_durable.work SET attempt_number = maximum_attempts WHERE scope_id = @scope_id AND work_id = @work_id;"))
+        {
+            exhaust.Parameters.AddWithValue("scope_id", scope.Value);
+            exhaust.Parameters.AddWithValue("work_id", accepted.Value!.WorkId.Value);
+            Assert.Equal(1, await exhaust.ExecuteNonQueryAsync());
+        }
+
+        var result = await provider.GetRequiredService<IDurableRuntimePump>().RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Work));
+
+        Assert.Equal(1, result.Discovered);
+        Assert.Equal(0, result.Claimed);
+        Assert.Equal(1, result.Processed);
+        Assert.Equal(0, result.Deferred);
+        Assert.Equal(0, result.Failed);
+        var snapshot = await provider.GetRequiredService<IDurableWorkControlClient>().GetAsync(
+            new DurableWorkGetRequest(scope, accepted.Value.WorkId));
+        Assert.True(snapshot.IsSuccess);
+        Assert.Equal(DurableWorkState.FailedTerminal, snapshot.Value!.State);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_DefersCompletionWhenTheOwningScopeIsFencedAfterTheEffectStarts()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "stale-completion");
+        var registration = new BlockingWorkRegistration();
+        var services = new ServiceCollection();
+        services.AddSingleton<DurableWorkRegistration>(registration);
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-stale-completion-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        var scope = new DurableScopeId("runtime-pump-stale-completion-scope");
+        var accepted = await provider.GetRequiredService<IDurableWorkClient>().EnqueueAsync(new DurableWorkRequest(
+            scope,
+            new DurableCommandId("runtime-pump-stale-completion-command"),
+            "runtime-pump-stale-completion-key",
+            BlockingWorkRegistration.Name,
+            "v1",
+            registration.InputCodec.EncodeObject(Encoding.UTF8.GetBytes("input")),
+            DurableProviderSafety.Idempotent));
+        Assert.True(accepted.IsSuccess);
+
+        var running = provider.GetRequiredService<IDurableRuntimePump>().RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Work)).AsTask();
+        await registration.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var disabled = await provider.GetRequiredService<IDurableScopeControlClient>().DisableAsync(
+            new DurableScopeDisableRequest(scope, "runtime-pump-test", "fence", expectedGeneration: 1));
+        Assert.True(disabled.IsSuccess);
+
+        registration.Complete.TrySetResult(registration.CompletionResult);
+        var result = await running;
+
+        Assert.Equal(1, result.Discovered);
+        Assert.Equal(1, result.Claimed);
+        Assert.Equal(0, result.Processed);
+        Assert.Equal(1, result.Deferred);
+        Assert.Equal(0, result.Failed);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_CountsAFlowEvaluationSuspensionAsFailed()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "flow-suspension");
+        var contextCodec = new PostgreSqlOpaqueTestCodec("tests.runtime-pump.flow-suspension", "v1");
+        var flow = new FailingFlowRegistration(contextCodec);
+        var services = new ServiceCollection();
+        services.AddSingleton<IDurablePayloadCodec>(contextCodec);
+        services.AddSingleton<DurableFlowRegistration>(flow);
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-flow-suspension-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        var scope = new DurableScopeId("runtime-pump-flow-suspension-scope");
+        var instance = new DurableFlowInstanceId("runtime-pump-flow-suspension-instance");
+        var accepted = await provider.GetRequiredService<IDurableFlowClient>().StartAsync(new DurableFlowStartRequest(
+            scope,
+            new DurableCommandId("runtime-pump-flow-suspension-command"),
+            "runtime-pump-flow-suspension-key",
+            instance,
+            flow.FlowId,
+            flow.FlowVersion,
+            contextCodec.EncodeObject(Encoding.UTF8.GetBytes("context"))));
+        Assert.True(accepted.IsSuccess);
+
+        var result = await provider.GetRequiredService<IDurableRuntimePump>().RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Flow));
+
+        Assert.Equal(1, result.Discovered);
+        Assert.Equal(1, result.Claimed);
+        Assert.Equal(0, result.Processed);
+        Assert.Equal(0, result.Deferred);
+        Assert.Equal(1, result.Failed);
+        var snapshot = await provider.GetRequiredService<IDurableFlowClient>().GetAsync(
+            new DurableFlowGetRequest(scope, instance));
+        Assert.True(snapshot.IsSuccess);
+        Assert.Equal(DurableFlowState.Suspended, snapshot.Value!.State);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_PreservesProviderFailureWhenFailedPassRecordingLosesTheRuntimeEpoch()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        await schema.ApplyAsync();
+        var epoch = Guid.NewGuid();
+        await schema.InitializeRuntimeEpochAsync(epoch, "runtime-pump-tests", "failed-pass-fenced");
+        var registration = new StartedFailingWorkRegistration();
+        var services = new ServiceCollection();
+        services.AddSingleton<DurableWorkRegistration>(registration);
+        services.AddAppSurfaceDurablePostgreSql(
+            database.DataSource,
+            database.DataSource,
+            new PostgreSqlDurableWorkOptions(epoch, (await schema.GetStatusAsync()).StoreId),
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            options =>
+            {
+                options.WorkerId = "runtime-pump-failed-pass-fenced-worker";
+                options.SendWakeNotifications = false;
+            });
+        await using var provider = services.BuildServiceProvider();
+        var scope = new DurableScopeId("runtime-pump-failed-pass-fenced-scope");
+        var accepted = await provider.GetRequiredService<IDurableWorkClient>().EnqueueAsync(new DurableWorkRequest(
+            scope,
+            new DurableCommandId("runtime-pump-failed-pass-fenced-command"),
+            "runtime-pump-failed-pass-fenced-key",
+            StartedFailingWorkRegistration.Name,
+            "v1",
+            registration.InputCodec.EncodeObject(Encoding.UTF8.GetBytes("input")),
+            DurableProviderSafety.Idempotent));
+        Assert.True(accepted.IsSuccess);
+
+        var running = provider.GetRequiredService<IDurableRuntimePump>().RunOnceAsync(
+            new DurableRuntimePumpRequest(maximumItems: 1, surfaces: DurableRuntimeSurface.Work)).AsTask();
+        await registration.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await using (var changeEpoch = database.DataSource.CreateCommand(
+            "UPDATE appsurface_durable.store_metadata SET active_runtime_epoch = @epoch WHERE singleton;"))
+        {
+            changeEpoch.Parameters.AddWithValue("epoch", Guid.NewGuid());
+            Assert.Equal(1, await changeEpoch.ExecuteNonQueryAsync());
+        }
+
+        registration.Fail.Set();
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await running.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.StartsWith(DurableProblemCodes.RecoveryEpochRequired, failure.Message, StringComparison.Ordinal);
     }
 
     private static PostgreSqlDurableRuntimePump CreatePump(
@@ -1119,6 +1519,7 @@ public sealed class PostgreSqlDurableRuntimePumpTests
         Expired,
         Missing,
         Fails,
+        CancellationRequested,
     }
 
     private sealed class RenewalOutcomeWorkStore(
@@ -1136,6 +1537,8 @@ public sealed class PostgreSqlDurableRuntimePumpTests
                 RenewalBehavior.Missing => ValueTask.FromResult<PostgreSqlDurableWorkClaim?>(null),
                 RenewalBehavior.Fails => ValueTask.FromException<PostgreSqlDurableWorkClaim?>(
                     new InvalidOperationException("Simulated lease renewal failure.")),
+                RenewalBehavior.CancellationRequested => ValueTask.FromResult<PostgreSqlDurableWorkClaim?>(
+                    claim with { CancellationRequested = true }),
                 _ => throw new InvalidDataException($"Unknown test renewal behavior '{behavior}'."),
             };
     }
@@ -1237,6 +1640,44 @@ public sealed class PostgreSqlDurableRuntimePumpTests
 
         public override DurablePreparedWork Prepare(IServiceProvider services, DurableWorkExecutionContext work) =>
             new BlockingPreparedWork(Started, Complete);
+
+        public override ValueTask<DurableEncodedPayload> InvokeAsync(
+            IServiceProvider services,
+            DurableWorkExecutionContext work,
+            CancellationToken cancellationToken = default) =>
+            Prepare(services, work).InvokeAsync(cancellationToken);
+
+        public override ValueTask<DurableEncodedEffectReconciliation> ReconcileAsync(
+            IServiceProvider services,
+            DurableWorkExecutionContext work,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Idempotent test Work does not reconcile.");
+    }
+
+    private sealed class StartedFailingWorkRegistration : DurableWorkRegistration
+    {
+        internal const string Name = "tests.runtime-pump.started-failure";
+
+        internal StartedFailingWorkRegistration()
+            : base(
+                Name,
+                "v1",
+                DurableProviderSafety.Idempotent,
+                new PostgreSqlOpaqueTestCodec("tests.runtime-pump.started-failure.input", "v1"),
+                new PostgreSqlOpaqueTestCodec("tests.runtime-pump.started-failure.result", "v1"))
+        {
+        }
+
+        internal TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal ManualResetEventSlim Fail { get; } = new(false);
+
+        internal IDurablePayloadCodec InputCodec => WorkCodec;
+
+        public override bool CanReconcile => false;
+
+        public override DurablePreparedWork Prepare(IServiceProvider services, DurableWorkExecutionContext work) =>
+            new StartedFailingPreparedWork(Started, Fail);
 
         public override ValueTask<DurableEncodedPayload> InvokeAsync(
             IServiceProvider services,
@@ -1408,6 +1849,19 @@ public sealed class PostgreSqlDurableRuntimePumpTests
         }
     }
 
+    private sealed class StartedFailingPreparedWork(
+        TaskCompletionSource started,
+        ManualResetEventSlim fail) : DurablePreparedWork
+    {
+        public override ValueTask<DurableEncodedPayload> InvokeAsync(CancellationToken cancellationToken = default)
+        {
+            started.TrySetResult();
+            fail.Wait(cancellationToken);
+            return ValueTask.FromException<DurableEncodedPayload>(
+                new InvalidOperationException("Simulated provider failure after start."));
+        }
+    }
+
     private sealed class SlowPreparedWork(DurableEncodedPayload result) : DurablePreparedWork
     {
         public override async ValueTask<DurableEncodedPayload> InvokeAsync(CancellationToken cancellationToken = default)
@@ -1448,6 +1902,32 @@ public sealed class PostgreSqlDurableRuntimePumpTests
                 timeout: null,
                 fault: null,
                 activity: null));
+    }
+
+    private sealed class FailingFlowRegistration(IDurablePayloadCodec contextCodec) : DurableFlowRegistration
+    {
+        public override string FlowId => "tests.runtime-pump.flow-suspension";
+
+        public override string FlowVersion => "v1";
+
+        public override string ImplementationVersion => "tests-runtime-pump-flow-suspension-v1";
+
+        public override string StartNodeId => "start";
+
+        public override string DefinitionFingerprint => new('e', 64);
+
+        public override IDurablePayloadCodec ContextCodec { get; } = contextCodec;
+
+        public override IReadOnlyList<DurableFlowEventBinding> EventBindings => [];
+
+        public override IReadOnlyList<DurableWorkRegistration> ActivityWorkRegistrations => [];
+
+        public override ValueTask<DurableFlowEvaluationResult> EvaluateAsync(
+            DurableFlowEvaluationInput input,
+            IDurablePayloadCodecRegistry payloadCodecs,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<DurableFlowEvaluationResult>(
+                new InvalidOperationException("Simulated Flow evaluation failure."));
     }
 
     private sealed class RuntimeSchedulePayloadCodec(

--- a/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/PostgreSqlDurableWorkStoreTests.cs
+++ b/Durable/ForgeTrust.AppSurface.Durable.PostgreSql.Tests/PostgreSqlDurableWorkStoreTests.cs
@@ -1959,6 +1959,28 @@ public sealed class PostgreSqlDurableWorkStoreTests
     }
 
     [Fact]
+    public async Task ControlClient_ConstructorRejectsMissingDependencies()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        await ApplySchemaAsync(database);
+        var epoch = Guid.NewGuid();
+        var workOptions = CreateOptions(database.DataSource, epoch);
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        var store = new PostgreSqlDurableWorkStore(database.DataSource, epoch);
+        var registration = new PostgreSqlDurableRuntimeRegistration(
+            database.DataSource,
+            database.DataSource,
+            workOptions,
+            new PostgreSqlDurableScheduleOptions("appsurface"),
+            new AppSurfaceDurablePostgreSqlOptions { WorkerId = "control-constructor-worker" }.SnapshotAndValidate(),
+            Guid.NewGuid());
+
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableControlClient(null!, schema, store));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableControlClient(registration, null!, store));
+        Assert.Throws<ArgumentNullException>(() => new PostgreSqlDurableControlClient(registration, schema, null!));
+    }
+
+    [Fact]
     public async Task ControlClient_ListsReadsCancelsAndDisablesThroughAuthoritativeOutcomes()
     {
         await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
@@ -2161,6 +2183,136 @@ public sealed class PostgreSqlDurableWorkStoreTests
             "UPDATE appsurface_durable.work SET result_sha256 = decode(repeat('00', 32), 'hex');");
         await Assert.ThrowsAsync<InvalidDataException>(async () =>
             await control.GetAsync(new DurableWorkGetRequest(request.ScopeId, accepted.Value.WorkId)));
+    }
+
+    [Fact]
+    public async Task ControlClient_ReturnsOperationalResultClassificationThroughPublicSnapshot()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        await ApplySchemaAsync(database);
+        var epoch = Guid.NewGuid();
+        var workOptions = CreateOptions(database.DataSource, epoch);
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        var store = new PostgreSqlDurableWorkStore(database.DataSource, epoch);
+        var control = CreateControlClient(database.DataSource, workOptions, schema, store, "control-operational-result-worker");
+        var client = CreateClient(database.DataSource, epoch);
+        var request = CreateRequest("control-operational-result-scope", "control-operational-result-command");
+        var accepted = await client.EnqueueAsync(request);
+        Assert.True(accepted.IsSuccess);
+
+        var claim = await store.TryClaimAsync(Assert.Single(await store.DiscoverAsync(1)), "control-operational-result-worker");
+        Assert.NotNull(claim);
+        var permit = await store.TryAcquireEffectPermitAsync(claim!);
+        Assert.NotNull(permit);
+        var result = new DurableEncodedPayload(
+            "tests.control-operational-result",
+            "v1",
+            DurableDataClassification.Operational,
+            Encoding.UTF8.GetBytes("operational-result"));
+        await store.RecordCompletionAsync(
+            permit!.Claim,
+            new PostgreSqlWorkCompletion(PostgreSqlWorkCompletionKind.Succeeded, "completed", "{}", result));
+
+        var snapshot = await control.GetAsync(new DurableWorkGetRequest(request.ScopeId, accepted.Value!.WorkId));
+
+        Assert.True(snapshot.IsSuccess);
+        Assert.Equal(DurableDataClassification.Operational, snapshot.Value!.Result!.Classification);
+        Assert.Equal(result.Sha256, snapshot.Value.Result.Sha256);
+    }
+
+    [Fact]
+    public async Task ControlClient_ListSurfacesTheServerShutdownThatAlsoBreaksRollback()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        await ApplySchemaAsync(database);
+        var epoch = Guid.NewGuid();
+        var workOptions = CreateOptions(database.DataSource, epoch);
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        var applicationName = $"control-list-loss-{Guid.NewGuid():N}";
+        var controlDataSourceBuilder = new NpgsqlConnectionStringBuilder(database.ConnectionString)
+        {
+            ApplicationName = applicationName,
+        };
+        await using var controlDataSource = NpgsqlDataSource.Create(controlDataSourceBuilder.ConnectionString);
+        var store = new PostgreSqlDurableWorkStore(controlDataSource, epoch);
+        var control = CreateControlClient(
+            controlDataSource,
+            workOptions,
+            schema,
+            store,
+            "control-list-loss-worker");
+
+        await using var blockerConnection = await database.DataSource.OpenConnectionAsync();
+        await using var blockerTransaction = await blockerConnection.BeginTransactionAsync();
+        await using (var lockCommand = new NpgsqlCommand(
+            "LOCK TABLE appsurface_durable.work IN ACCESS EXCLUSIVE MODE;",
+            blockerConnection,
+            blockerTransaction))
+        {
+            await lockCommand.ExecuteNonQueryAsync();
+        }
+
+        var listing = control.ListAsync(
+                new DurableWorkListRequest(new DurableScopeId("control-list-loss-scope"), pageSize: 1))
+            .AsTask();
+        var backendPid = await WaitForBackendAsync(database.DataSource, applicationName, "relation");
+        await using (var terminate = database.DataSource.CreateCommand("SELECT pg_terminate_backend(@pid);"))
+        {
+            terminate.Parameters.AddWithValue("pid", backendPid);
+            Assert.True((bool)(await terminate.ExecuteScalarAsync())!);
+        }
+
+        var failure = await Assert.ThrowsAsync<PostgresException>(async () => await listing);
+        Assert.Equal("57P01", failure.SqlState);
+        await blockerTransaction.RollbackAsync();
+    }
+
+    [Fact]
+    public async Task ControlClient_ListProjectsAuthoritativeInventoryFields()
+    {
+        await using var database = await PostgreSqlIntegrationTestDatabase.TryCreateAsync();
+        await ApplySchemaAsync(database);
+        var epoch = Guid.NewGuid();
+        var workOptions = CreateOptions(database.DataSource, epoch);
+        var schema = new PostgreSqlDurableRuntimeSchemaManager(database.DataSource);
+        var store = new PostgreSqlDurableWorkStore(database.DataSource, epoch);
+        var control = CreateControlClient(database.DataSource, workOptions, schema, store, "control-list-projection-worker");
+        var client = CreateClient(database.DataSource, epoch);
+        var scope = new DurableScopeId("control-list-projection-scope");
+        var request = CreateRequest(scope.Value, "control-list-projection-command", DurableProviderSafety.ProviderKeyed);
+        var accepted = await client.EnqueueAsync(request);
+        Assert.True(accepted.IsSuccess);
+
+        await ExecuteScopedNonQueryAsync(
+            database.DataSource,
+            scope,
+            """
+            UPDATE appsurface_durable.work
+            SET state = 'cancel_pending',
+                attempt_number = 3,
+                revision = 7,
+                terminal_code = 'cancel-requested',
+                cancellation_requested_at = now(),
+                runtime_epoch = '00000000-0000-0000-0000-000000000001'
+            WHERE work_id = @work_id;
+            """,
+            ("work_id", accepted.Value!.WorkId.Value));
+
+        var listed = await control.ListAsync(new DurableWorkListRequest(scope, pageSize: 10));
+
+        var item = Assert.Single(listed.Value!.Items);
+        Assert.Equal(accepted.Value.WorkId, item.WorkId);
+        Assert.Equal(accepted.Value.WorkId.Value, item.ActivityId);
+        Assert.Equal(request.WorkName, item.WorkName);
+        Assert.Equal(request.WorkVersion, item.WorkVersion);
+        Assert.Equal(DurableWorkState.CancelPending, item.State);
+        Assert.Equal(DurableProviderSafety.ProviderKeyed, item.ProviderSafety);
+        Assert.Equal(3, item.AttemptNumber);
+        Assert.Equal(7, item.Revision);
+        Assert.NotEqual(default, item.DueAtUtc);
+        Assert.Equal("cancel-requested", item.TerminalCode);
+        Assert.True(item.CancellationRequested);
+        Assert.True(item.RequiresRecoveryRelease);
     }
 
     [Fact]
@@ -3029,6 +3181,34 @@ public sealed class PostgreSqlDurableWorkStoreTests
         throw new TimeoutException("Runtime epoch rotation did not wait for the in-flight acceptance transaction.");
     }
 
+    private static async ValueTask<int> WaitForBackendAsync(
+        NpgsqlDataSource dataSource,
+        string applicationName,
+        string waitEvent)
+    {
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            await using var command = dataSource.CreateCommand(
+                """
+                SELECT pid
+                FROM pg_catalog.pg_stat_activity
+                WHERE application_name = @application_name
+                  AND wait_event = @wait_event
+                LIMIT 1;
+                """);
+            command.Parameters.AddWithValue("application_name", applicationName);
+            command.Parameters.AddWithValue("wait_event", waitEvent);
+            if (await command.ExecuteScalarAsync() is int backendPid)
+            {
+                return backendPid;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        throw new TimeoutException($"The control session did not begin waiting for the {waitEvent} lock.");
+    }
+
     private static async ValueTask<T> ExecuteScalarAsync<T>(NpgsqlDataSource dataSource, string sql)
     {
         await using var command = dataSource.CreateCommand(sql);
@@ -3115,12 +3295,17 @@ public sealed class PostgreSqlDurableWorkStoreTests
     private static async ValueTask<int> ExecuteScopedNonQueryAsync(
         NpgsqlDataSource dataSource,
         DurableScopeId scopeId,
-        string sql)
+        string sql,
+        params (string Name, object Value)[] parameters)
     {
         await using var connection = await dataSource.OpenConnectionAsync();
         await using var transaction = await connection.BeginTransactionAsync();
         await SetTestScopeAsync(connection, transaction, scopeId);
         await using var command = new NpgsqlCommand(sql, connection, transaction);
+        foreach (var (name, value) in parameters)
+        {
+            command.Parameters.AddWithValue(name, value);
+        }
         var result = await command.ExecuteNonQueryAsync();
         await transaction.CommitAsync();
         return result;

--- a/scripts/coverage-solution.sh
+++ b/scripts/coverage-solution.sh
@@ -111,6 +111,7 @@ if [[ -n "$COVERAGE_GATE_DIFF_BASE" ]]; then
     --diff-base "$COVERAGE_GATE_DIFF_BASE"
     --min-patch-line 95
     --min-patch-branch 85
+    --patch-line-mode codecov
   )
 fi
 


### PR DESCRIPTION
## Summary

- add a Codecov-compatible changed-line coverage mode and use it in the repository coverage script
- document and test the calculation while retaining the backwards-compatible CLI default
- add Slice 6 regression coverage for the remaining runtime pump, hosted-service, health, and control-client paths

## Validation

- `dotnet test Cli/ForgeTrust.AppSurface.Cli.Tests/ForgeTrust.AppSurface.Cli.Tests.csproj --configuration Release --no-restore` (1,129 passed)
- instrumented Durable PostgreSQL coverage run (348 passed)
- Codecov-compatible patch gate against `origin/main`: 96.27% (1,162/1,207), patch branches 91.97%
- `dotnet format ForgeTrust.AppSurface.slnx --verify-no-changes --no-restore`

## Stacking

This PR targets #713 and should merge after the Slice 6 runtime-host PR. Retarget it to `main` after #713 merges.