### PR TITLE
fix(release): allow canonical unreleased sidecar

### DIFF
--- a/releases/unreleased.entries/2026-08-13-release-prep-canonical-sidecar.md
+++ b/releases/unreleased.entries/2026-08-13-release-prep-canonical-sidecar.md
@@ -1,0 +1,6 @@
+<!-- appsurface:unreleased-entry section="included" -->
+### Reliable release preparation
+
+- AppSurface release preparation now accepts an unchanged canonical Unreleased documentation sidecar while still
+  rejecting added, deleted, or renamed next-cycle metadata. Maintainers can prepare the next coordinated release
+  without manufacturing a no-op sidecar edit when its provisional metadata already matches the approved template.

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleasePreparationDiffVerifierTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleasePreparationDiffVerifierTests.cs
@@ -429,6 +429,29 @@ public sealed class ReleasePreparationDiffVerifierTests
     }
 
     [Fact]
+    public void ReleaseArtifactValidationAcceptsAnUnchangedCanonicalNextCycleSidecar()
+    {
+        var diagnostics = new List<ReleaseDiagnostic>();
+
+        ReleasePreparationDiffVerifier.ValidateReleaseArtifactChanges(
+            "1.2.3",
+            [
+                new ReleasePreparationChange("A", "releases/v1.2.3.md"),
+                new ReleasePreparationChange("A", "releases/v1.2.3.md.yml"),
+                new ReleasePreparationChange("A", "releases/v1.2.3.release.json"),
+                new ReleasePreparationChange("A", "releases/v1.2.3.evidence.json"),
+                new ReleasePreparationChange("M", "releases/current.md"),
+                new ReleasePreparationChange("M", "CHANGELOG.md"),
+                new ReleasePreparationChange("M", "releases/unreleased.md"),
+                new ReleasePreparationChange("D", "releases/unreleased.entries/2026-08-11.md")
+            ],
+            ["releases/unreleased.entries/2026-08-11.md"],
+            diagnostics);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public void ReleaseArtifactValidationReportsInvalidStatusesMissingConsumedEntriesAndUnrelatedChanges()
     {
         var diagnostics = new List<ReleaseDiagnostic>();

--- a/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
+++ b/tools/ForgeTrust.AppSurface.Release.Tests/ReleaseWorkflowPolicyTests.cs
@@ -28,6 +28,46 @@ public sealed class ReleaseWorkflowPolicyTests
     }
 
     [Fact]
+    public void ReleasePreparationChangePolicyAcceptsAnUnchangedCanonicalNextCycleSidecar()
+    {
+        var result = ReleasePreparationChangePolicy.Validate(
+            "1.2.3",
+            [
+                new("A", "releases/v1.2.3.md"),
+                new("A", "releases/v1.2.3.md.yml"),
+                new("A", "releases/v1.2.3.release.json"),
+                new("A", "releases/v1.2.3.evidence.json"),
+                new("M", "releases/current.md"),
+                new("M", "CHANGELOG.md"),
+                new("M", "releases/unreleased.md"),
+                new("D", "releases/unreleased.entries/2026-08-08-release-workflow.md")
+            ],
+            ["releases/unreleased.entries/2026-08-08-release-workflow.md"]);
+
+        Assert.True(result.IsValid, string.Join(Environment.NewLine, result.Errors));
+    }
+
+    [Fact]
+    public void ReleasePreparationChangePolicyRejectsAnAddedNextCycleSidecar()
+    {
+        var result = ReleasePreparationChangePolicy.Validate(
+            "1.2.3",
+            [
+                new("A", "releases/v1.2.3.md"),
+                new("A", "releases/v1.2.3.md.yml"),
+                new("A", "releases/v1.2.3.release.json"),
+                new("A", "releases/v1.2.3.evidence.json"),
+                new("M", "releases/current.md"),
+                new("M", "CHANGELOG.md"),
+                new("M", "releases/unreleased.md"),
+                new("A", "releases/unreleased.md.yml")
+            ]);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Contains("must be M when present", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ReleasePreparationChangePolicyRejectsPackageReadmeChanges()
     {
         var result = ReleasePreparationChangePolicy.Validate(

--- a/tools/ForgeTrust.AppSurface.Release/ReleasePreparationChangePolicy.cs
+++ b/tools/ForgeTrust.AppSurface.Release/ReleasePreparationChangePolicy.cs
@@ -52,7 +52,7 @@ internal static class ReleasePreparationChangePolicy
             return new ReleasePreparationChangePolicyResult(errors);
         }
 
-        var expectedPaths = new HashSet<string>(StringComparer.Ordinal)
+        var requiredPaths = new HashSet<string>(StringComparer.Ordinal)
         {
             $"releases/v{version}.md",
             $"releases/v{version}.md.yml",
@@ -60,9 +60,16 @@ internal static class ReleasePreparationChangePolicy
             $"releases/v{version}.evidence.json",
             "releases/current.md",
             "CHANGELOG.md",
-            "releases/unreleased.md",
+            "releases/unreleased.md"
+        };
+        // Resetting an already-canonical unreleased sidecar produces no Git diff. If it is present, it must remain an
+        // ordinary modification so release preparation cannot add, delete, or rename the next-cycle metadata.
+        var optionalModifiedPaths = new HashSet<string>(StringComparer.Ordinal)
+        {
             "releases/unreleased.md.yml"
         };
+        var expectedPaths = new HashSet<string>(requiredPaths, StringComparer.Ordinal);
+        expectedPaths.UnionWith(optionalModifiedPaths);
         var actualChanges = changes.ToArray();
         var declaredEntryPaths = (consumedUnreleasedEntryPaths ?? []).ToArray();
         var declaredEntryPathSet = new HashSet<string>(declaredEntryPaths, StringComparer.Ordinal);
@@ -136,13 +143,19 @@ internal static class ReleasePreparationChangePolicy
                 continue;
             }
 
+            if (optionalModifiedPaths.Contains(change.Path)
+                && !string.Equals(change.Status, "M", StringComparison.Ordinal))
+            {
+                errors.Add($"Optional release-preparation path must be M when present: {change.Path}.");
+            }
+
             if (!seenPaths.Add(change.Path))
             {
                 errors.Add($"Release-preparation path appears more than once: {change.Path}.");
             }
         }
 
-        foreach (var expectedPath in expectedPaths)
+        foreach (var expectedPath in requiredPaths)
         {
             if (!seenPaths.Contains(expectedPath))
             {

--- a/tools/ForgeTrust.AppSurface.Release/ReleasePreparationDiffVerifier.cs
+++ b/tools/ForgeTrust.AppSurface.Release/ReleasePreparationDiffVerifier.cs
@@ -348,7 +348,7 @@ internal sealed class ReleasePreparationDiffVerifier
         IReadOnlyList<string> consumedEntryPaths,
         List<ReleaseDiagnostic> diagnostics)
     {
-        var expected = new Dictionary<string, string>(StringComparer.Ordinal)
+        var required = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [$"releases/v{version}.md"] = "A",
             [$"releases/v{version}.md.yml"] = "A",
@@ -356,13 +356,19 @@ internal sealed class ReleasePreparationDiffVerifier
             [$"releases/v{version}.evidence.json"] = "A",
             ["releases/current.md"] = "M",
             ["CHANGELOG.md"] = "M",
-            ["releases/unreleased.md"] = "M",
+            ["releases/unreleased.md"] = "M"
+        };
+        // A canonical next-cycle sidecar can already match the base branch byte for byte. When it changes, it remains
+        // release-owned and must be a regular modification; when it does not, Git correctly omits it from the diff.
+        var optional = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
             ["releases/unreleased.md.yml"] = "M"
         };
         var consumed = new HashSet<string>(consumedEntryPaths, StringComparer.Ordinal);
         foreach (var change in changes)
         {
-            if (expected.TryGetValue(change.Path, out var requiredStatus))
+            if (required.TryGetValue(change.Path, out var requiredStatus)
+                || optional.TryGetValue(change.Path, out requiredStatus))
             {
                 if (!string.Equals(change.Status, requiredStatus, StringComparison.Ordinal))
                 {
@@ -393,7 +399,7 @@ internal sealed class ReleasePreparationDiffVerifier
                 $"'{change.Path}' with status {change.Status} is not part of the release-preparation contract.", "Move unrelated work to a separate pull request, or regenerate the approved release artifacts.");
         }
 
-        foreach (var expectedPath in expected.Where(expectedPath => !changes.Any(change => string.Equals(change.Path, expectedPath.Key, StringComparison.Ordinal))))
+        foreach (var expectedPath in required.Where(expectedPath => !changes.Any(change => string.Equals(change.Path, expectedPath.Key, StringComparison.Ordinal))))
         {
             Add(diagnostics, "release-prep-unexpected-path", "A required release-preparation artifact is missing.",
                 $"The complete diff does not contain '{expectedPath.Key}'.", "Regenerate the complete release artifact set with ./eng/release prepare.");


### PR DESCRIPTION
## Summary
- Treat the next-cycle Unreleased sidecar as optional in release-preparation diffs when the generated canonical content is already present on the base branch.
- Preserve the requirement that any sidecar which is present is an ordinary modification.
- Add regression coverage for the unchanged-sidecar and invalid-status paths.

## Root cause
Release preparation writes a static canonical sidecar. After preview.6, the base branch already contained those exact bytes, but both release-prep validators still required a Git modification for that path.

## Validation
- dotnet test tools/ForgeTrust.AppSurface.Release.Tests/ForgeTrust.AppSurface.Release.Tests.csproj --configuration Release --no-restore (598 passed)
- dotnet build tools/ForgeTrust.AppSurface.Release/ForgeTrust.AppSurface.Release.csproj --configuration Release --no-restore
- Disposable end-to-end preview preparation followed by verify-prep-diff: pass